### PR TITLE
Time of transactions

### DIFF
--- a/src/app/archive/lib/diff.ml
+++ b/src/app/archive/lib/diff.ml
@@ -143,7 +143,7 @@ module Builder = struct
   let zeko_transaction_added
       ~(constraint_constants : Genesis_constants.Constraint_constants.t)
       ~accounts_created ~new_state_hash ~protocol_state ~ledger ~txn
-      ~dummy_fee_payer =
+      ~dummy_fee_payer ~timestamp =
     let advance_protocol_state ~protocol_state ~new_state_hash
         ~increase_blockchain_length =
       let old_protocol_state = protocol_state in
@@ -164,6 +164,7 @@ module Builder = struct
                   ( Or_error.ok_exn
                   @@ Pending_coinbase.create
                        ~depth:constraint_constants.pending_coinbase_depth () ))
+          ; timestamp
           } )
       in
       let consensus_state =

--- a/src/app/zeko/da_layer/lib/client.ml
+++ b/src/app/zeko/da_layer/lib/client.ml
@@ -36,11 +36,11 @@ module Rpc = struct
     go max_tries []
 
   let post_diff ~logger ~node_location ~ledger_openings ~diff =
-    dispatch ~logger node_location Rpc.Post_diff.v1 { ledger_openings; diff }
+    dispatch ~logger node_location Rpc.Post_diff.v2 { ledger_openings; diff }
 
   let get_diff ~logger ~node_location ~ledger_hash :
       (Diff.t option, Error.t) result Deferred.t =
-    dispatch ~max_tries:1 ~logger node_location Rpc.Get_diff.v1 ledger_hash
+    dispatch ~max_tries:1 ~logger node_location Rpc.Get_diff.v2 ledger_hash
 
   let get_all_keys ~logger ~node_location () =
     dispatch ~max_tries:1 ~logger node_location Rpc.Get_all_keys.v1 ()
@@ -182,7 +182,7 @@ let get_diff ~logger ~config ~ledger_hash =
           return (Error e) )
 
 (** Distribute diff of initial accounts *)
-let distribute_genesis_diff ~logger ~config ~ledger =
+let distribute_genesis_diff ~logger ~config ~ledger ~timestamp =
   let%bind account_ids =
     Ledger.accounts ledger |> Deferred.map ~f:Account_id.Set.to_list
   in
@@ -201,7 +201,7 @@ let distribute_genesis_diff ~logger ~config ~ledger =
   let diff =
     Diff.create
       ~source_ledger_hash:(Diff.empty_ledger_hash ~depth:(Ledger.depth ledger))
-      ~changed_accounts ~command_with_action_step_flags:None
+      ~changed_accounts ~command_with_action_step_flags:None ~timestamp
   in
   distribute_diff ~logger ~config ~ledger_openings ~diff ~quorum:0
 

--- a/src/app/zeko/da_layer/lib/diff.ml
+++ b/src/app/zeko/da_layer/lib/diff.ml
@@ -4,22 +4,6 @@ open Mina_ledger
 
 [%%versioned
 module Stable = struct
-  module V2 = struct
-    type t =
-      { source_ledger_hash : Ledger_hash.Stable.V1.t
-            (** Source ledger hash of the diff *)
-      ; changed_accounts : (int * Account.Stable.V2.t) list
-            (** List of changed accounts with corresponding index in the ledger *)
-      ; command_with_action_step_flags :
-          (User_command.Stable.V2.t * bool list) option
-            (** Optionally add command with corresponding action steps to store the history *)
-      ; timestamp : Block_time.Stable.V1.t
-      }
-    [@@deriving yojson, fields, sexp_of]
-
-    let to_latest = Fn.id
-  end
-
   module V1 = struct
     type t =
       { source_ledger_hash : Ledger_hash.Stable.V1.t
@@ -32,23 +16,13 @@ module Stable = struct
       }
     [@@deriving yojson, fields, sexp_of]
 
-    let to_latest t =
-      V2.
-        { source_ledger_hash = t.source_ledger_hash
-        ; changed_accounts = t.changed_accounts
-        ; command_with_action_step_flags = t.command_with_action_step_flags
-        ; timestamp = Block_time.zero
-        }
+    let to_latest = Fn.id
   end
 end]
 
 let create ~source_ledger_hash ~changed_accounts ~command_with_action_step_flags
