### PR TITLE
Merge upstream

### DIFF
--- a/src/app/zeko/circuits/compile_simple.ml
+++ b/src/app/zeko/circuits/compile_simple.ml
@@ -665,8 +665,8 @@ let compile (type out_t out_var first_input branches n_available_branches)
           ~max_proofs_verified:(module Pickles_types.Nat.N2)
           ~name:("compile_simple of " ^ name)
           ~constraint_constants:
-            Genesis_constants.Constraint_constants.(
-              to_snark_keys_header compiled)
+            (Genesis_constants.Constraint_constants.to_snark_keys_header
+               Genesis_constants.Compiled.constraint_constants )
       in
       let provers = transform_provers provers in
       let r :

--- a/src/app/zeko/circuits/rule_commit.ml
+++ b/src/app/zeko/circuits/rule_commit.ml
@@ -63,7 +63,7 @@ struct
       (PathElt)
       (struct
         let length =
-          Genesis_constants.Constraint_constants.compiled.ledger_depth
+          Genesis_constants.Compiled.constraint_constants.ledger_depth
       end)
 
   module Witness = struct

--- a/src/app/zeko/circuits/zeko_transaction_snark.ml
+++ b/src/app/zeko/circuits/zeko_transaction_snark.ml
@@ -5,7 +5,7 @@ module PC = Signature_lib.Public_key.Compressed
 open Zeko_util
 open Checked.Let_syntax
 
-let constraint_constants = Genesis_constants.Constraint_constants.compiled
+let constraint_constants = Genesis_constants.Compiled.constraint_constants
 
 module Stack_frame = struct
   include Mina_base.Stack_frame.Digest
@@ -158,7 +158,7 @@ end
 
 let dummy_pc_init = Pending_coinbase.Stack.empty
 
-let genesis_constants = Genesis_constants.compiled
+let genesis_constants = Genesis_constants.Compiled.genesis_constants
 
 let consensus_constants =
   Consensus.Constants.create ~constraint_constants

--- a/src/app/zeko/da_layer/lib/client.ml
+++ b/src/app/zeko/da_layer/lib/client.ml
@@ -4,6 +4,9 @@ open Mina_base
 open Mina_ledger
 module Field = Snark_params.Tick.Field
 
+(* FIXME: Don't use Mina_compile_config.For_tests.t *)
+let compile_config = Mina_compile_config.For_unit_tests.t
+
 module Rpc = struct
   let dispatch ?(max_tries = 5) ?(timeout = 5.) ~logger
       (node_location : Host_and_port.t Cli_lib.Flag.Types.with_name) rpc data =
@@ -22,7 +25,10 @@ module Rpc = struct
                 , ("daemon-argument", node_location.name) )
                 [%sexp_of: (string * Host_and_port.t) * (string * string)] ) )
       else
-        match%bind Daemon_rpcs.Client.dispatch rpc data node_location.value with
+        match%bind
+          Daemon_rpcs.Client.dispatch ~compile_config rpc data
+            node_location.value
+        with
         | Ok result ->
             return (Ok result)
         | Error e ->

--- a/src/app/zeko/da_layer/lib/node.ml
+++ b/src/app/zeko/da_layer/lib/node.ml
@@ -3,7 +3,7 @@ open Mina_base
 open Mina_ledger
 open Signature_lib
 
-let constraint_constants = Genesis_constants.Constraint_constants.compiled
+let constraint_constants = Genesis_constants.Compiled.constraint_constants
 
 type t = { db : Db.t; signer : Keypair.t; logger : Logger.t }
 

--- a/src/app/zeko/sequencer/archive_relay/run.ml
+++ b/src/app/zeko/sequencer/archive_relay/run.ml
@@ -4,7 +4,7 @@ open Mina_base
 open Mina_lib
 open Mina_ledger
 
-let constraint_constants = Genesis_constants.Constraint_constants.compiled
+let constraint_constants = Genesis_constants.Compiled.constraint_constants
 
 let rec rmrf path =
   match Sys.is_directory path with
@@ -16,7 +16,7 @@ let rec rmrf path =
       Sys.remove path
 
 let compile_time_genesis_state =
-  let genesis_constants = Genesis_constants.compiled in
+  let genesis_constants = Genesis_constants.Compiled.genesis_constants in
   let consensus_constants =
     Consensus.Constants.create ~constraint_constants
       ~protocol_constants:genesis_constants.protocol
@@ -115,10 +115,13 @@ let sync_archive ~(state : State.t) ~hash =
                 Archive_lib.Diff.Builder.zeko_transaction_added
                   ~constraint_constants
                   ~accounts_created:
-                    (Ledger.Transaction_applied.new_accounts txn_applied)
+                    (Mina_transaction_logic.Transaction_applied.new_accounts
+                       txn_applied )
                   ~new_state_hash:(Ledger.merkle_root ledger)
                   ~protocol_state:!protocol_state ~ledger
