### PR TITLE
Add recommitting

### DIFF
--- a/src/app/zeko/sequencer/cli.ml
+++ b/src/app/zeko/sequencer/cli.ml
@@ -93,9 +93,9 @@ let committer =
                let%bind nonce =
                  match nonce_opt with
                  | Some nonce ->
-                     return nonce
+                     return (Account.Nonce.of_int nonce)
                  | None ->
-                     Sequencer_lib.Gql_client.fetch_nonce l1_uri
+                     Sequencer_lib.Gql_client.inferr_nonce l1_uri
                        (Signature_lib.Public_key.compress signer.public_key)
                in
                let executor = Executor.create ~nonce ~l1_uri ~signer ~kvdb () in

--- a/src/app/zeko/sequencer/cli.ml
+++ b/src/app/zeko/sequencer/cli.ml
@@ -95,7 +95,7 @@ let committer =
                  | Some nonce ->
                      return (Account.Nonce.of_int nonce)
                  | None ->
-                     Sequencer_lib.Gql_client.inferr_nonce l1_uri
+                     Sequencer_lib.Gql_client.infer_nonce l1_uri
                        (Signature_lib.Public_key.compress signer.public_key)
                in
                let executor = Executor.create ~nonce ~l1_uri ~signer ~kvdb () in

--- a/src/app/zeko/sequencer/deploy.ml
+++ b/src/app/zeko/sequencer/deploy.ml
@@ -27,7 +27,7 @@ let run uri sk test_accounts_path () =
 
   let nonce =
     Thread_safe.block_on_async_exn (fun () ->
-        Sequencer_lib.Gql_client.fetch_nonce uri
+        Sequencer_lib.Gql_client.inferr_nonce uri
           (Signature_lib.Public_key.compress sender_keypair.public_key) )
   in
   let command =
@@ -47,8 +47,7 @@ let run uri sk test_accounts_path () =
         Sequencer_lib.Deploy.deploy_command_exn ~signer:sender_keypair
           ~zkapp:zkapp_keypair
           ~fee:(Currency.Fee.of_mina_int_exn 1)
-          ~nonce:(Account.Nonce.of_int nonce)
-          ~constraint_constants ~initial_ledger:ledger
+          ~nonce ~constraint_constants ~initial_ledger:ledger
           (module M) )
   in
   Thread_safe.block_on_async_exn (fun () ->

--- a/src/app/zeko/sequencer/deploy.ml
+++ b/src/app/zeko/sequencer/deploy.ml
@@ -27,7 +27,7 @@ let run uri sk test_accounts_path () =
 
   let nonce =
     Thread_safe.block_on_async_exn (fun () ->
-        Sequencer_lib.Gql_client.inferr_nonce uri
+        Sequencer_lib.Gql_client.infer_nonce uri
           (Signature_lib.Public_key.compress sender_keypair.public_key) )
   in
   let command =

--- a/src/app/zeko/sequencer/lib/executor.ml
+++ b/src/app/zeko/sequencer/lib/executor.ml
@@ -161,7 +161,7 @@ let send_commit t command ~source ~target =
 
 let recommit_all t ~zkapp_pk =
   let%bind current_state =
-    Gql_client.infer_commited_state t.l1_uri ~zkapp_pk
+    Gql_client.infer_committed_state t.l1_uri ~zkapp_pk
       ~signer_pk:(Public_key.compress t.signer.public_key)
   in
   let commits = Commits_store.get_index t.kvdb in

--- a/src/app/zeko/sequencer/lib/executor.ml
+++ b/src/app/zeko/sequencer/lib/executor.ml
@@ -40,7 +40,7 @@ let process_command t (command : Zkapp_command.t) =
       | Some nonce ->
           return nonce
       | None ->
-          Gql_client.inferr_nonce t.l1_uri
+          Gql_client.infer_nonce t.l1_uri
             (Public_key.compress t.signer.public_key)
     in
     let command =
@@ -148,7 +148,7 @@ let send_commit t command ~source ~target =
 
 let recommit_all t ~zkapp_pk =
   let%bind current_state =
-    Gql_client.inferr_commited_state t.l1_uri ~zkapp_pk
+    Gql_client.infer_commited_state t.l1_uri ~zkapp_pk
       ~signer_pk:(Public_key.compress t.signer.public_key)
   in
   let commits = Commits_store.get_index t.kvdb in

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -1532,7 +1532,7 @@ module Mutations = struct
             ~fee_payer_pk:from
             ~nonce:
               (Option.value
-                 ~default:(Zeko_sequencer.inferr_nonce sequencer from)
+                 ~default:(Zeko_sequencer.infer_nonce sequencer from)
                  nonce_opt )
             ~valid_until:
               (Option.map valid_until

--- a/src/app/zeko/sequencer/lib/gql_client.ml
+++ b/src/app/zeko/sequencer/lib/gql_client.ml
@@ -88,8 +88,8 @@ let fetch_pooled_signed_commands uri pk =
     |> List.map ~f:to_string
     |> List.map ~f:(Fn.compose ok_exn Signed_command.of_base64))
 
-(* Inferrs nonce based on pooled commands *)
-let inferr_nonce uri pk =
+(* Infers nonce based on pooled commands *)
+let infer_nonce uri pk =
   let%bind pooled_zkapp_commands = fetch_pooled_zkapp_commands uri pk
   and pooled_signed_commands = fetch_pooled_signed_commands uri pk in
   let max_pooled_nonce =
@@ -139,7 +139,7 @@ let fetch_commited_state uri pk =
     result |> member "account" |> member "zkappState" |> index 0 |> to_string)
   |> Frozen_ledger_hash.of_decimal_string
 
