### PR TITLE
Make access permission Proof

### DIFF
--- a/src/app/zeko/zeko_util.ml
+++ b/src/app/zeko/zeko_util.ml
@@ -51,7 +51,7 @@ let proof_permissions : Permissions.t =
   ; increment_nonce = None
   ; set_voting_for = Proof
   ; set_timing = Proof
-  ; access = None
+  ; access = Proof
   }
 
 (* Intended to be used for custom token accounts *)


### PR DESCRIPTION
Otherwise I believe token owner logic would be meaningless, since access permission seems to be the one that's relevant in this case.