-                  ~txn:(Ledger.Transaction_applied.transaction txn_applied)
+                  ~txn:
+                    (Mina_transaction_logic.Transaction_applied
+                     .transaction_with_status txn_applied )
                   ~dummy_fee_payer:Zkapps_rollup.inner_public_key
                   ~timestamp:(Da_layer.Diff.Stable.Latest.timestamp diff)
               in
@@ -126,9 +129,11 @@ let sync_archive ~(state : State.t) ~hash =
               if State.has_been_relayed state (Ledger.merkle_root ledger) then
                 return ()
               else
+                (* FIXME: Don't use Mina_compile_config.For_tests.t *)
+                let compile_config = Mina_compile_config.For_unit_tests.t in
                 match%bind
-                  Archive_client.dispatch ~logger state.archive_uri
-                    (Archive_lib.Diff.Transition_frontier diff)
+                  Archive_client.dispatch ~compile_config ~logger
+                    state.archive_uri (Archive_lib.Diff.Transition_frontier diff)
                 with
                 | Ok () ->
                     State.add_hash state (Ledger.merkle_root ledger) ;

--- a/src/app/zeko/sequencer/deploy.ml
+++ b/src/app/zeko/sequencer/deploy.ml
@@ -4,7 +4,7 @@ open Async
 open Mina_ledger
 module L = Ledger
 
-let constraint_constants = Genesis_constants.Constraint_constants.compiled
+let constraint_constants = Genesis_constants.Compiled.constraint_constants
 
 module Test_accounts = struct
   type t = { pk : string; balance : int64 } [@@deriving yojson]

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -264,18 +264,19 @@ module Types = struct
         }
 
       let of_full_account
-          { Account.Poly.public_key
-          ; token_id
-          ; token_symbol
-          ; nonce
-          ; balance
-          ; receipt_chain_hash
-          ; delegate
-          ; voting_for
-          ; timing
-          ; permissions
-          ; zkapp
-          } =
+          ({ public_key
+           ; token_id
+           ; token_symbol
+           ; nonce
+           ; balance
+           ; receipt_chain_hash
+           ; delegate
+           ; voting_for
+           ; timing
+           ; permissions
+           ; zkapp
+           } :
+            Account.value ) =
         { Account.Poly.public_key
         ; token_id
         ; token_symbol = Some token_symbol
@@ -651,7 +652,8 @@ module Types = struct
                  ~resolve:(fun _ { account; _ } ->
                    let open Option.Let_syntax in
                    let%map account = Partial_account.to_full_account account in
-                   Ledger_hash.of_digest (Account.digest account) )
+                   Ledger_hash.of_digest
+                     (Account.of_poly account |> Account.digest) )
              ; field "merklePath"
                  ~doc:
                    "Merkle path is a list of path elements that are either the \

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -8,7 +8,7 @@ open Signature_lib
 module L = Ledger
 module Field = Snark_params.Tick.Field
 
-let constraint_constants = Genesis_constants.Constraint_constants.compiled
+let constraint_constants = Genesis_constants.Compiled.constraint_constants
 
 module Sequencer = struct
   let constraint_constants = constraint_constants
@@ -41,7 +41,7 @@ module Sequencer = struct
       }
   end
 
-  let genesis_constants = Genesis_constants.compiled
+  let genesis_constants = Genesis_constants.Compiled.genesis_constants
 
   let compile_time_genesis_state =
     let consensus_constants =
@@ -467,7 +467,10 @@ module Sequencer = struct
       let%bind.Result txn_applied =
         L.apply_transaction_second_pass l partialy_applied_txn
       in
