### PR TITLE
Make all DA scripts chdir to correct dir automatically

### DIFF
--- a/src/app/zeko/da-layer/scripts/getBatches.ts
+++ b/src/app/zeko/da-layer/scripts/getBatches.ts
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
 
+import { chdir } from "process";
+
+chdir(__dirname);
+
 import fs from "fs";
 import { ethers } from "hardhat";
 import { z } from "zod";

--- a/src/app/zeko/da-layer/scripts/postBatch.ts
+++ b/src/app/zeko/da-layer/scripts/postBatch.ts
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
 
+import { chdir } from "process";
+
+chdir(__dirname);
+
 import fs from "fs";
 import { ethers } from "hardhat";
 import { z } from "zod";


### PR DESCRIPTION
Previously only the deploy script would.

This is necessary to ensure the hardhat config is picked up by hardhat.