-let inferr_commited_state uri ~zkapp_pk ~signer_pk =
+let infer_commited_state uri ~zkapp_pk ~signer_pk =
   let%bind commited_state = fetch_commited_state uri zkapp_pk
   and pooled_zkapp_commands = fetch_pooled_zkapp_commands uri signer_pk in
   let pooled_zkapp_commands =

--- a/src/app/zeko/sequencer/lib/gql_client.ml
+++ b/src/app/zeko/sequencer/lib/gql_client.ml
@@ -110,10 +110,10 @@ let infer_nonce uri pk =
     in
     Unsigned.UInt32.(max max_zkapp_commands_nonce max_signed_commands_nonce)
   in
-  let%map commited_nonce = fetch_nonce uri pk in
-  Unsigned.UInt32.max max_pooled_nonce commited_nonce
+  let%map committed_nonce = fetch_nonce uri pk in
+  Unsigned.UInt32.max max_pooled_nonce committed_nonce
 
-let fetch_commited_state uri pk =
+let fetch_committed_state uri pk =
   let q =
     object
       method query =
@@ -139,8 +139,8 @@ let fetch_commited_state uri pk =
     result |> member "account" |> member "zkappState" |> index 0 |> to_string)
   |> Frozen_ledger_hash.of_decimal_string
 
-let infer_commited_state uri ~zkapp_pk ~signer_pk =
-  let%bind commited_state = fetch_commited_state uri zkapp_pk
+let infer_committed_state uri ~zkapp_pk ~signer_pk =
+  let%bind committed_state = fetch_committed_state uri zkapp_pk
   and pooled_zkapp_commands = fetch_pooled_zkapp_commands uri signer_pk in
   let pooled_zkapp_commands =
     List.sort pooled_zkapp_commands ~compare:(fun a b ->
@@ -152,7 +152,7 @@ let infer_commited_state uri ~zkapp_pk ~signer_pk =
     |> List.filter_opt
   in
   let future_state =
-    List.fold_until pooled_state_transitions ~init:commited_state
+    List.fold_until pooled_state_transitions ~init:committed_state
       ~f:(fun acc (source, target) ->
         if Frozen_ledger_hash.equal acc source then Continue target
         else Stop acc )

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -889,14 +889,13 @@ let%test_unit "apply commands and commit" =
                    Compressed.to_base58_check
                    @@ compress zkapp_keypair.public_key) ) ;
               let%bind nonce =
-                Gql_client.fetch_nonce gql_uri
+                Gql_client.inferr_nonce gql_uri
                   (Signature_lib.Public_key.compress signer.public_key)
               in
               let command =
                 Deploy.deploy_command_exn ~signer ~zkapp:zkapp_keypair
                   ~fee:(Currency.Fee.of_mina_int_exn 1)
-                  ~nonce:(Account.Nonce.of_int nonce)
-                  ~initial_ledger:expected_ledger ~constraint_constants
+                  ~nonce ~initial_ledger:expected_ledger ~constraint_constants
                   (module M)
               in
               let%bind _ = Gql_client.send_zkapp gql_uri command in

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -1007,6 +1007,17 @@ let%test_unit "apply commands and commit" =
               let%bind () =
                 Executor.wait_to_finish sequencer.snark_q.executor
               in
+              let%bind commited_ledger_hash =
+                Gql_client.inferr_commited_state gql_uri
+                  ~signer_pk:
+                    (Signature_lib.Public_key.compress signer.public_key)
+                  ~zkapp_pk:
+                    (Signature_lib.Public_key.compress zkapp_keypair.public_key)
+              in
+              let target_ledger_hash = get_root sequencer in
+              [%test_eq: Frozen_ledger_hash.t] commited_ledger_hash
+                target_ledger_hash ;
+
               Deferred.unit ) ;
 
           (* To test nonce inferring from pool *)

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -735,12 +735,12 @@ module Sequencer = struct
     let%bind () =
       Executor.recommit_all snark_q.executor ~zkapp_pk:config.zkapp_pk
     in
