### PR TITLE
Replace use of As_prover.Ref with Prover_value (V)

### DIFF
--- a/src/app/zeko/action_state_extension.ml
+++ b/src/app/zeko/action_state_extension.ml
@@ -32,7 +32,7 @@ module T = struct
     in
     { public_input = { source; target }
     ; proof_must_verify (* Don't check proof if source == target *)
-    ; proof = v_ref proof
+    ; proof = ref_of_v proof
     }
 
   let statement_var ({ source; target } : var) : Stmt.var = { source; target }

--- a/src/app/zeko/action_state_extension.ml
+++ b/src/app/zeko/action_state_extension.ml
@@ -32,7 +32,7 @@ module T = struct
     in
     { public_input = { source; target }
     ; proof_must_verify (* Don't check proof if source == target *)
-    ; proof
+    ; proof = v_ref proof
     }
 
   let statement_var ({ source; target } : var) : Stmt.var = { source; target }

--- a/src/app/zeko/wrapper.ml
+++ b/src/app/zeko/wrapper.ml
@@ -32,7 +32,7 @@ module T = struct
     Pickles.Inductive_rule.Previous_proof_statement.
       { public_input = stmt
       ; proof_must_verify = Boolean.true_
-      ; proof = v_ref proof
+      ; proof = ref_of_v proof
       }
 
   let statement_var { stmt } = stmt
@@ -154,7 +154,7 @@ module Wrap = struct
           (* Proof for txn_snark_stmt using normal txn snark *)
           [ { public_input = txn_snark_stmt
             ; proof_must_verify = Boolean.true_
-            ; proof = V.map txn_snark ~f:Transaction_snark.proof |> v_ref
+            ; proof = V.map txn_snark ~f:Transaction_snark.proof |> ref_of_v
             }
           ]
       ; public_output = stmt

--- a/src/app/zeko/wrapper.ml
+++ b/src/app/zeko/wrapper.ml
@@ -30,7 +30,10 @@ module T = struct
 
   let verify { stmt; proof } =
     Pickles.Inductive_rule.Previous_proof_statement.
-      { public_input = stmt; proof_must_verify = Boolean.true_; proof }
+      { public_input = stmt
+      ; proof_must_verify = Boolean.true_
+      ; proof = v_ref proof
+      }
 
   let statement_var { stmt } = stmt
 
@@ -78,7 +81,7 @@ module Wrap = struct
     let txn_snark_stmt =
       Transaction_snark.(
         exists With_sok.typ ~compute:(fun () ->
-            statement_with_sok @@ As_prover.Ref.get txn_snark ))
+            statement_with_sok @@ V.get txn_snark ))
     in
     let stmt =
       Stmt.(
@@ -151,9 +154,7 @@ module Wrap = struct
           (* Proof for txn_snark_stmt using normal txn snark *)
           [ { public_input = txn_snark_stmt
             ; proof_must_verify = Boolean.true_
-            ; proof =
-                As_prover.Ref.create (fun () ->
-                    Transaction_snark.proof @@ As_prover.Ref.get txn_snark )
+            ; proof = V.map txn_snark ~f:Transaction_snark.proof |> v_ref
             }
           ]
       ; public_output = stmt

--- a/src/app/zeko/zeko_util.ml
+++ b/src/app/zeko/zeko_util.ml
@@ -208,9 +208,9 @@ end) =
 struct
   type t = T.t [@@deriving yojson]
 
-  type var = T.t As_prover.Ref.t
+  type var = T.t V.t
 
-  let typ : (var, t) Typ.t = Typ.Internal.ref ()
+  let typ : (var, t) Typ.t = V.typ ()
 end
 
 (** A list of `length` `t`s *)
@@ -310,3 +310,6 @@ let assert_var label expr =
 
 let assert_var_checked label expr =
   with_label label (fun () -> expr () |> run |> Boolean.Assert.is_true)
+
+let v_ref (x : 'a V.t) : 'a As_prover.Ref.t =
+  As_prover.Ref.create (fun () -> V.get x)

--- a/src/app/zeko/zeko_util.ml
+++ b/src/app/zeko/zeko_util.ml
@@ -311,5 +311,5 @@ let assert_var label expr =
 let assert_var_checked label expr =
   with_label label (fun () -> expr () |> run |> Boolean.Assert.is_true)
 
-let v_ref (x : 'a V.t) : 'a As_prover.Ref.t =
+let ref_of_v (x : 'a V.t) : 'a As_prover.Ref.t =
   As_prover.Ref.create (fun () -> V.get x)

--- a/src/app/zeko/zkapps_rollup.ml
+++ b/src/app/zeko/zkapps_rollup.ml
@@ -505,7 +505,7 @@ module Outer = struct
         (Stmt.var, Nat.N2.n) Pickles.Inductive_rule.Previous_proof_statement.t =
       { public_input = stmt
       ; proof_must_verify = Boolean.(true_)
-      ; proof = v_ref proof
+      ; proof = ref_of_v proof
       }
   end
 

--- a/src/app/zeko/zkapps_rollup.ml
+++ b/src/app/zeko/zkapps_rollup.ml
@@ -503,7 +503,10 @@ module Outer = struct
 
     let verify ({ stmt; proof } : var) :
         (Stmt.var, Nat.N2.n) Pickles.Inductive_rule.Previous_proof_statement.t =
-      { public_input = stmt; proof_must_verify = Boolean.(true_); proof }
+      { public_input = stmt
+      ; proof_must_verify = Boolean.(true_)
+      ; proof = v_ref proof
+      }
   end
 
   module Witness = struct


### PR DESCRIPTION
Prover_value is a wrapper on top of As_prover.Ref (but it doesn't have to be), but doesn't provide a mutable interface notably.
Using As_prover.Ref is confusing because it signals that you might change the value later, which is not true most of the time.