### PR TITLE
Fix transfers fetching

### DIFF
--- a/src/app/zeko/sequencer/lib/committer.ml
+++ b/src/app/zeko/sequencer/lib/committer.ml
@@ -127,8 +127,6 @@ let prove_commit (module M : Zkapps_rollup.S) ~(executor : Executor.t) ~zkapp_pk
     Gql_client.fetch_transfers archive_uri
       ~from_action_state:processed_deposits_pointer zkapp_pk
     |> Deferred.map ~f:(List.map ~f:fst)
-    (* Drop first since the filter is inclusive from both sides *)
-    |> Deferred.map ~f:(fun l -> List.drop l 1)
   in
   let%bind account_update =
     M.Outer.step last_snark ~outer_public_key:zkapp_pk

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -1349,7 +1349,7 @@ module Make
           type input = Zeko_sequencer.Transfer.claim
 
           let arg_typ =
-            obj "TransferRequestInput"
+            obj "TransferClaimInput"
               ~coerce:(fun is_new pointer before after transfer ->
                 Zeko_sequencer.Transfer.
                   { is_new

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -1942,7 +1942,7 @@ module Make
 
     module Archive = struct
       let actions =
-        field "actions"
+        io_field "actions"
           ~typ:(non_null @@ list @@ non_null Types.Archive.ActionOutput.t)
           ~args:
             Arg.
@@ -1957,9 +1957,10 @@ module Make
                         , from_action_state
                         , end_action_state ) ->
             let token_id = Option.value ~default:Token_id.default token_id in
-            Archive.get_actions sequencer.archive
-              (Account_id.create public_key token_id)
-              ~from:from_action_state ~to_:end_action_state )
+            return
+            @@ Archive.get_actions sequencer.archive
+                 (Account_id.create public_key token_id)
+                 ~from:from_action_state ~to_:end_action_state )
 
       let events =
         field "events"

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -1847,10 +1847,12 @@ module Make
           with
           | None ->
               None
-          | Some (_, account_update) ->
+          | Some (_, Ok account_update) ->
               Some
                 ( Yojson.Safe.to_string
-                @@ Zkapp_command.account_updates_to_json account_update ) )
+                @@ Zkapp_command.account_updates_to_json account_update )
+          | Some (_, Error msg) ->
+              Some msg )
 
     let committed_transaction =
       io_field "committedTransactions"

--- a/src/app/zeko/sequencer/lib/gql_client.ml
+++ b/src/app/zeko/sequencer/lib/gql_client.ml
@@ -134,10 +134,6 @@ let fetch_transfers uri ?from_action_state ?end_action_state pk =
           , block_height ) ) )
   |> List.join
 
-(* stiahnut transfery a pridat to outer.step *)
-(* pustit inner.step *)
-(* exposnut api na posielanie withdrawalov a provovanie depositov *)
-
 let fetch_pooled_zkapp_commands uri pk =
   let q =
     object

--- a/src/app/zeko/sequencer/lib/gql_client.ml
+++ b/src/app/zeko/sequencer/lib/gql_client.ml
@@ -133,6 +133,11 @@ let fetch_transfers uri ?from_action_state ?end_action_state pk =
               }
           , block_height ) ) )
   |> List.join