-    let%bind commited_ledger_hash =
-      Gql_client.infer_commited_state config.l1_uri ~zkapp_pk:config.zkapp_pk
+    let%bind committed_ledger_hash =
+      Gql_client.infer_committed_state config.l1_uri ~zkapp_pk:config.zkapp_pk
         ~signer_pk:(Signature_lib.Public_key.compress config.signer.public_key)
     in
     printf "Fetched root: %s\n%!"
-      Frozen_ledger_hash.(to_decimal_string commited_ledger_hash) ;
+      Frozen_ledger_hash.(to_decimal_string committed_ledger_hash) ;
 
     (* add initial accounts *)
     List.iter genesis_accounts ~f:(fun (account_id, account) ->
@@ -752,7 +752,7 @@ module Sequencer = struct
     (* apply commands from DA layer *)
     let%bind commands =
       Da_layer.get_batches da_config
-        ~to_:(Frozen_ledger_hash.to_decimal_string commited_ledger_hash)
+        ~to_:(Frozen_ledger_hash.to_decimal_string committed_ledger_hash)
     in
     printf "Applying %d commands\n%!" (List.length commands) ;
     List.iter commands ~f:(fun command ->
@@ -770,7 +770,7 @@ module Sequencer = struct
     printf "Current root: %s\n%!"
       Frozen_ledger_hash.(to_decimal_string current_root) ;
 
-    if not @@ Frozen_ledger_hash.equal current_root commited_ledger_hash then
+    if not @@ Frozen_ledger_hash.equal current_root committed_ledger_hash then
       print_endline "Ledger mismatch" ;
 
     let sparse_ledger =
@@ -1019,15 +1019,15 @@ let%test_unit "apply commands and commit" =
               let%bind () =
                 Executor.wait_to_finish sequencer.snark_q.executor
               in
-              let%bind commited_ledger_hash =
-                Gql_client.infer_commited_state gql_uri
+              let%bind committed_ledger_hash =
+                Gql_client.infer_committed_state gql_uri
                   ~signer_pk:
                     (Signature_lib.Public_key.compress signer.public_key)
                   ~zkapp_pk:
                     (Signature_lib.Public_key.compress zkapp_keypair.public_key)
               in
               let target_ledger_hash = get_root sequencer in
-              [%test_eq: Frozen_ledger_hash.t] commited_ledger_hash
+              [%test_eq: Frozen_ledger_hash.t] committed_ledger_hash
                 target_ledger_hash ;
 
               Deferred.unit ) ;
@@ -1121,12 +1121,12 @@ let%test_unit "apply commands and commit" =
               let%bind _created =
                 Gql_client.For_tests.create_new_block gql_uri
               in
-              let%bind commited_ledger_hash =
-                Gql_client.fetch_commited_state gql_uri
+              let%bind committed_ledger_hash =
+                Gql_client.fetch_committed_state gql_uri
                   Signature_lib.Public_key.(compress zkapp_keypair.public_key)
               in
               let target_ledger_hash = get_root sequencer in
-              [%test_eq: Frozen_ledger_hash.t] commited_ledger_hash
+              [%test_eq: Frozen_ledger_hash.t] committed_ledger_hash
                 target_ledger_hash ;
 
               Deferred.unit ) ) )

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -443,7 +443,7 @@ module Sequencer = struct
     Mina_state.Protocol_state.consensus_state t.protocol_state
     |> Consensus.Data.Consensus_state.global_slot_since_genesis
 
-  let inferr_nonce t public_key =
+  let infer_nonce t public_key =
     match get_account t public_key Token_id.default with
     | Some account ->
         account.nonce
@@ -736,7 +736,7 @@ module Sequencer = struct
       Executor.recommit_all snark_q.executor ~zkapp_pk:config.zkapp_pk
     in
     let%bind commited_ledger_hash =
-      Gql_client.inferr_commited_state config.l1_uri ~zkapp_pk:config.zkapp_pk
+      Gql_client.infer_commited_state config.l1_uri ~zkapp_pk:config.zkapp_pk
         ~signer_pk:(Signature_lib.Public_key.compress config.signer.public_key)
     in
     printf "Fetched root: %s\n%!"
@@ -901,7 +901,7 @@ let%test_unit "apply commands and commit" =
                    Compressed.to_base58_check
                    @@ compress zkapp_keypair.public_key) ) ;
               let%bind nonce =