-    ~timestamp =
-  { source_ledger_hash
-  ; changed_accounts
-  ; command_with_action_step_flags
-  ; timestamp
-  }
+    =
+  { source_ledger_hash; changed_accounts; command_with_action_step_flags }
 
 let to_bigstring = Binable.to_bigstring (module Stable.Latest)
 
@@ -57,3 +31,18 @@ let of_bigstring = Binable.of_bigstring (module Stable.Latest)
 (** [Ledger_hash.empty_hash] is [zero], so we need this for the genesis state of the rollup *)
 let empty_ledger_hash ~depth =
   Ledger.merkle_root @@ Ledger.create_ephemeral ~depth ()
+
+module With_timestamp = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = Stable.V1.t * Block_time.Stable.V1.t [@@deriving yojson, sexp_of]
+
+      let to_latest = Fn.id
+    end
+  end]
+
+  let to_bigstring = Binable.to_bigstring (module Stable.Latest)
+
+  let of_bigstring = Binable.of_bigstring (module Stable.Latest)
+end

--- a/src/app/zeko/da_layer/lib/diff.ml
+++ b/src/app/zeko/da_layer/lib/diff.ml
@@ -4,6 +4,22 @@ open Mina_ledger
 
 [%%versioned
 module Stable = struct
+  module V2 = struct
+    type t =
+      { source_ledger_hash : Ledger_hash.Stable.V1.t
+            (** Source ledger hash of the diff *)
+      ; changed_accounts : (int * Account.Stable.V2.t) list
+            (** List of changed accounts with corresponding index in the ledger *)
+      ; command_with_action_step_flags :
+          (User_command.Stable.V2.t * bool list) option
+            (** Optionally add command with corresponding action steps to store the history *)
+      ; timestamp : Block_time.Stable.V1.t
+      }
+    [@@deriving yojson, fields, sexp_of]
+
+    let to_latest = Fn.id
+  end
+
   module V1 = struct
     type t =
       { source_ledger_hash : Ledger_hash.Stable.V1.t
@@ -16,13 +32,23 @@ module Stable = struct
       }
     [@@deriving yojson, fields, sexp_of]
 
-    let to_latest = Fn.id
+    let to_latest t =
+      V2.
+        { source_ledger_hash = t.source_ledger_hash
+        ; changed_accounts = t.changed_accounts
+        ; command_with_action_step_flags = t.command_with_action_step_flags
+        ; timestamp = Block_time.zero
+        }
   end
 end]
 
 let create ~source_ledger_hash ~changed_accounts ~command_with_action_step_flags
-    =
-  { source_ledger_hash; changed_accounts; command_with_action_step_flags }
+    ~timestamp =
+  { source_ledger_hash
+  ; changed_accounts
+  ; command_with_action_step_flags
+  ; timestamp
+  }
 
 let to_bigstring = Binable.to_bigstring (module Stable.Latest)
 

--- a/src/app/zeko/da_layer/lib/node.ml
+++ b/src/app/zeko/da_layer/lib/node.ml
@@ -321,7 +321,7 @@ let get_signature t ~ledger_hash =
 let implementations t =
   Async.Rpc.Implementations.create_exn ~on_unknown_rpc:`Raise
     ~implementations:
-      [ Async.Rpc.Rpc.implement Rpc.Post_diff.v1
+      [ Async.Rpc.Rpc.implement Rpc.Post_diff.v2
           (fun () { ledger_openings; diff } ->
             match post_diff t ~ledger_openings ~diff with
             | Ok signature ->
@@ -331,7 +331,7 @@ let implementations t =
                 [%log warn] "Error posting diff: $error"
                   ~metadata:[ ("error", `String (Error.to_string_hum e)) ] ;
                 failwith (Error.to_string_hum e) )
