### PR TITLE
Fix kvdb in cli

### DIFF
--- a/src/app/zeko/sequencer/cli.ml
+++ b/src/app/zeko/sequencer/cli.ml
@@ -211,7 +211,7 @@ let snark_queue =
              Mina_ledger.Ledger.Db.create ~directory_name:db_dir
                ~depth:Zeko_sequencer.constraint_constants.ledger_depth ()
            in
-           let kvdb = Kvdb.of_dir db_dir in
+           let kvdb = Mina_ledger.Ledger.Db.kvdb db in
            let (module T), (module M) =
              Lazy.force Zeko_sequencer.prover_modules
            in


### PR DESCRIPTION
Creating 2 instances of database locks out the second one, so the `kvdb` needs to be derived from the `db` instance.