-                Gql_client.inferr_nonce gql_uri
+                Gql_client.infer_nonce gql_uri
                   (Signature_lib.Public_key.compress signer.public_key)
               in
               let command =
@@ -1020,7 +1020,7 @@ let%test_unit "apply commands and commit" =
                 Executor.wait_to_finish sequencer.snark_q.executor
               in
               let%bind commited_ledger_hash =
-                Gql_client.inferr_commited_state gql_uri
+                Gql_client.infer_commited_state gql_uri
                   ~signer_pk:
                     (Signature_lib.Public_key.compress signer.public_key)
                   ~zkapp_pk:

--- a/src/app/zeko/sequencer/tests/local_network/dune
+++ b/src/app/zeko/sequencer/tests/local_network/dune
@@ -74,4 +74,4 @@
   core_unix.command_unix)
  (preprocess
   (pps ppx_jane ppx_mina))
- (modules run gql))
+ (modules run state gql))

--- a/src/app/zeko/sequencer/tests/local_network/gql.ml
+++ b/src/app/zeko/sequencer/tests/local_network/gql.ml
@@ -1270,7 +1270,7 @@ module Mutations = struct
           | `Enqueued ->
               return (Ok Types.Command_status.Enqueued)
           | `Failed err ->
-              return (Error err)
+              return (Error (Error.to_string_hum err))
         in
         let command = Signed_command.forget_check command in
         let cmd =
@@ -1305,7 +1305,7 @@ module Mutations = struct
           | `Enqueued ->
               return (Ok Types.Command_status.Enqueued)
           | `Failed err ->
-              return (Error err)
+              return (Error (Error.to_string_hum err))
         in
         let cmd =
           { Types.Zkapp_command.With_status.data = zkapp_command; status }

--- a/src/app/zeko/sequencer/tests/local_network/gql.ml
+++ b/src/app/zeko/sequencer/tests/local_network/gql.ml
@@ -8,30 +8,6 @@ open Signature_lib
 open Currency
 module Schema = Graphql_wrapper.Make (Schema)
 
-type t =
-  { db : Ledger.Db.t
-  ; slot : Mina_numbers.Global_slot_since_genesis.t
-  ; commands : (string, User_command.t * Transaction_status.t) Hashtbl.t
-  }
-
-let constraint_constants = Genesis_constants.Constraint_constants.compiled
-
-let genesis_constants = Genesis_constants.compiled
-
-let consensus_constants =
-  Consensus.Constants.create ~constraint_constants
-    ~protocol_constants:genesis_constants.protocol
-
-let state_body =
-  let compile_time_genesis =
-    Mina_state.Genesis_protocol_state.t
-      ~genesis_ledger:Genesis_ledger.(Packed.t for_unit_tests)
-      ~genesis_epoch_data:Consensus.Genesis_epoch_data.for_unit_tests
-      ~constraint_constants ~consensus_constants
-      ~genesis_body_reference:Staged_ledger_diff.genesis_body_reference
-  in
-  Mina_state.Protocol_state.body compile_time_genesis.data
-
 module Types = struct
   open Schema
 
@@ -98,7 +74,7 @@ module Types = struct
               match x with `Left _ -> None | `Right h -> Some h )
         ] )
 