+  |>
+  (* Drop the first transfer if it's not the initial state *)
+  if Stdlib.(from_action_state = Some Zkapp_account.Actions.empty_state_element)
+  then Fn.id
+  else function [] -> [] | _ :: tail -> tail
 
 let fetch_pooled_zkapp_commands uri pk =
   let q =

--- a/src/app/zeko/sequencer/lib/transfers_memory.ml
+++ b/src/app/zeko/sequencer/lib/transfers_memory.ml
@@ -7,15 +7,16 @@ open Base
 open Mina_base
 
 module Transfers_memory = struct
+  type t_ =
+    ( ( Account_update.t
+      , Zkapp_command.Digest.Account_update.t
+      , Zkapp_command.Digest.Forest.t )
+      Zkapp_command.Call_forest.t
+    , string )
+    Result.t
+
   type t =
-    { table :
-        ( string
-        , float
-          * ( Account_update.t
-            , Zkapp_command.Digest.Account_update.t
-            , Zkapp_command.Digest.Forest.t )
-            Zkapp_command.Call_forest.t )
-        Hashtbl.t
+    { table : (string, float * t_) Hashtbl.t
     ; queue : (string * float) Queue.t
     ; lifetime : float
     }
@@ -39,9 +40,9 @@ module Transfers_memory = struct
     in
     loop ()
 
-  let add t key account_update =
+  let add t key account_update_result =
     let now = Unix.time () in
-    Hashtbl.set t.table ~key ~data:(now, account_update) ;
+    Hashtbl.set t.table ~key ~data:(now, account_update_result) ;
     Queue.enqueue t.queue (key, now) ;
     cleanup t
 

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -257,40 +257,57 @@ module Make (T : Transaction_snark.S) (M : Zkapps_rollup.S) = struct
 
     let enqueue_prove_transfer_request t ~key ~(transfer : Transfer.t) =
       Throttle.enqueue t.q (fun () ->
-          let%bind tree =
-            match transfer with
-            | { direction = Deposit; transfer } ->
-                M.Outer.submit_deposit ~outer_public_key:t.config.zkapp_pk
-                  ~deposit:transfer
-            | { direction = Withdraw; transfer } ->
-                M.Inner.submit_withdrawal ~withdrawal:transfer
+          let%bind result =
+            try_with (fun () ->
+                match transfer with
+                | { direction = Deposit; transfer } ->
+                    M.Outer.submit_deposit ~outer_public_key:t.config.zkapp_pk
+                      ~deposit:transfer
+                | { direction = Withdraw; transfer } ->
+                    M.Inner.submit_withdrawal ~withdrawal:transfer )
           in
-          Transfers_memory.add t.transfers_memory key
-            (Zkapp_command.Call_forest.cons_tree tree []) ;
+          let () =
+            match result with
+            | Ok tree ->
+                Transfers_memory.add t.transfers_memory key
+                  (Ok (Zkapp_command.Call_forest.cons_tree tree []))
+            | Error e ->
+                Transfers_memory.add t.transfers_memory key
+                  (Error (Exn.to_string e))
+          in
           return () )
 
     let enqueue_prove_transfer_claim t ~key ~(claim : Transfer.claim) =
       Throttle.enqueue t.q (fun () ->
-          let%bind _, forest =
-            match claim with
-            | { transfer = { direction = Deposit; transfer }
-              ; is_new
-              ; pointer
-              ; before
-              ; after
-              } ->
-                M.Inner.process_deposit ~is_new ~pointer ~before ~after
-                  ~deposit:transfer
-            | { transfer = { direction = Withdraw; transfer }
-              ; is_new
-              ; pointer
-              ; before
-              ; after
-              } ->
-                M.Outer.process_withdrawal ~outer_public_key:t.config.zkapp_pk
-                  ~is_new ~pointer ~before ~after ~withdrawal:transfer
+          let%bind result =
+            try_with (fun () ->
+                match claim with
+                | { transfer = { direction = Deposit; transfer }
+                  ; is_new
+                  ; pointer
+                  ; before
+                  ; after
+                  } ->
+                    M.Inner.process_deposit ~is_new ~pointer ~before ~after
+                      ~deposit:transfer
+                | { transfer = { direction = Withdraw; transfer }
+                  ; is_new
+                  ; pointer
+                  ; before
+                  ; after
+                  } ->
+                    M.Outer.process_withdrawal
+                      ~outer_public_key:t.config.zkapp_pk ~is_new ~pointer
+                      ~before ~after ~withdrawal:transfer )
           in
-          Transfers_memory.add t.transfers_memory key forest ;
+          let () =
+            match result with
+            | Ok (_, forest) ->
+                Transfers_memory.add t.transfers_memory key (Ok forest)
+            | Error e ->
+                Transfers_memory.add t.transfers_memory key
+                  (Error (Exn.to_string e))
+          in
           return () )
 
     let enqueue_prove_commit t ~target_ledger ~old_deposits_pointer

--- a/src/app/zeko/sequencer/tests/testing_ledger/gql.ml
+++ b/src/app/zeko/sequencer/tests/testing_ledger/gql.ml
@@ -1836,7 +1836,7 @@ module Queries = struct
 
   module Archive = struct
     let actions =
-      field "actions"
+      io_field "actions"
         ~typ:(non_null @@ list @@ non_null Types.Archive.ActionOutput.t)
         ~args:
           Arg.
@@ -1848,9 +1848,10 @@ module Queries = struct
                       (public_key, token_id, from_action_state, end_action_state)
                       ->
           let token_id = Option.value ~default:Token_id.default token_id in
-          Archive.get_actions t.archive
-            (Account_id.create public_key token_id)
-            ~from:from_action_state ~to_:end_action_state )
+          return
+          @@ Archive.get_actions t.archive
+               (Account_id.create public_key token_id)
+               ~from:from_action_state ~to_:end_action_state )
 
     let events =
       field "events"


### PR DESCRIPTION
Fixes few issues:
1. The graphql schema type naming.
2. The archive gql should error out on incorrect filter.
3. The sequencer was crashing on invalid input for transfers proving.
4. The archive query for actions is inclusive from both sides (`fromActionState` and `endActionState`). The `actionState` pointer however is always the state after applying of the action. So if you have actions _x_, _y_, _z_, and states `X := hash(init, x)`, `Y := hash(X, y)`, `Z := hash(Y, z)`, the filter from _Y_ to _Z_ returns both _y_, _z_.