-      match L.Transaction_applied.transaction_status txn_applied with
+      match
+        Mina_transaction_logic.Transaction_applied.transaction_status
+          txn_applied
+      with
       | Failed failure ->
           Error
             ( Error.of_string @@ Yojson.Safe.to_string
@@ -651,7 +654,8 @@ module Sequencer = struct
                     ( Mina_transaction.Transaction.fee_excess (Command command)
                     |> Or_error.ok_exn )
                   ~supply_increase:
-                    ( L.Transaction_applied.supply_increase txn_applied
+                    ( Mina_transaction_logic.Transaction_applied.supply_increase
+                        ~constraint_constants txn_applied
                     |> Or_error.ok_exn )
                   ~pending_coinbase_stack_state:pc
               in
@@ -731,7 +735,10 @@ module Sequencer = struct
           apply_user_command t ~skip_validity_check:true (Zkapp_command command)
         with
         | Ok (status, witness) -> (
-            match L.Transaction_applied.transaction_status status with
+            match
+              Mina_transaction_logic.Transaction_applied.transaction_status
+                status
+            with
             | Applied ->
                 return witness
             | Failed failure ->
@@ -1192,7 +1199,8 @@ let%test_module "Sequencer tests" =
                            ~data:command_witness ;
 
                       let status =
-                        L.Transaction_applied.transaction_status txn_applied
+                        Mina_transaction_logic.Transaction_applied
+                        .transaction_status txn_applied
                       in
                       [%test_eq: Transaction_status.t] status Applied )
                 in
@@ -1291,7 +1299,8 @@ let%test_module "Sequencer tests" =
                          ~data:command_witness ;
 
                     let status =
-                      L.Transaction_applied.transaction_status txn_applied
+                      Mina_transaction_logic.Transaction_applied
+                      .transaction_status txn_applied
                     in
                     [%test_eq: Transaction_status.t] status Applied )
               in

--- a/src/app/zeko/sequencer/prover/lib/prover.ml
+++ b/src/app/zeko/sequencer/prover/lib/prover.ml
@@ -11,7 +11,7 @@ module Field = Data_hash.Make_full_size (struct
   let version_byte = '\x00'
 end)
 
-let constraint_constants = Genesis_constants.Constraint_constants.compiled
+let constraint_constants = Genesis_constants.Compiled.constraint_constants
 
 let time ~logger label (d : 'a Deferred.t) =
   [%log info] "Starting %s\n%!" label ;

--- a/src/app/zeko/sequencer/tests/testing_ledger/gql.ml
+++ b/src/app/zeko/sequencer/tests/testing_ledger/gql.ml
@@ -255,18 +255,19 @@ module Types = struct
         }
 
       let of_full_account
-          { Account.Poly.public_key
-          ; token_id
-          ; token_symbol
-          ; nonce
-          ; balance
-          ; receipt_chain_hash
-          ; delegate
-          ; voting_for
-          ; timing
-          ; permissions
-          ; zkapp
-          } =
+          ({ public_key
+           ; token_id
+           ; token_symbol
+           ; nonce
+           ; balance
+           ; receipt_chain_hash
+           ; delegate
+           ; voting_for
+           ; timing
+           ; permissions
+           ; zkapp
+           } :
+            Account.value ) =
         { Account.Poly.public_key
         ; token_id
         ; token_symbol = Some token_symbol
@@ -642,7 +643,8 @@ module Types = struct
                  ~resolve:(fun _ { account; _ } ->
                    let open Option.Let_syntax in
                    let%map account = Partial_account.to_full_account account in
-                   Ledger_hash.of_digest (Account.digest account) )
+                   Ledger_hash.of_digest
+                     (Account.of_poly account |> Account.digest) )
              ; field "merklePath"
                  ~doc:
                    "Merkle path is a list of path elements that are either the \

--- a/src/app/zeko/sequencer/tests/testing_ledger/state.ml
+++ b/src/app/zeko/sequencer/tests/testing_ledger/state.ml
@@ -10,9 +10,9 @@ module Ledger = Mina_ledger.Ledger
 let logger = Logger.create ()
 
 module Constants = struct
-  let constraint_constants = Genesis_constants.Constraint_constants.compiled
+  let constraint_constants = Genesis_constants.Compiled.constraint_constants
 
-  let genesis_constants = Genesis_constants.compiled
+  let genesis_constants = Genesis_constants.Compiled.genesis_constants
 
   let consensus_constants =
     Consensus.Constants.create ~constraint_constants
@@ -97,11 +97,14 @@ let apply_command t ~command =
     Transaction_hash.to_base58_check @@ Transaction_hash.hash_command command
   in
   Hashtbl.add_exn t.commands ~key:txn_hash
-    ~data:(command, Ledger.Transaction_applied.transaction_status txn_applied) ;
+    ~data:
+      ( command
+      , Mina_transaction_logic.Transaction_applied.transaction_status
+          txn_applied ) ;
 
   print_endline @@ "applied zkapp command: " ^ txn_hash ^ " "
   ^ Yojson.Safe.pretty_to_string @@ Transaction_status.to_yojson
-  @@ Ledger.Transaction_applied.transaction_status txn_applied ;
+  @@ Mina_transaction_logic.Transaction_applied.transaction_status txn_applied ;
 
   Ok ()
 

--- a/src/lib/mina_lib/archive_client.mli
+++ b/src/lib/mina_lib/archive_client.mli
@@ -4,6 +4,7 @@ open Pipe_lib
 val dispatch :
      ?max_tries:int
   -> logger:Logger.t
+  -> compile_config:Mina_compile_config.t
   -> Host_and_port.t Cli_lib.Flag.Types.with_name
   -> Archive_lib.Diff.t
   -> (unit, Error.t) result Async.Deferred.t


### PR DESCRIPTION
Changes relevant to us:

- Compiled genesis/constraint constants are now in Genesis_constants.Compiled.
- L.Transaction_applied -> Mina_transaction_logic.Transaction_applied
- Mina_compile_config exists and needed in some new places.
- Account.t/Account.value is now not an instantiation of Account.Poly.t but its own concrete type. The original still exists for some reason (perhaps to make it easier to derive the typ?) and conversions are needed in some places.