-  let account_timing : (t, Account_timing.t option) typ =
+  let account_timing : (State.t, Account_timing.t option) typ =
     obj "AccountTiming" ~fields:(fun _ ->
         [ field "initialMinimumBalance" ~typ:balance
             ~doc:"The initial minimum balance for a time-locked account"
@@ -797,7 +773,7 @@ module Types = struct
           resolve c uc.With_status.data )
 
     let user_command_shared_fields :
-        ( t
+        ( State.t
         , (Signed_command.t, Transaction_hash.t) With_hash.t With_status.t )
         field
         list =
@@ -935,8 +911,9 @@ module Types = struct
           resolve c cmd.With_status.data )
 
     let zkapp_command =
-      let conv (x : (t, Zkapp_command.t) Fields_derivers_graphql.Schema.typ) :
-          (t, Zkapp_command.t) typ =
+      let conv
+          (x : (State.t, Zkapp_command.t) Fields_derivers_graphql.Schema.typ) :
+          (State.t, Zkapp_command.t) typ =
         Obj.magic x
       in
       obj "ZkappCommandResult" ~fields:(fun _ ->
@@ -1280,50 +1257,32 @@ module Mutations = struct
                   payload
               with
               | Some command ->
-                  return (Ok (Signed_command.forget_check command))
+                  return (Ok command)
               | None ->
                   return (Error "Signature verification failed") )
         in
-        let l = Ledger.of_database t.db in
-        match
-          Result.( >>= )
-            (Ledger.apply_transaction_first_pass ~constraint_constants
-               ~global_slot:Mina_numbers.Global_slot_since_genesis.zero
-               ~txn_state_view:(Mina_state.Protocol_state.Body.view state_body)
-               l (Command (Signed_command command)) )
-            (Ledger.apply_transaction_second_pass l)
-        with
-        | Error err ->
-            return (Error (Error.to_string_mach err))
-        | Ok txn_applied ->
-            Ledger.Mask.Attached.commit l ;
-
-            let txn_hash =
-              Transaction_hash.to_base58_check
-              @@ Transaction_hash.hash_command (Signed_command command)
-            in
-            Hashtbl.add_exn t.commands ~key:txn_hash
-              ~data:
-                ( Signed_command command
-                , Ledger.Transaction_applied.transaction_status txn_applied ) ;
-
-            print_endline @@ "applied payment: " ^ txn_hash ^ " "
-            ^ Yojson.Safe.pretty_to_string @@ Transaction_status.to_yojson
-            @@ Ledger.Transaction_applied.transaction_status txn_applied ;
-
-            let cmd =
-              { Types.User_command.With_status.data = command
-              ; status = Applied
-              }
-            in
-            let cmd_with_hash =
-              Types.User_command.With_status.map cmd ~f:(fun cmd ->
-                  { With_hash.data = cmd
-                  ; hash = Transaction_hash.hash_command (Signed_command cmd)
-                  } )
-            in
-            Deferred.Result.return (Types.User_command.mk_payment cmd_with_hash)
-        )
+        let%bind.Deferred.Result status =
+          match
+            State.add_command_to_pool t ~command:(Signed_command command)
+          with
+          | `Applied ->
+              return (Ok Types.Command_status.Applied)
+          | `Enqueued ->
+              return (Ok Types.Command_status.Enqueued)
+          | `Failed err ->
+              return (Error err)
+        in
+        let command = Signed_command.forget_check command in
+        let cmd =
+          { Types.User_command.With_status.data = command; status = Applied }
+        in
+        let cmd_with_hash =
+          Types.User_command.With_status.map cmd ~f:(fun cmd ->
+              { With_hash.data = cmd
+              ; hash = Transaction_hash.hash_command (Signed_command cmd)
+              } )
+        in
+        Deferred.Result.return (Types.User_command.mk_payment cmd_with_hash) )
 
   let send_zkapp =
     io_field "sendZkapp" ~doc:"Send a zkApp transaction"
@@ -1331,47 +1290,25 @@ module Mutations = struct
       ~args:
         Arg.[ arg "input" ~typ:(non_null Types.Input.SendZkappInput.arg_typ) ]
       ~resolve:(fun { ctx = t; _ } () zkapp_command ->
-        let l = Ledger.of_database t.db in
-        let%bind.Deferred.Result partialy_applied_txn =
+        let command =
+          match Zkapp_command.Valid.to_valid_unsafe zkapp_command with
+          (* FIXME: check zkapp command if needed *)
+          | `If_this_is_used_it_should_have_a_comment_justifying_it command ->
+              command
+        in
+        let%bind.Deferred.Result status =
           match
-            Ledger.apply_transaction_first_pass ~constraint_constants
-              ~global_slot:Mina_numbers.Global_slot_since_genesis.zero
-              ~txn_state_view:(Mina_state.Protocol_state.Body.view state_body)
-              l (Command (Zkapp_command zkapp_command))
+            State.add_command_to_pool t ~command:(Zkapp_command command)
           with
