### PR TITLE
Try adding archive relay to Nix build

### DIFF
--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -186,6 +186,7 @@ let
             src/app/zeko/sequencer/run.exe \
             src/app/zeko/sequencer/deploy.exe \
             src/app/zeko/sequencer/tests/local_network/run.exe \
+            src/app/zeko/sequencer/archive_relay/run.exe \
             src/app/logproc/logproc.exe \
             src/app/cli/src/mina.exe \
             src/app/batch_txn_tool/batch_txn_tool.exe \
@@ -252,6 +253,7 @@ let
           cp src/app/swap_bad_balances/swap_bad_balances.exe $archive/bin/mina-swap-bad-balances
           cp src/app/zeko/sequencer/run.exe $zeko/bin/zeko-run
           cp src/app/zeko/sequencer/deploy.exe $zeko/bin/zeko-deploy
+          cp src/app/zeko/sequencer/archive_relay/run.exe $zeko/bin/zeko-archive-relay
           cp src/app/zeko/sequencer/tests/local_network/run.exe $localnet/bin/mina-localnet
           cp -R _doc/_html $out/share/doc/html
           # cp src/lib/mina_base/sample_keypairs.json $sample/share/mina


### PR DESCRIPTION
Unfortunately, this doesn't work.
The build fails at the end for no apparent reason.

It manages to `ocamlopt` the deploy exe, the run exe, and then fails. I assume it fails when trying to `ocamlopt` the archive relay exe, but it does not show up in the log.