### PR TITLE
Prove transfer request in sequencer

### DIFF
--- a/src/app/zkapps_examples/rollup/sequencer/lib/transfers_memory.ml
+++ b/src/app/zkapps_examples/rollup/sequencer/lib/transfers_memory.ml
@@ -1,0 +1,39 @@
+open Base
+open Mina_base
+
+module Transfers_memory = struct
+  type t =
+    { table : (string, float * Account_update.t) Hashtbl.t
+    ; queue : (string * float) Queue.t
+    ; lifetime : float
+    }
+
+  let create ~lifetime =
+    { table = Hashtbl.create (module String)
+    ; queue = Queue.create ()
+    ; lifetime
+    }
+
+  let cleanup t =
+    let now = Unix.gettimeofday () in
+    let rec loop () =
+      match Queue.peek t.queue with
+      | Some (key, timestamp) when Float.(now -. timestamp > t.lifetime) ->
+          Hashtbl.remove t.table key ;
+          (Queue.dequeue_exn t.queue : string * float) |> ignore ;
+          loop ()
+      | _ ->
+          ()
+    in
+    loop ()
+
+  let add t key account_update =
+    let now = Unix.time () in
+    Hashtbl.set t.table ~key ~data:(now, account_update) ;
+    Queue.enqueue t.queue (key, now) ;
+    cleanup t
+
+  let get t key = Hashtbl.find t.table key
+end
+
+include Transfers_memory

--- a/src/lib/fields_derivers_zkapps/fields_derivers_zkapps.ml
+++ b/src/lib/fields_derivers_zkapps/fields_derivers_zkapps.ml
@@ -368,6 +368,9 @@ module Make (Schema : Graphql_intf.Schema) = struct
 
   let typ obj = !(obj#graphql_fields).Graphql.Fields.Input.T.run ()
 
+  let nullable_typ obj =
+    !(obj#nullable_graphql_fields).Graphql.Fields.Input.T.run ()
+
   let arg_typ obj = !(obj#graphql_arg) ()
 
   let inner_query obj = Fields_derivers_graphql.Graphql_query.inner_query obj


### PR DESCRIPTION
Expose async api in gql to prove transfer request:
- `proveTransfer` mutation enqueues request and returns key
- `transfer` query fetches the proved account update based on key, if it's ready return au, if not return null
- after proving sequencer retains the transfer for 10 minutes