-      ; Async.Rpc.Rpc.implement Rpc.Get_diff.v1 (fun () query ->
+      ; Async.Rpc.Rpc.implement Rpc.Get_diff.v2 (fun () query ->
             Async.return @@ Db.get_diff t.db ~ledger_hash:query )
       ; Async.Rpc.Rpc.implement Rpc.Get_all_keys.v1 (fun () () ->
             Async.return @@ Db.get_index t.db )

--- a/src/app/zeko/da_layer/lib/node.ml
+++ b/src/app/zeko/da_layer/lib/node.ml
@@ -22,7 +22,7 @@ module Db = struct
 
   module Key_value = struct
     type _ t =
-      | Diff : (Ledger_hash.t * Diff.t) t
+      | Diff : (Ledger_hash.t * Diff.With_timestamp.t) t
       | Diff_index : (unit * Index.t) t
 
     let serialize_key : type k v. (k * v) t -> k -> Bigstring.t =
@@ -40,7 +40,7 @@ module Db = struct
      fun pair_type value ->
       match pair_type with
       | Diff ->
-          Diff.to_bigstring value
+          Diff.With_timestamp.to_bigstring value
       | Diff_index ->
           Index.to_bigstring value
 
@@ -48,7 +48,7 @@ module Db = struct
      fun pair_type data ->
       match pair_type with
       | Diff ->
-          Diff.of_bigstring data
+          Diff.With_timestamp.of_bigstring data
       | Diff_index ->
           Index.of_bigstring data
   end
@@ -78,7 +78,8 @@ type t = { db : Db.t; signer : Keypair.t; logger : Logger.t }
     4. Set each account in [diff.diff] to the [ledger_openings] and call the resulting ledger hash [target_ledger_hash].
     5. Sign [target_ledger_hash].
     6. Check that after applying all the receipts of the command, the receipt chain hashes match the target ledger.
-    7. Store the diff under the [target_ledger_hash]. *)
+    7. Attach timestamp.
+    8. Store the diff under the [target_ledger_hash]. *)
 let post_diff t ~ledger_openings ~diff =
   let logger = t.logger in
   (* 1 *)
@@ -248,6 +249,11 @@ let post_diff t ~ledger_openings ~diff =
   in
 
   (* 7 *)