-          | Error err ->
-              return (Error (Error.to_string_mach err))
-          | Ok partialy_applied_txn ->
-              return (Ok partialy_applied_txn)
+          | `Applied ->
+              return (Ok Types.Command_status.Applied)
+          | `Enqueued ->
+              return (Ok Types.Command_status.Enqueued)
+          | `Failed err ->
+              return (Error err)
         in
-
-        let%bind.Deferred.Result txn_applied =
-          match Ledger.apply_transaction_second_pass l partialy_applied_txn with
-          | Error err ->
-              return (Error (Error.to_string_mach err))
-          | Ok txn_applied ->
-              return (Ok txn_applied)
-        in
-
-        Ledger.Mask.Attached.commit l ;
-
-        let txn_hash =
-          Transaction_hash.to_base58_check
-          @@ Transaction_hash.hash_command (Zkapp_command zkapp_command)
-        in
-        Hashtbl.add_exn t.commands ~key:txn_hash
-          ~data:
-            ( Zkapp_command zkapp_command
-            , Ledger.Transaction_applied.transaction_status txn_applied ) ;
-
-        print_endline @@ "applied zkapp command: " ^ txn_hash ^ " "
-        ^ Yojson.Safe.pretty_to_string @@ Transaction_status.to_yojson
-        @@ Ledger.Transaction_applied.transaction_status txn_applied ;
-
         let cmd =
-          { Types.Zkapp_command.With_status.data = zkapp_command
-          ; status = Applied
-          }
+          { Types.Zkapp_command.With_status.data = zkapp_command; status }
         in
         let cmd_with_hash =
           Types.Zkapp_command.With_status.map cmd ~f:(fun cmd ->
@@ -1392,7 +1329,9 @@ module Mutations = struct
             (Currency.Balance.of_uint64
                (Unsigned.UInt64.of_int64 1_000_000_000_000L) )
         in
-        match Ledger.Db.get_or_create_account t.db account_id account with
+        match
+          Ledger.Db.get_or_create_account (State.db t) account_id account
+        with
         | Ok (`Added, _) ->
             return (Ok "Added")
         | Ok (`Existed, _) ->
@@ -1400,7 +1339,12 @@ module Mutations = struct
         | Error err ->
             return (Error (Error.to_string_mach err)) )
 
-  let commands = [ send_payment; send_zkapp; create_account ]
+  let create_new_block =
+    field "createNewBlock" ~doc:"Create a new block" ~typ:(non_null string)
+      ~args:Arg.[]
+      ~resolve:(fun { ctx = t; _ } () -> State.create_new_block t ; "Created")
+
+  let commands = [ send_payment; send_zkapp; create_account; create_new_block ]
 end
 
 module Queries = struct
@@ -1520,7 +1464,40 @@ module Queries = struct
               ~typ:(list (non_null string))
           ; arg "ids" ~typ:(list (non_null guid)) ~doc:"Ids of User commands"
           ]
-      ~resolve:(fun _ () _ _ _ -> [])
+      ~resolve:(fun { ctx = t; _ } () pk_opt _ _ ->
+        (* FIXME: currently it queries only based on public key *)
+        let commands = State.pooled_commands t in
+        Sequence.to_list commands
+        |> List.filter_map ~f:(fun command_with_hash ->
+               match
+                 Transaction_hash.User_command_with_valid_signature.command
+                   command_with_hash
+               with
+               | Signed_command cmd -> (
+                   let sender = Signed_command.fee_payer_pk cmd in
+                   match
+                     Option.map pk_opt ~f:(fun pk ->
+                         Account.Key.equal sender pk )
+                   with
+                   | Some true | None ->
+                       let cmd =
+                         { Types.User_command.With_status.data = cmd
+                         ; status = Enqueued
+                         }
+                       in
+                       let cmd_with_hash =
+                         Types.User_command.With_status.map cmd ~f:(fun cmd ->
+                             { With_hash.data = cmd
+                             ; hash =
+                                 Transaction_hash.hash_command
+                                   (Signed_command cmd)
+                             } )
+                       in
+                       Some (Types.User_command.mk_payment cmd_with_hash)
+                   | _ ->
+                       None )
+               | _ ->
+                   None ) )
 
   let pooled_zkapp_commands =
     field "pooledZkappCommands"
@@ -1537,7 +1514,40 @@ module Queries = struct
               ~typ:(list (non_null string))
           ; arg "ids" ~typ:(list (non_null guid)) ~doc:"Ids of zkApp commands"
           ]
-      ~resolve:(fun _ () _ _ _ -> [])
+      ~resolve:(fun { ctx = t; _ } () pk_opt _ _ ->
+        (* FIXME: currently it queries only based on public key *)
+        let commands = State.pooled_commands t in
+        Sequence.to_list commands
+        |> List.filter_map ~f:(fun command_with_hash ->
+               match
+                 Transaction_hash.User_command_with_valid_signature.command
+                   command_with_hash
+               with
+               | Zkapp_command cmd -> (
+                   let sender = Zkapp_command.fee_payer_pk cmd in
+                   match
+                     Option.map pk_opt ~f:(fun pk ->
+                         Account.Key.equal sender pk )
+                   with
+                   | Some true | None ->
+                       let cmd =
+                         { Types.Zkapp_command.With_status.data = cmd
+                         ; status = Enqueued
+                         }
+                       in
+                       let cmd_with_hash =
+                         Types.Zkapp_command.With_status.map cmd ~f:(fun cmd ->
+                             { With_hash.data = cmd
+                             ; hash =
+                                 Transaction_hash.hash_command
+                                   (Zkapp_command cmd)
+                             } )
+                       in
+                       Some cmd_with_hash
+                   | _ ->
+                       None )
+               | _ ->
+                   None ) )
 
   let commands =
     [ sync_status

--- a/src/app/zeko/sequencer/tests/local_network/gql.ml
+++ b/src/app/zeko/sequencer/tests/local_network/gql.ml
@@ -1452,7 +1452,7 @@ module Queries = struct
   let pooled_user_commands =
     field "pooledUserCommands"
       ~doc:
-        "Retrieve all the scheduled user commands for a specified sender that \
+        "Retrieve all the scheduled user commands for a specified signer that \
          the current daemon sees in its transaction pool. All scheduled \
          commands are queried if no sender is specified"
       ~typ:(non_null @@ list @@ non_null Types.User_command.user_command)
@@ -1502,8 +1502,8 @@ module Queries = struct
   let pooled_zkapp_commands =
     field "pooledZkappCommands"
       ~doc:
-        "Retrieve all the scheduled zkApp commands for a specified sender that \
-         the current daemon sees in its transaction pool. All scheduled \
+        "Retrieve all the scheduled zkApp commands for a specified fee payer \
+         that the current daemon sees in its transaction pool. All scheduled \
          commands are queried if no sender is specified"
       ~typ:(non_null @@ list @@ non_null Types.Zkapp_command.zkapp_command)
       ~args:

--- a/src/app/zeko/sequencer/tests/local_network/gql.ml
+++ b/src/app/zeko/sequencer/tests/local_network/gql.ml
@@ -1505,8 +1505,49 @@ module Queries = struct
         in
         Some cmd_with_hash )
 
+  let pooled_user_commands =
+    field "pooledUserCommands"
+      ~doc:
+        "Retrieve all the scheduled user commands for a specified sender that \
+         the current daemon sees in its transaction pool. All scheduled \
+         commands are queried if no sender is specified"
+      ~typ:(non_null @@ list @@ non_null Types.User_command.user_command)
+      ~args:
+        Arg.
+          [ arg "publicKey" ~doc:"Public key of sender of pooled user commands"
+              ~typ:Types.Input.PublicKey.arg_typ
+          ; arg "hashes" ~doc:"Hashes of the commands to find in the pool"
+              ~typ:(list (non_null string))
+          ; arg "ids" ~typ:(list (non_null guid)) ~doc:"Ids of User commands"
+          ]
+      ~resolve:(fun _ () _ _ _ -> [])
+
+  let pooled_zkapp_commands =
+    field "pooledZkappCommands"
+      ~doc:
+        "Retrieve all the scheduled zkApp commands for a specified sender that \
+         the current daemon sees in its transaction pool. All scheduled \
+         commands are queried if no sender is specified"
+      ~typ:(non_null @@ list @@ non_null Types.Zkapp_command.zkapp_command)
+      ~args:
+        Arg.
+          [ arg "publicKey" ~doc:"Public key of sender of pooled zkApp commands"
+              ~typ:Types.Input.PublicKey.arg_typ
+          ; arg "hashes" ~doc:"Hashes of the zkApp commands to find in the pool"
+              ~typ:(list (non_null string))
+          ; arg "ids" ~typ:(list (non_null guid)) ~doc:"Ids of zkApp commands"
+          ]
+      ~resolve:(fun _ () _ _ _ -> [])
+
   let commands =
-    [ sync_status; daemon_status; account; user_command; zkapp_command ]
+    [ sync_status
+    ; daemon_status
+    ; account
+    ; user_command
+    ; zkapp_command
+    ; pooled_user_commands
+    ; pooled_zkapp_commands
+    ]
 end
 
 let schema =

--- a/src/app/zeko/sequencer/tests/local_network/state.ml
+++ b/src/app/zeko/sequencer/tests/local_network/state.ml
@@ -1,0 +1,156 @@
+open Core
+open Async
+open Async_kernel
+open Mina_base
+open Mina_transaction
+open Network_pool
+module Ledger = Mina_ledger.Ledger
+
+let logger = Logger.create ()
+
+module Constants = struct
+  let constraint_constants = Genesis_constants.Constraint_constants.compiled
+
+  let genesis_constants = Genesis_constants.compiled
+
+  let consensus_constants =
+    Consensus.Constants.create ~constraint_constants
+      ~protocol_constants:genesis_constants.protocol
+
+  let state_body =
+    let compile_time_genesis =
+      Mina_state.Genesis_protocol_state.t
+        ~genesis_ledger:Genesis_ledger.(Packed.t for_unit_tests)
+        ~genesis_epoch_data:Consensus.Genesis_epoch_data.for_unit_tests
+        ~constraint_constants ~consensus_constants
+        ~genesis_body_reference:Staged_ledger_diff.genesis_body_reference
+    in
+    Mina_state.Protocol_state.body compile_time_genesis.data
+end
+
+type t =
+  { block_period : Time_ns.Span.t option
+  ; mutable block_height : int
+  ; db : Ledger.Db.t
+  ; commands : (string, User_command.t * Transaction_status.t) Hashtbl.t
+  ; mutable pool : Indexed_pool.t
+  }
+
+let db t = t.db
+
+let commands t = t.commands
+
+let pooled_commands t = Indexed_pool.transactions ~logger t.pool
+
+let apply_command t ~command =
+  let l = Ledger.of_database t.db in
+  let%bind.Result partialy_applied_txn =
+    match
+      Ledger.apply_transaction_first_pass
+        ~constraint_constants:Constants.constraint_constants
+        ~global_slot:Mina_numbers.Global_slot_since_genesis.zero
+        ~txn_state_view:
+          (Mina_state.Protocol_state.Body.view Constants.state_body)
+        l (Command command)
+    with
+    | Error err ->
+        Error (Error.to_string_mach err)
+    | Ok partialy_applied_txn ->
+        Ok partialy_applied_txn
+  in
+  let%bind.Result txn_applied =
+    match Ledger.apply_transaction_second_pass l partialy_applied_txn with
+    | Error err ->
+        Error (Error.to_string_mach err)
+    | Ok txn_applied ->
+        Ok txn_applied
+  in
+
+  Ledger.Mask.Attached.commit l ;
+
+  let txn_hash =
+    Transaction_hash.to_base58_check @@ Transaction_hash.hash_command command
+  in
+  Hashtbl.add_exn t.commands ~key:txn_hash
+    ~data:(command, Ledger.Transaction_applied.transaction_status txn_applied) ;
+
+  print_endline @@ "applied zkapp command: " ^ txn_hash ^ " "
+  ^ Yojson.Safe.pretty_to_string @@ Transaction_status.to_yojson
+  @@ Ledger.Transaction_applied.transaction_status txn_applied ;
+
+  Ok ()
+
+let get_account t account_id =
+  let%bind.Option location = Ledger.Db.location_of_account t.db account_id in
+  Ledger.Db.get t.db location
+
+let add_command_to_pool t ~(command : User_command.Valid.t) =
+  match t.block_period with
+  | None -> (
+      match apply_command t ~command:(User_command.forget_check command) with
+      | Ok () ->
+          `Applied
+      | Error err ->
+          `Failed err )
+  | Some _ -> (
+      match
+        get_account t
+          (User_command.fee_payer @@ User_command.forget_check command)
+      with
+      | None ->
+          `Failed "fee payer account not found"
+      | Some account -> (
+          let nonce = account.nonce in
+          let balance = account.balance in
+          match
+            Indexed_pool.add_from_gossip_exn t.pool
+              (Transaction_hash.User_command_with_valid_signature.create command)
+              nonce
+              (Currency.Balance.to_amount balance)
+          with
+          | Error err ->
+              `Failed (Yojson.Safe.to_string @@ Command_error.to_yojson err)
+          | Ok (_, pool, _) ->
+              t.pool <- pool ;
+              print_endline "added command to pool" ;
+              `Enqueued ) )
+
+let create_pool () =
+  Indexed_pool.empty ~constraint_constants:Constants.constraint_constants
+    ~consensus_constants:Constants.consensus_constants
+    ~time_controller:(Block_time.Controller.basic ~logger)
+    ~slot_tx_end:None
+
+let create_new_block t =
+  t.block_height <- t.block_height + 1 ;
+  printf "Creating a new block %d\n%!" t.block_height ;
+  let transactions = Indexed_pool.transactions ~logger t.pool in
+  Sequence.iter transactions ~f:(fun txn ->
+      let command =
+        Transaction_hash.User_command_with_valid_signature.command txn
+      in
+      match apply_command t ~command with
+      | Ok () ->
+          ()
+      | Error err ->
+          printf "Failed to apply command: %s\n%!" err ) ;
+  t.pool <- create_pool ()
+
+let create ~block_period ~db_dir () =
+  let t =
+    { block_period
+    ; block_height = 0
+    ; db =
+        Ledger.Db.create ~directory_name:db_dir
+          ~depth:Constants.constraint_constants.ledger_depth ()
+    ; commands = Hashtbl.create (module String)
+    ; pool = create_pool ()
+    }
+  in
+  match block_period with
+  | None ->
+      t
+  | Some block_period ->
+      every ~start:(after block_period) block_period (fun () ->
+          create_new_block t ) ;
+      t


### PR DESCRIPTION
1. Infer nonce from the pool, not just from the latest block
2. Infer state also from the pool, not just from the latest block
3. If we have stored commits that have not been yet committed, send them to L1

Added also a possibility to do "blocks" on the testing network. Commands are added to the indexed transaction pool and they are applied in predefined period, or when `createNewBlock` mutation gets triggered.