### PR TITLE
Add support for global slot

### DIFF
--- a/src/app/zkapps_examples/rollup/sequencer/lib/gql_client.ml
+++ b/src/app/zkapps_examples/rollup/sequencer/lib/gql_client.ml
@@ -51,8 +51,8 @@ let fetch_commited_state uri pk =
   in
   let%map result = Graphql_client.query_json_exn q uri in
   Yojson.Safe.Util.(
-    result |> member "account" |> member "zkappState" |> index 0 |> to_string)
-  |> Frozen_ledger_hash.of_decimal_string
+    result |> member "account" |> member "zkappState" |> to_list
+    |> List.map ~f:to_string)
 
 let send_zkapp uri command =
   let q =

--- a/src/app/zkapps_examples/rollup/sequencer/lib/gql_client.ml
+++ b/src/app/zkapps_examples/rollup/sequencer/lib/gql_client.ml
@@ -134,6 +134,28 @@ let fetch_best_chain ?(max_length = 10) uri =
     |> map (member "stateHash")
     |> to_list |> List.map ~f:to_string)
 
+let fetch_genesis_timestamp uri =
+  let q =
+    object
+      method query =
+        String.substr_replace_all ~pattern:"\n" ~with_:" "
+          {|
+            query {
+              genesisConstants {
+                genesisTimestamp
+              }
+            } 
+          |}
+
+      method variables = `Assoc []
+    end
+  in
+  let%map result = Graphql_client.query_json_exn q uri in
+  Yojson.Safe.Util.(
+    result |> member "genesisConstants" |> member "genesisTimestamp"
+    |> to_string)
+  |> Time.of_string
+
 module For_tests = struct
   let create_account uri pk =
     let q =

--- a/src/app/zkapps_examples/rollup/sequencer/lib/rollback_checker.ml
+++ b/src/app/zkapps_examples/rollup/sequencer/lib/rollback_checker.ml
@@ -15,6 +15,9 @@ module Rollback_checker = struct
   let create zkapp_pk interval uri =
     let%bind chain = Gql_client.fetch_best_chain uri in
     let%bind last_rollup_state = Gql_client.fetch_commited_state uri zkapp_pk in
+    let last_rollup_state =
+      Frozen_ledger_hash.of_decimal_string @@ List.nth_exn last_rollup_state 0
+    in
     let last_state_hash = List.last_exn chain in
     return { last_state_hash; last_rollup_state; zkapp_pk; interval; uri }
 
@@ -24,6 +27,9 @@ module Rollback_checker = struct
     in
     let%bind.Deferred.Result last_rollup_state =
       try_with (fun () -> Gql_client.fetch_commited_state t.uri t.zkapp_pk)
+    in
+    let last_rollup_state =
+      Frozen_ledger_hash.of_decimal_string @@ List.nth_exn last_rollup_state 0
     in
 
     let last_state_hash = List.last_exn chain in

--- a/src/app/zkapps_examples/rollup/sequencer/tests/local_network/run.ml
+++ b/src/app/zkapps_examples/rollup/sequencer/tests/local_network/run.ml
@@ -13,8 +13,8 @@ let run port db_dir genesis_account () =
       { db =
           Ledger.Db.create ~directory_name:db_dir
             ~depth:Gql.constraint_constants.ledger_depth ()
-      ; slot = Mina_numbers.Global_slot_since_genesis.zero
       ; commands = Hashtbl.create (module String)
+      ; genesis_timestamp = Block_time.(to_int64 @@ of_time @@ Core.Time.now ())
       }
   in
 

--- a/src/app/zkapps_examples/rollup/sequencer/tests/local_network/run.ml
+++ b/src/app/zkapps_examples/rollup/sequencer/tests/local_network/run.ml
@@ -14,7 +14,9 @@ let run port db_dir genesis_account () =
           Ledger.Db.create ~directory_name:db_dir
             ~depth:Gql.constraint_constants.ledger_depth ()
       ; commands = Hashtbl.create (module String)
-      ; genesis_timestamp = Block_time.(to_int64 @@ of_time @@ Core.Time.now ())
+      ; genesis_timestamp =
+          Block_time.(
+            to_int64 @@ of_time @@ Core.Time.(sub (now ()) (Span.of_day 1.)))
       }
   in
 

--- a/src/app/zkapps_examples/rollup/zkapps_rollup.ml
+++ b/src/app/zkapps_examples/rollup/zkapps_rollup.ml
@@ -1599,6 +1599,10 @@ struct
       let tree = mkforest tree proof in
       return tree
 
+    let acceptable_global_slot_difference =
+      Mina_numbers.Global_slot_span.of_int
+        Outer_rules.Step.acceptable_global_slot_difference
+
     let unsafe_deploy_update (ledger_hash : Ledger_hash.t) =
       let update =
         { Update.dummy with

--- a/src/app/zkapps_examples/rollup/zkapps_rollup.mli
+++ b/src/app/zkapps_examples/rollup/zkapps_rollup.mli
@@ -18,7 +18,10 @@ module Make (T : sig
   val tag : Transaction_snark.tag
 end) : sig
   module Wrapper : sig
-    val wrap : Transaction_snark.t -> t Deferred.t
+    val wrap :
+         Transaction_snark.t
+      -> Mina_numbers.Global_slot_since_genesis.t
+      -> t Deferred.t
 
     val merge : t -> t -> t Deferred.t
 

--- a/src/app/zkapps_examples/rollup/zkapps_rollup.mli
+++ b/src/app/zkapps_examples/rollup/zkapps_rollup.mli
@@ -113,6 +113,8 @@ end) : sig
          Zkapp_command.Call_forest.t
          Deferred.t
 
+    val acceptable_global_slot_difference : Mina_numbers.Global_slot_span.t
+
     (* Create an account update update for deploying the zkapp, given a valid ledger for it. *)
     val deploy_update_exn : Mina_ledger.Ledger.t -> Account_update.Update.t
 

--- a/src/app/zkapps_examples/rollup/zkapps_rollup.mli
+++ b/src/app/zkapps_examples/rollup/zkapps_rollup.mli
@@ -94,6 +94,7 @@ end) : sig
       -> remaining_withdrawals:TR.t list
       -> source_ledger:Mina_ledger.Sparse_ledger.t
       -> target_ledger:Mina_ledger.Sparse_ledger.t
+      -> previous_global_slot_update:Mina_numbers.Global_slot_since_genesis.t
       -> ( ( Account_update.t
            , Zkapp_command.Digest.Account_update.t
            , Zkapp_command.Digest.Forest.t )
@@ -105,6 +106,7 @@ end) : sig
     val step_without_transfers :
          t
       -> public_key:Public_key.Compressed.t
+      -> previous_global_slot_update:Mina_numbers.Global_slot_since_genesis.t
       -> ( Account_update.t
          , Zkapp_command.Digest.Account_update.t
          , Zkapp_command.Digest.Forest.t )


### PR DESCRIPTION
The global slot on L2 follows the L1. To ensure that transactions in batch don't go back in time, we need to commit the global slot of last batch to the outer zkapp state.