+  let diff =
+    (diff, Block_time.now (Block_time.Controller.basic ~logger:t.logger))
+  in
+
+  (* 8 *)
   (* We don't care if the diff already existed *)
   let () =
     match Db.add_diff t.db ~ledger_hash:target_ledger_hash ~diff with
@@ -321,7 +327,7 @@ let get_signature t ~ledger_hash =
 let implementations t =
   Async.Rpc.Implementations.create_exn ~on_unknown_rpc:`Raise
     ~implementations:
-      [ Async.Rpc.Rpc.implement Rpc.Post_diff.v2
+      [ Async.Rpc.Rpc.implement Rpc.Post_diff.v1
           (fun () { ledger_openings; diff } ->
             match post_diff t ~ledger_openings ~diff with
             | Ok signature ->
@@ -336,7 +342,7 @@ let implementations t =
       ; Async.Rpc.Rpc.implement Rpc.Get_all_keys.v1 (fun () () ->
             Async.return @@ Db.get_index t.db )
       ; Async.Rpc.Rpc.implement Rpc.Get_diff_source.v1 (fun () query ->
-            Async.return @@ Diff.source_ledger_hash
+            Async.return @@ Diff.source_ledger_hash @@ fst
             @@ Option.value_exn
                  ~error:
                    ( Error.of_string

--- a/src/app/zeko/da_layer/lib/rpc.ml
+++ b/src/app/zeko/da_layer/lib/rpc.ml
@@ -9,10 +9,10 @@ module Post_diff = struct
   module Query = struct
     [%%versioned
     module Stable = struct
-      module V1 = struct
+      module V2 = struct
         type t =
           { ledger_openings : Sparse_ledger.Stable.V2.t
-          ; diff : Diff.Stable.V1.t
+          ; diff : Diff.Stable.V2.t
           }
 
         let to_latest = Fn.id
@@ -20,8 +20,8 @@ module Post_diff = struct
     end]
   end
 
-  let v1 : (Query.t, Signature.t) Rpc.Rpc.t =
-    Rpc.Rpc.create ~name:"Post_diff" ~version:1 ~bin_query:Query.Stable.V1.bin_t
+  let v2 : (Query.t, Signature.t) Rpc.Rpc.t =
+    Rpc.Rpc.create ~name:"Post_diff" ~version:2 ~bin_query:Query.Stable.V2.bin_t
       ~bin_response:Signature.Stable.V1.bin_t
 end
 
@@ -30,18 +30,18 @@ module Get_diff = struct
   module Response = struct
     [%%versioned
     module Stable = struct
-      module V1 = struct
-        type t = Diff.Stable.V1.t option
+      module V2 = struct
+        type t = Diff.Stable.V2.t option
 
         let to_latest = Fn.id
       end
     end]
   end
 
-  let v1 : (Ledger_hash.t, Response.t) Rpc.Rpc.t =
-    Rpc.Rpc.create ~name:"Get_diff" ~version:1
+  let v2 : (Ledger_hash.t, Response.t) Rpc.Rpc.t =
+    Rpc.Rpc.create ~name:"Get_diff" ~version:2
       ~bin_query:Ledger_hash.Stable.V1.bin_t
-      ~bin_response:Response.Stable.V1.bin_t
+      ~bin_response:Response.Stable.V2.bin_t
 end
 
 (* val get_all_keys : unit -> Ledger_hash.t list *)

--- a/src/app/zeko/da_layer/lib/rpc.ml
+++ b/src/app/zeko/da_layer/lib/rpc.ml
@@ -9,10 +9,10 @@ module Post_diff = struct
   module Query = struct
     [%%versioned
     module Stable = struct
-      module V2 = struct
+      module V1 = struct
         type t =
           { ledger_openings : Sparse_ledger.Stable.V2.t
-          ; diff : Diff.Stable.V2.t
+          ; diff : Diff.Stable.V1.t
           }
 
         let to_latest = Fn.id
@@ -20,8 +20,8 @@ module Post_diff = struct
     end]
   end
 
-  let v2 : (Query.t, Signature.t) Rpc.Rpc.t =
-    Rpc.Rpc.create ~name:"Post_diff" ~version:2 ~bin_query:Query.Stable.V2.bin_t
+  let v1 : (Query.t, Signature.t) Rpc.Rpc.t =
+    Rpc.Rpc.create ~name:"Post_diff" ~version:1 ~bin_query:Query.Stable.V1.bin_t
       ~bin_response:Signature.Stable.V1.bin_t
 end
 
@@ -31,7 +31,7 @@ module Get_diff = struct
     [%%versioned
     module Stable = struct
       module V2 = struct
-        type t = Diff.Stable.V2.t option
+        type t = Diff.With_timestamp.Stable.V1.t option
 
         let to_latest = Fn.id
       end

--- a/src/app/zeko/sequencer/archive_relay/run.ml
+++ b/src/app/zeko/sequencer/archive_relay/run.ml
@@ -165,6 +165,7 @@ let sync_archive ~(state : State.t) ~hash =
                   ~protocol_state:!protocol_state ~ledger
                   ~txn:(Ledger.Transaction_applied.transaction txn_applied)
                   ~dummy_fee_payer:Zkapps_rollup.inner_public_key
+                  ~timestamp:(Da_layer.Diff.timestamp diff)
               in
               protocol_state := new_protocol_state ;
               if State.has_been_relayed state (Ledger.merkle_root ledger) then

--- a/src/app/zeko/sequencer/archive_relay/run.ml
+++ b/src/app/zeko/sequencer/archive_relay/run.ml
@@ -30,7 +30,7 @@ let time label (d : 'a Deferred.t) =
   return x
 
 module Cache = struct
-  type t = Da_layer.Diff.t Ledger_hash.Map.t
+  type t = Da_layer.Diff.With_timestamp.t Ledger_hash.Map.t
 
   let empty = Ledger_hash.Map.empty
 
@@ -134,7 +134,7 @@ let sync_archive ~(state : State.t) ~hash =
   let%bind diffs = Deferred.List.map chain ~f:(fetch_diff ~state) in
   Ledger.with_ledger ~depth:constraint_constants.ledger_depth ~f:(fun ledger ->
       let protocol_state = ref compile_time_genesis_state in
-      Deferred.List.iter diffs ~f:(fun diff ->
+      Deferred.List.iter diffs ~f:(fun (diff, diff_timestamp) ->
           match Da_layer.Diff.command_with_action_step_flags diff with
           | None ->
               (* Apply accounts diff *)
@@ -165,7 +165,7 @@ let sync_archive ~(state : State.t) ~hash =
                   ~protocol_state:!protocol_state ~ledger
                   ~txn:(Ledger.Transaction_applied.transaction txn_applied)
                   ~dummy_fee_payer:Zkapps_rollup.inner_public_key
-                  ~timestamp:(Da_layer.Diff.timestamp diff)
+                  ~timestamp:diff_timestamp
               in
               protocol_state := new_protocol_state ;
               if State.has_been_relayed state (Ledger.merkle_root ledger) then

--- a/src/app/zeko/sequencer/deploy.ml
+++ b/src/app/zeko/sequencer/deploy.ml
@@ -93,7 +93,6 @@ let run ~l1_uri ~sk ~initial_state ~da_nodes () =
       let config = Da_layer.Client.Config.{ nodes = da_nodes } in
       match%bind
         Da_layer.Client.distribute_genesis_diff ~logger ~config ~ledger
-          ~timestamp:(Block_time.now (Block_time.Controller.basic ~logger))
       with
       | Ok _ ->
           return ()

--- a/src/app/zeko/sequencer/deploy.ml
+++ b/src/app/zeko/sequencer/deploy.ml
@@ -93,6 +93,7 @@ let run ~l1_uri ~sk ~initial_state ~da_nodes () =
       let config = Da_layer.Client.Config.{ nodes = da_nodes } in
       match%bind
         Da_layer.Client.distribute_genesis_diff ~logger ~config ~ledger
+          ~timestamp:(Block_time.now (Block_time.Controller.basic ~logger))
       with
       | Ok _ ->
           return ()

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -603,6 +603,8 @@ module Make (T : Transaction_snark.S) (M : Zkapps_rollup.S) = struct
                      | Zkapp_command command ->
                          Zkapp_command.all_account_updates_list command
                          |> List.map ~f:(fun _ -> true) ) )
+              ~timestamp:
+                (Block_time.now (Block_time.Controller.basic ~logger:t.logger))
           in
           Da_layer.Client.Sequencer.enqueue_distribute_diff t.da_client
             ~ledger_openings:first_pass_ledger ~diff ~target_ledger_hash ;
@@ -1055,6 +1057,8 @@ let%test_module "Sequencer tests" =
             match%bind
               Da_layer.Client.distribute_genesis_diff ~logger ~config:da_config
                 ~ledger:ephemeral_ledger
+                ~timestamp:
+                  (Block_time.now (Block_time.Controller.basic ~logger))
             with
             | Ok _ ->
                 return ()

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -603,8 +603,6 @@ module Make (T : Transaction_snark.S) (M : Zkapps_rollup.S) = struct
                      | Zkapp_command command ->
                          Zkapp_command.all_account_updates_list command
                          |> List.map ~f:(fun _ -> true) ) )
-              ~timestamp:
-                (Block_time.now (Block_time.Controller.basic ~logger:t.logger))
           in
           Da_layer.Client.Sequencer.enqueue_distribute_diff t.da_client
             ~ledger_openings:first_pass_ledger ~diff ~target_ledger_hash ;
@@ -787,7 +785,7 @@ module Make (T : Transaction_snark.S) (M : Zkapps_rollup.S) = struct
         ~f:(fun ledger_hash ->
           let%bind diff : Da_layer.Diff.t Deferred.t =
             Da_layer.Client.get_diff ~logger ~config:da_config ~ledger_hash
-            |> Deferred.map ~f:(fun r -> Or_error.ok_exn r)
+            >>| Or_error.ok_exn >>| fst
           in
           assert (
             Ledger_hash.equal
@@ -1057,8 +1055,6 @@ let%test_module "Sequencer tests" =
             match%bind
               Da_layer.Client.distribute_genesis_diff ~logger ~config:da_config
                 ~ledger:ephemeral_ledger
-                ~timestamp:
-                  (Block_time.now (Block_time.Controller.basic ~logger))
             with
             | Ok _ ->
                 return ()


### PR DESCRIPTION
Adds time to the diff on da layer. Needed for analytics and metadata for explorer.
Upgrades the da node api to v2.

Order of upgrades:
1. da nodes
2. sequencer
3. archive relay