### PR TITLE
Add chunking to da sync

### DIFF
--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -198,6 +198,7 @@ let
             src/app/zeko/sequencer/cli.exe \
             src/app/zeko/sequencer/archive_relay/run.exe \
             src/app/zeko/sequencer/tests/testing_ledger/run.exe \
+            src/app/zeko/sequencer/prover/cli.exe \
             src/app/zeko/da_layer/cli.exe \
             src/app/logproc/logproc.exe \
             src/app/cli/src/mina.exe \
@@ -268,6 +269,7 @@ let
           cp src/app/zeko/sequencer/deploy.exe $zeko/bin/zeko-deploy
           cp src/app/zeko/sequencer/cli.exe $zeko/bin/zeko-cli
           cp src/app/zeko/sequencer/tests/testing_ledger/run.exe $localnet/bin/mina-localnet
+          cp src/app/zeko/sequencer/prover/cli.exe $zeko/bin/zeko-prover
           cp src/app/zeko/da_layer/cli.exe $zeko_da/bin/zeko-da
           cp src/app/zeko/sequencer/archive_relay/run.exe $zeko_archive_relay/bin/zeko-archive-relay
           cp -R _doc/_html $out/share/doc/html

--- a/src/app/zeko/da_layer/cli.ml
+++ b/src/app/zeko/da_layer/cli.ml
@@ -1,6 +1,8 @@
 open Core
 open Async
 open Signature_lib
+open Mina_base
+open Mina_ledger
 
 let run_node =
   ( "run-node"
@@ -54,4 +56,59 @@ let run_node =
            ~metadata:[ ("port", `Int port) ] ;
          Async.never () ) )
 
-let () = Command.group ~summary:"DA layer CLI" [ run_node ] |> Command_unix.run
+let sync_node =
+  ( "sync-node"
+  , Command.async ~summary:"Sync node"
+      (let%map_open.Command synced_node =
+         flag "--synced-node" (required string)
+           ~doc:"string Node that is providing data"
+       and unsynced_node =
+         flag "--unsynced-node" (required string)
+           ~doc:"string Node that needs to be synced"
+       and hash_to_sync =
+         flag "--hash-to-sync" (required string)
+           ~doc:"string Hash to sync with in decimal string form"
+       in
+       fun () ->
+         let logger = Logger.create () in
+         [%log info] "Fetching intervals" ;
+         let ledger =
+           Ledger.create_ephemeral
+             ~depth:Da_layer.Node.constraint_constants.ledger_depth ()
+         in
+         let synced_node =
+           Cli_lib.Flag.Types.
+             { value = Host_and_port.of_string synced_node
+             ; name = sprintf "synced_node"
+             }
+         in
+         let unsynced_node =
+           Cli_lib.Flag.Types.
+             { value = Host_and_port.of_string unsynced_node
+             ; name = sprintf "unsynced_node"
+             }
+         in
+         Da_layer.Client.map_diffs ~logger
+           ~depth:Da_layer.Node.constraint_constants.ledger_depth
+           ~config:(Da_layer.Client.Config.of_node_locations [ synced_node ])
+           ~source_ledger_hash:`Genesis
+           ~target_ledger_hash:(Ledger_hash.of_decimal_string hash_to_sync)
+           ~f:(fun progress diff ->
+             Zeko_util.progress_bar progress ;
+             let diff = Da_layer.Diff.drop_time diff in
+             let ledger_openings = Da_layer.Client.get_openings ~diff ~ledger in
+             match%bind
+               Da_layer.Client.Rpc.post_diff ~logger
+                 ~node_location:unsynced_node ~diff ~ledger_openings
+             with
+             | Ok _signature ->
+                 return ()
+             | Error e ->
+                 [%log warn] "Error posting diff: $error"
+                   ~metadata:[ ("error", `String (Error.to_string_hum e)) ] ;
+                 Error.raise e )
+         >>| Or_error.ok_exn >>| ignore ) )
+
+let () =
+  Command.group ~summary:"DA layer CLI" [ run_node; sync_node ]
+  |> Command_unix.run

--- a/src/app/zeko/da_layer/cli.ml
+++ b/src/app/zeko/da_layer/cli.ml
@@ -3,11 +3,14 @@ open Async
 open Signature_lib
 open Mina_base
 open Mina_ledger
+open Cli_lib
 
 let run_node =
   ( "run-node"
   , Command.async ~summary:"Run da layer node"
-      (let%map_open.Command db_dir =
+      (let%map_open.Command log_json = Flag.Log.json
+       and log_level = Flag.Log.level
+       and db_dir =
          flag "--db-dir"
            (optional_with_default "da_db" string)
            ~doc:"string Directory to store the database"
@@ -33,6 +36,7 @@ let run_node =
            else Sys.getenv_exn "MINA_PRIVATE_KEY"
          in
          let logger = Logger.create () in
+         Stdout_log.setup log_json log_level ;
          let sync_arg =
            match (node_to_sync, hash_to_sync) with
            | Some node_to_sync, Some hash_to_sync ->

--- a/src/app/zeko/da_layer/cli.ml
+++ b/src/app/zeko/da_layer/cli.ml
@@ -97,8 +97,11 @@ let sync_node =
            ~config:(Da_layer.Client.Config.of_node_locations [ synced_node ])
            ~source_ledger_hash:`Genesis
            ~target_ledger_hash:(Ledger_hash.of_decimal_string hash_to_sync)
-           ~print_progress:true
-           ~f:(fun diff ->
+           ~f:(fun ~current_chunk ~chunks_length diff ->
+             let progress =
+               Float.of_int current_chunk /. Float.of_int chunks_length
+             in
+             Zeko_util.progress_bar progress ;
              let diff = Da_layer.Diff.drop_time diff in
              let ledger_openings = Da_layer.Client.get_openings ~diff ~ledger in
              match%bind

--- a/src/app/zeko/da_layer/cli.ml
+++ b/src/app/zeko/da_layer/cli.ml
@@ -83,13 +83,13 @@ let sync_node =
          let synced_node =
            Cli_lib.Flag.Types.
              { value = Host_and_port.of_string synced_node
-             ; name = sprintf "synced_node"
+             ; name = "synced_node"
              }
          in
          let unsynced_node =
            Cli_lib.Flag.Types.
              { value = Host_and_port.of_string unsynced_node
-             ; name = sprintf "unsynced_node"
+             ; name = "unsynced_node"
              }
          in
          Da_layer.Client.map_diffs ~logger

--- a/src/app/zeko/da_layer/cli.ml
+++ b/src/app/zeko/da_layer/cli.ml
@@ -93,8 +93,8 @@ let sync_node =
            ~config:(Da_layer.Client.Config.of_node_locations [ synced_node ])
            ~source_ledger_hash:`Genesis
            ~target_ledger_hash:(Ledger_hash.of_decimal_string hash_to_sync)
-           ~f:(fun progress diff ->
-             Zeko_util.progress_bar progress ;
+           ~print_progress:true
+           ~f:(fun diff ->
              let diff = Da_layer.Diff.drop_time diff in
              let ledger_openings = Da_layer.Client.get_openings ~diff ~ledger in
              match%bind

--- a/src/app/zeko/da_layer/lib/client.ml
+++ b/src/app/zeko/da_layer/lib/client.ml
@@ -75,13 +75,14 @@ module Rpc = struct
     dispatch ~max_tries:1 ~logger node_location Rpc.Get_signature.V1.t
       ledger_hash
 
-  let get_ledger_hashes_chain ~logger ~node_location ~source ~target =
+  let get_ledger_hashes_chain ~logger ~node_location ?max_length ~source ~target
+      () =
     dispatch ~max_tries:1 ~logger node_location Rpc.Get_ledger_hashes_chain.V1.t
-      { source; target }
+      { source; target; max_length }
 
-  let get_diffs_chain ~logger ~node_location ~source ~target =
+  let get_diffs_chain ~logger ~node_location ?max_length ~source ~target () =
     dispatch ~max_tries:1 ~logger node_location Rpc.Get_diffs_chain.V1.t
-      { source; target }
+      { source; target; max_length }
 end
 
 module Config = struct
@@ -99,6 +100,8 @@ module Config = struct
               ; name = sprintf "da-node-%d" i
               } )
     }
+
+  let of_node_locations nodes = { nodes }
 
   let throw_out_node t ~(node : Host_and_port.t Cli_lib.Flag.Types.with_name) =
     let open Cli_lib.Flag.Types in
@@ -191,17 +194,61 @@ let try_all_nodes ~config ~f =
   try_first ~accum_errors:[] (Config.nodes config)
 
 (** Get the chain of ledger hashes from [source_ledger_hash] hash to [target_ledger_hash] *)
-let get_ledger_hashes_chain ~logger ~config ~source_ledger_hash
-    ~target_ledger_hash =
+let get_ledger_hashes_chain ~logger ~config ?max_length ~source_ledger_hash
+    ~target_ledger_hash () =
   try_all_nodes ~config ~f:(fun ~node_location () ->
-      Rpc.get_ledger_hashes_chain ~logger ~node_location
-        ~source:source_ledger_hash ~target:target_ledger_hash )
+      Rpc.get_ledger_hashes_chain ~logger ~node_location ?max_length
+        ~source:source_ledger_hash ~target:target_ledger_hash () )
 
 (** Get the chain of diffs from [source_ledger_hash] hash to [target_ledger_hash] *)
-let get_diffs_chain ~logger ~config ~source_ledger_hash ~target_ledger_hash =
+let get_diffs_chain ~logger ~config ?max_length ~source_ledger_hash
+    ~target_ledger_hash () =
   try_all_nodes ~config ~f:(fun ~node_location () ->
-      Rpc.get_diffs_chain ~logger ~node_location ~source:source_ledger_hash
-        ~target:target_ledger_hash )
+      Rpc.get_diffs_chain ~logger ~node_location ?max_length
+        ~source:source_ledger_hash ~target:target_ledger_hash () )
+
+(** Lazily fetch chunks of diffs, used to minimize memory usage *)
+let get_lazy_diffs_chunks ~logger ~depth ~config ?(n = 100) ~source_ledger_hash
+    ~target_ledger_hash () =
+  let source_ledger_hash =
+    match source_ledger_hash with
+    | `Genesis ->
+        Diff.empty_ledger_hash ~depth
+    | `Specific h ->
+        h
+  in
+  (* Get ledger hashes intervals of size [n] *)
+  let rec get_intervals ~target_ledger_hash =
+    let%bind.Deferred.Result chain =
+      get_ledger_hashes_chain ~logger ~config ~max_length:n
+        ~source_ledger_hash:(`Specific source_ledger_hash) ~target_ledger_hash
+        ()
+    in
+    match chain with
+    | [] ->
+        return (Ok [])
+    | [ last ] ->
+        let interval = (source_ledger_hash, last) in
+        return (Ok [ interval ])
+    | chain ->
+        let hd = List.hd_exn chain in
+        let tl = List.last_exn chain in
+        let interval = (hd, tl) in
+        let%bind.Deferred.Result next_intervals =
+          get_intervals ~target_ledger_hash:hd
+        in
+        return (Ok (interval :: next_intervals))
+  in
+  let%bind.Deferred.Result intervals =
+    get_intervals ~target_ledger_hash >>| Result.map ~f:List.rev
+  in
+  return
+  @@ Ok
+       (List.map intervals ~f:(fun (source, target) ->
+            lazy
+              (get_diffs_chain ~logger ~config
+                 ~source_ledger_hash:(`Specific source)
+                 ~target_ledger_hash:target () ) ) )
 
 (** Try to get the diff from the first node in the list, if it fails, try the next one *)
 let get_diff ~logger ~config ~ledger_hash =
@@ -238,8 +285,7 @@ let distribute_genesis_diff ~logger ~config ~ledger =
   in
   distribute_diff ~logger ~config ~ledger_openings ~diff ~quorum:0
 
-let attach_openings ~diffs ~depth =
-  let l = Ledger.create_ephemeral ~depth () in
+let attach_openings ~diffs ~ledger =
   List.map diffs ~f:(fun diff ->
       let changed_accounts =
         Diff.changed_accounts diff
@@ -248,9 +294,9 @@ let attach_openings ~diffs ~depth =
       let account_ids =
         List.map changed_accounts ~f:snd |> List.map ~f:Account.identifier
       in
-      let openings = Sparse_ledger.of_ledger_subset_exn l account_ids in
+      let openings = Sparse_ledger.of_ledger_subset_exn ledger account_ids in
       List.iter changed_accounts ~f:(fun (index, account) ->
-          Ledger.set_at_index_exn l index account ) ;
+          Ledger.set_at_index_exn ledger index account ) ;
       (diff, openings) )
 
 let sync_nodes ~logger ~config ~depth ~target_ledger_hash =
@@ -259,11 +305,13 @@ let sync_nodes ~logger ~config ~depth ~target_ledger_hash =
       (* TODO: don't fetch all the diffs from genesis, using binary search determine which diffs is the node missing *)
       (let%bind.Deferred.Result diffs =
          get_diffs_chain ~logger ~config ~source_ledger_hash:`Genesis
-           ~target_ledger_hash
+           ~target_ledger_hash ()
        in
        return
-         (Ok (attach_openings ~diffs:(List.map diffs ~f:Diff.drop_time) ~depth))
-      )
+         (Ok
+            (attach_openings
+               ~diffs:(List.map diffs ~f:Diff.drop_time)
+               ~ledger:(Ledger.create_ephemeral ~depth ()) ) ) )
   in
   Deferred.List.map config.nodes ~f:(fun node ->
       match%bind

--- a/src/app/zeko/da_layer/lib/client.ml
+++ b/src/app/zeko/da_layer/lib/client.ml
@@ -250,6 +250,19 @@ let get_lazy_diffs_chunks ~logger ~depth ~config ?(n = 100) ~source_ledger_hash
                  ~source_ledger_hash:(`Specific source)
                  ~target_ledger_hash:target () ) ) )
 
+let map_diffs ~logger ~depth ~config ~source_ledger_hash ~target_ledger_hash ~f
+    =
+  let%bind.Deferred.Result lazy_chunks =
+    get_lazy_diffs_chunks ~logger ~depth ~config ~source_ledger_hash
+      ~target_ledger_hash ()
+  in
+  let l = List.length lazy_chunks in
+  Deferred.List.mapi ~how:`Sequential lazy_chunks ~f:(fun i lazy_chunk ->
+      let progress = Float.of_int i /. Float.of_int l in
+      let%bind.Deferred.Result diffs = Lazy.force lazy_chunk in
+      Deferred.List.map ~how:`Sequential diffs ~f:(f progress) >>| Result.return )
+  >>| Result.all >>| Result.map ~f:List.join
+
 (** Try to get the diff from the first node in the list, if it fails, try the next one *)
 let get_diff ~logger ~config ~ledger_hash =
   try_all_nodes ~config ~f:(fun ~node_location () ->
@@ -285,19 +298,21 @@ let distribute_genesis_diff ~logger ~config ~ledger =
   in
   distribute_diff ~logger ~config ~ledger_openings ~diff ~quorum:0
 
+let get_openings ~diff ~ledger =
+  let changed_accounts =
+    Diff.changed_accounts diff
+    |> List.sort ~compare:(fun (a, _) (b, _) -> Int.compare a b)
+  in
+  let account_ids =
+    List.map changed_accounts ~f:snd |> List.map ~f:Account.identifier
+  in
+  let openings = Sparse_ledger.of_ledger_subset_exn ledger account_ids in
+  List.iter changed_accounts ~f:(fun (index, account) ->
+      Ledger.set_at_index_exn ledger index account ) ;
+  openings
+
 let attach_openings ~diffs ~ledger =
-  List.map diffs ~f:(fun diff ->
-      let changed_accounts =
-        Diff.changed_accounts diff
-        |> List.sort ~compare:(fun (a, _) (b, _) -> Int.compare a b)
-      in
-      let account_ids =
-        List.map changed_accounts ~f:snd |> List.map ~f:Account.identifier
-      in
-      let openings = Sparse_ledger.of_ledger_subset_exn ledger account_ids in
-      List.iter changed_accounts ~f:(fun (index, account) ->
-          Ledger.set_at_index_exn ledger index account ) ;
-      (diff, openings) )
+  List.map diffs ~f:(fun diff -> (diff, get_openings ~diff ~ledger))
 
 let sync_nodes ~logger ~config ~depth ~target_ledger_hash =
   let diffs_with_openings =

--- a/src/app/zeko/da_layer/lib/client.ml
+++ b/src/app/zeko/da_layer/lib/client.ml
@@ -314,46 +314,12 @@ let get_openings ~diff ~ledger =
 let attach_openings ~diffs ~ledger =
   List.map diffs ~f:(fun diff -> (diff, get_openings ~diff ~ledger))
 
-let sync_nodes ~logger ~config ~depth ~target_ledger_hash =
-  let diffs_with_openings =
-    lazy
-      (* TODO: don't fetch all the diffs from genesis, using binary search determine which diffs is the node missing *)
-      (let%bind.Deferred.Result diffs =
-         get_diffs_chain ~logger ~config ~source_ledger_hash:`Genesis
-           ~target_ledger_hash ()
-       in
-       return
-         (Ok
-            (attach_openings
-               ~diffs:(List.map diffs ~f:Diff.drop_time)
-               ~ledger:(Ledger.create_ephemeral ~depth ()) ) ) )
-  in
-  Deferred.List.map config.nodes ~f:(fun node ->
+let check_synced_nodes ~logger ~(config : Config.t) ~target_ledger_hash =
+  Deferred.List.iter config.nodes ~f:(fun node ->
       match%bind
         Rpc.get_diff ~logger ~node_location:node ~ledger_hash:target_ledger_hash
       with
       | Ok (Some _) ->
-          printf "Node %s is already synced\n%!"
-            (Host_and_port.to_string node.value) ;
-          return (Ok ())
-      | Ok None | Error _ -> (
-          printf "Syncing node %s\n%!" (Host_and_port.to_string node.value) ;
-          let%bind.Deferred.Result diffs_with_openings =
-            Lazy.force diffs_with_openings
-          in
-          match%bind
-            Deferred.List.map diffs_with_openings ~f:(fun (diff, openings) ->
-                Rpc.post_diff ~logger ~node_location:node
-                  ~ledger_openings:openings ~diff
-                >>| Result.ignore_m )
-            >>| Result.all_unit
-          with
-          | Ok () ->
-              return (Ok ())
-          | Error e ->
-              printf "Error syncing node %s: %s\n%!"
-                (Host_and_port.to_string node.value)
-                (Error.to_string_hum e) ;
-              Config.throw_out_node config ~node ;
-              return (Ok ()) ) )
-  >>| Result.all_unit
+          return ( (* synced node *) )
+      | Ok None | Error _ ->
+          return (Config.throw_out_node config ~node) )

--- a/src/app/zeko/da_layer/lib/client.ml
+++ b/src/app/zeko/da_layer/lib/client.ml
@@ -250,18 +250,18 @@ let get_lazy_diffs_chunks ~logger ~depth ~config ?(n = 100) ~source_ledger_hash
                  ~source_ledger_hash:(`Specific source)
                  ~target_ledger_hash:target () ) ) )
 
-let map_diffs ~logger ~depth ~config ~source_ledger_hash ~target_ledger_hash
-    ~print_progress ~f =
+let map_diffs ~logger ~depth ~config ~source_ledger_hash ~target_ledger_hash ~f
+    =
   let%bind.Deferred.Result lazy_chunks =
     get_lazy_diffs_chunks ~logger ~depth ~config ~source_ledger_hash
       ~target_ledger_hash ()
   in
   let l = List.length lazy_chunks in
   Deferred.List.mapi ~how:`Sequential lazy_chunks ~f:(fun i lazy_chunk ->
-      let progress = Float.of_int i /. Float.of_int l in
-      if print_progress then Zeko_util.progress_bar progress ;
       let%bind.Deferred.Result diffs = Lazy.force lazy_chunk in
-      Deferred.List.map ~how:`Sequential diffs ~f >>| Result.return )
+      Deferred.List.map ~how:`Sequential diffs ~f:(fun diff ->
+          f ~current_chunk:i ~chunks_length:l diff )
+      >>| Result.return )
   >>| Result.all >>| Result.map ~f:List.join
 
 (** Try to get the diff from the first node in the list, if it fails, try the next one *)

--- a/src/app/zeko/da_layer/lib/client.ml
+++ b/src/app/zeko/da_layer/lib/client.ml
@@ -250,8 +250,8 @@ let get_lazy_diffs_chunks ~logger ~depth ~config ?(n = 100) ~source_ledger_hash
                  ~source_ledger_hash:(`Specific source)
                  ~target_ledger_hash:target () ) ) )
 
-let map_diffs ~logger ~depth ~config ~source_ledger_hash ~target_ledger_hash ~f
-    =
+let map_diffs ~logger ~depth ~config ~source_ledger_hash ~target_ledger_hash
+    ~print_progress ~f =
   let%bind.Deferred.Result lazy_chunks =
     get_lazy_diffs_chunks ~logger ~depth ~config ~source_ledger_hash
       ~target_ledger_hash ()
@@ -259,8 +259,9 @@ let map_diffs ~logger ~depth ~config ~source_ledger_hash ~target_ledger_hash ~f
   let l = List.length lazy_chunks in
   Deferred.List.mapi ~how:`Sequential lazy_chunks ~f:(fun i lazy_chunk ->
       let progress = Float.of_int i /. Float.of_int l in
+      if print_progress then Zeko_util.progress_bar progress ;
       let%bind.Deferred.Result diffs = Lazy.force lazy_chunk in
-      Deferred.List.map ~how:`Sequential diffs ~f:(f progress) >>| Result.return )
+      Deferred.List.map ~how:`Sequential diffs ~f >>| Result.return )
   >>| Result.all >>| Result.map ~f:List.join
 
 (** Try to get the diff from the first node in the list, if it fails, try the next one *)
@@ -322,4 +323,7 @@ let check_synced_nodes ~logger ~(config : Config.t) ~target_ledger_hash =
       | Ok (Some _) ->
           return ( (* synced node *) )
       | Ok None | Error _ ->
+          printf
+            !"Node %s is not synced\n%!"
+            (Host_and_port.to_string node.value) ;
           return (Config.throw_out_node config ~node) )

--- a/src/app/zeko/da_layer/lib/db.ml
+++ b/src/app/zeko/da_layer/lib/db.ml
@@ -76,3 +76,18 @@ let get_diff t ~ledger_hash = get t Diff ~key:ledger_hash
 let get_migration t = get t Migration ~key:() |> Option.value ~default:0
 
 let set_migration t ~migration = set t Migration ~key:() ~data:migration
+
+module Async = struct
+  let set_index t ~index = Async.return (set_index t ~index)
+
+  let get_index t = Async.return (get_index t)
+
+  let add_diff t ~ledger_hash ~diff =
+    Async.return (add_diff t ~ledger_hash ~diff)
+
+  let get_diff t ~ledger_hash = Async.return (get_diff t ~ledger_hash)
+
+  let get_migration t = Async.return (get_migration t)
+
+  let set_migration t ~migration = Async.return (set_migration t ~migration)
+end

--- a/src/app/zeko/da_layer/lib/migrations.ml
+++ b/src/app/zeko/da_layer/lib/migrations.ml
@@ -2,14 +2,6 @@ open Core_kernel
 
 type migration = Db.t -> unit
 
-let progress_bar ?(width = 30) progress =
-  let filled_length = int_of_float (float_of_int width *. progress) in
-  let bar =
-    String.make filled_length '#' ^ String.make (width - filled_length) '-'
-  in
-  Printf.printf "\r[%s] %.0f%%%!" bar (progress *. 100.0) ;
-  if Float.(progress >= 1.0) then Printf.printf "\n%!"
-
 let add_version_tag db =
   let try_read buff =
     try
@@ -20,7 +12,7 @@ let add_version_tag db =
   let all = Db.to_alist db in
   let l = List.length all in
   List.iteri all ~f:(fun i (key, value) ->
-      progress_bar (Float.of_int i /. Float.of_int l) ;
+      Zeko_util.progress_bar (Float.of_int i /. Float.of_int l) ;
       match try_read value with
       | Error _ ->
           ( (* The pair is something different from diff *) )

--- a/src/app/zeko/da_layer/lib/node.ml
+++ b/src/app/zeko/da_layer/lib/node.ml
@@ -218,8 +218,8 @@ let sync t ~node_location ~ledger_hash =
   Client.map_diffs ~logger ~depth:constraint_constants.ledger_depth
     ~config:(Client.Config.of_node_locations [ node_location ])
     ~source_ledger_hash:`Genesis ~target_ledger_hash:ledger_hash
-    ~f:(fun progress diff ->
-      Zeko_util.progress_bar progress ;
+    ~print_progress:true
+    ~f:(fun diff ->
       let diff = Diff.drop_time diff in
       let ledger_openings = Client.get_openings ~diff ~ledger in
       match post_diff t ~diff ~ledger_openings with

--- a/src/app/zeko/da_layer/lib/node.ml
+++ b/src/app/zeko/da_layer/lib/node.ml
@@ -210,25 +210,33 @@ let post_diff t ~ledger_openings ~diff =
 let sync t ~node_location ~ledger_hash =
   let logger = t.logger in
   let open Async in
-  let%bind.Deferred.Result diffs =
-    Client.Rpc.get_diffs_chain ~logger ~node_location ~source:`Genesis
-      ~target:ledger_hash
-  in
-  let diffs =
-    Client.attach_openings
-      ~diffs:(List.map diffs ~f:Diff.drop_time)
+  let%bind.Deferred.Result lazy_chunks =
+    Client.get_lazy_diffs_chunks ~logger
       ~depth:constraint_constants.ledger_depth
+      ~config:(Client.Config.of_node_locations [ node_location ])
+      ~source_ledger_hash:`Genesis ~target_ledger_hash:ledger_hash ()
   in
-  List.map diffs ~f:(fun (diff, ledger_openings) ->
-      match post_diff t ~diff ~ledger_openings with
-      | Ok _signature ->
-          Ok ()
-      | Error e ->
-          let logger = t.logger in
-          [%log warn] "Error posting diff: $error"
-            ~metadata:[ ("error", `String (Error.to_string_hum e)) ] ;
-          Error e )
-  |> Result.all_unit |> return
+  let ledger =
+    Ledger.create_ephemeral ~depth:constraint_constants.ledger_depth ()
+  in
+  let l = List.length lazy_chunks in
+  Deferred.List.mapi ~how:`Sequential lazy_chunks ~f:(fun i lazy_chunk ->
+      Zeko_util.progress_bar (Float.of_int i /. Float.of_int l) ;
+      let%bind.Deferred.Result diffs = Lazy.force lazy_chunk in
+      let diffs =
+        Client.attach_openings ~diffs:(List.map diffs ~f:Diff.drop_time) ~ledger
+      in
+      List.map diffs ~f:(fun (diff, ledger_openings) ->
+          match post_diff t ~diff ~ledger_openings with
+          | Ok _signature ->
+              Ok ()
+          | Error e ->
+              let logger = t.logger in
+              [%log warn] "Error posting diff: $error"
+                ~metadata:[ ("error", `String (Error.to_string_hum e)) ] ;
+              Error e )
+      |> Result.all_unit |> return )
+  >>| Result.all_unit
 
 let get_signature t ~ledger_hash =
   let%bind.Option _diff = Db.get_diff t.db ~ledger_hash in
@@ -236,7 +244,11 @@ let get_signature t ~ledger_hash =
   Some (Schnorr.Chunked.sign t.signer.private_key message)
 
 let get_ledger_hashes_chain t
-    ({ source = source_opt; target } : Rpc.Get_ledger_hashes_chain.V1.Query.t) =
+    ({ source = source_opt; target; max_length = max_length_opt } :
+      Rpc.Get_ledger_hashes_chain.V1.Query.t ) =
+  let max_length =
+    match max_length_opt with Some n -> n | None -> Int.max_value
+  in
   let source =
     match source_opt with
     | `Genesis ->
@@ -244,8 +256,8 @@ let get_ledger_hashes_chain t
     | `Specific source ->
         source
   in
-  let rec go current =
-    if Ledger_hash.equal current source then []
+  let rec go n current =
+    if Ledger_hash.equal current source || n <= 0 then []
     else
       let source =
         Db.get_diff ~ledger_hash:current t.db
@@ -253,25 +265,9 @@ let get_ledger_hashes_chain t
              ~message:"Get_ledger_hashes_chain: diff not found"
         |> Diff.Stable.V2.source_ledger_hash
       in
-      current :: go source
+      current :: go (n - 1) source
   in
-  let chain = List.rev (go target) in
-  match (source_opt, chain) with
-  | _, [] ->
-      failwithf
-        "Get_ledger_hashes_chain: no diffs found for source ledger hash %s and \
-         target ledger hash %s"
-        (Ledger_hash.to_decimal_string source)
-        (Ledger_hash.to_decimal_string target)
-        ()
-  | `Specific wanted_source, first_source :: _
-    when not (Ledger_hash.equal wanted_source first_source) ->
-      failwithf
-        "Get_ledger_hashes_chain: source ledger hash %s is not in the chain"
-        (Ledger_hash.to_decimal_string source)
-        ()
-  | _ ->
-      chain
+  List.rev (go max_length target)
 
 let implementations t =
   Async.Rpc.Implementations.create_exn ~on_unknown_rpc:`Raise
@@ -319,8 +315,10 @@ let implementations t =
           (fun () query -> Async.return @@ get_ledger_hashes_chain t query)
       ; (* Get_diffs_chain *)
         Async.Rpc.Rpc.implement Rpc.Get_diffs_chain.V1.t
-          (fun () { source; target } ->
-            let chain = get_ledger_hashes_chain t { source; target } in
+          (fun () { source; target; max_length } ->
+            let chain =
+              get_ledger_hashes_chain t { source; target; max_length }
+            in
             Async.return
             @@ List.map chain ~f:(fun ledger_hash ->
                    Db.get_diff ~ledger_hash t.db

--- a/src/app/zeko/da_layer/lib/node.ml
+++ b/src/app/zeko/da_layer/lib/node.ml
@@ -210,33 +210,28 @@ let post_diff t ~ledger_openings ~diff =
 let sync t ~node_location ~ledger_hash =
   let logger = t.logger in
   let open Async in
-  let%bind.Deferred.Result lazy_chunks =
-    Client.get_lazy_diffs_chunks ~logger
-      ~depth:constraint_constants.ledger_depth
-      ~config:(Client.Config.of_node_locations [ node_location ])
-      ~source_ledger_hash:`Genesis ~target_ledger_hash:ledger_hash ()
-  in
+  [%log info] "Syncing" ;
+  [%log info] "Fetching intervals" ;
   let ledger =
     Ledger.create_ephemeral ~depth:constraint_constants.ledger_depth ()
   in
-  let l = List.length lazy_chunks in
-  Deferred.List.mapi ~how:`Sequential lazy_chunks ~f:(fun i lazy_chunk ->
-      Zeko_util.progress_bar (Float.of_int i /. Float.of_int l) ;
-      let%bind.Deferred.Result diffs = Lazy.force lazy_chunk in
-      let diffs =
-        Client.attach_openings ~diffs:(List.map diffs ~f:Diff.drop_time) ~ledger
-      in
-      List.map diffs ~f:(fun (diff, ledger_openings) ->
-          match post_diff t ~diff ~ledger_openings with
-          | Ok _signature ->
-              Ok ()
-          | Error e ->
-              let logger = t.logger in
-              [%log warn] "Error posting diff: $error"
-                ~metadata:[ ("error", `String (Error.to_string_hum e)) ] ;
-              Error e )
-      |> Result.all_unit |> return )
-  >>| Result.all_unit
+  Client.map_diffs ~logger ~depth:constraint_constants.ledger_depth
+    ~config:(Client.Config.of_node_locations [ node_location ])
+    ~source_ledger_hash:`Genesis ~target_ledger_hash:ledger_hash
+    ~f:(fun progress diff ->
+      Zeko_util.progress_bar progress ;
+      let diff = Diff.drop_time diff in
+      let ledger_openings = Client.get_openings ~diff ~ledger in
+      match post_diff t ~diff ~ledger_openings with
+      | Ok _signature ->
+          return (Ok ())
+      | Error e ->
+          let logger = t.logger in
+          [%log warn] "Error posting diff: $error"
+            ~metadata:[ ("error", `String (Error.to_string_hum e)) ] ;
+          return (Error e) )
+  >>| Result.map ~f:(fun asd -> Result.all_unit asd)
+  >>| Result.join
 
 let get_signature t ~ledger_hash =
   let%bind.Option _diff = Db.get_diff t.db ~ledger_hash in

--- a/src/app/zeko/da_layer/lib/node.ml
+++ b/src/app/zeko/da_layer/lib/node.ml
@@ -218,8 +218,9 @@ let sync t ~node_location ~ledger_hash =
   Client.map_diffs ~logger ~depth:constraint_constants.ledger_depth
     ~config:(Client.Config.of_node_locations [ node_location ])
     ~source_ledger_hash:`Genesis ~target_ledger_hash:ledger_hash
-    ~print_progress:true
-    ~f:(fun diff ->
+    ~f:(fun ~current_chunk ~chunks_length diff ->
+      let progress = Float.of_int current_chunk /. Float.of_int chunks_length in
+      Zeko_util.progress_bar progress ;
       let diff = Diff.drop_time diff in
       let ledger_openings = Client.get_openings ~diff ~ledger in
       match post_diff t ~diff ~ledger_openings with

--- a/src/app/zeko/da_layer/lib/node.ml
+++ b/src/app/zeko/da_layer/lib/node.ml
@@ -2,6 +2,8 @@ open Core_kernel
 open Mina_base
 open Mina_ledger
 open Signature_lib
+module Rpc_def = Rpc
+open Async
 
 let constraint_constants = Genesis_constants.Constraint_constants.compiled
 
@@ -209,7 +211,6 @@ let post_diff t ~ledger_openings ~diff =
 
 let sync t ~node_location ~ledger_hash =
   let logger = t.logger in
-  let open Async in
   [%log info] "Syncing" ;
   [%log info] "Fetching intervals" ;
   let ledger =
@@ -241,7 +242,7 @@ let get_signature t ~ledger_hash =
 
 let get_ledger_hashes_chain t
     ({ source = source_opt; target; max_length = max_length_opt } :
-      Rpc.Get_ledger_hashes_chain.V1.Query.t ) =
+      Rpc_def.Get_ledger_hashes_chain.V1.Query.t ) =
   let max_length =
     match max_length_opt with Some n -> n | None -> Int.max_value
   in
@@ -253,76 +254,79 @@ let get_ledger_hashes_chain t
         source
   in
   let rec go n current =
-    if Ledger_hash.equal current source || n <= 0 then []
+    if Ledger_hash.equal current source || n <= 0 then return []
     else
-      let source =
-        Db.get_diff ~ledger_hash:current t.db
-        |> Option.value_exn ~here:[%here]
-             ~message:"Get_ledger_hashes_chain: diff not found"
+      let%bind source =
+        Db.Async.get_diff ~ledger_hash:current t.db
+        >>| fun diff ->
+        Option.value_exn ~here:[%here]
+          ~message:"Get_ledger_hashes_chain: diff not found" diff
         |> Diff.Stable.V2.source_ledger_hash
       in
-      current :: go (n - 1) source
+      let%map next = go (n - 1) source in
+      current :: next
   in
-  List.rev (go max_length target)
+  go max_length target >>| List.rev
 
 let implementations t =
-  Async.Rpc.Implementations.create_exn ~on_unknown_rpc:`Raise
+  Rpc.Implementations.create_exn ~on_unknown_rpc:`Raise
     ~implementations:
       [ (* Post_diff *)
-        Async.Rpc.Rpc.implement Rpc.Post_diff.V1.t
+        Rpc.Rpc.implement Rpc_def.Post_diff.V1.t
           (fun () { ledger_openings; diff } ->
             match post_diff t ~ledger_openings ~diff with
             | Ok signature ->
-                Async.return signature
+                return signature
             | Error e ->
                 let logger = t.logger in
                 [%log warn] "Error posting diff: $error"
                   ~metadata:[ ("error", `String (Error.to_string_hum e)) ] ;
                 failwith (Error.to_string_hum e) )
       ; (* Get_diff *)
-        Async.Rpc.Rpc.implement Rpc.Get_diff.V1.t (fun () query ->
-            let v2_diff = Db.get_diff t.db ~ledger_hash:query in
+        Rpc.Rpc.implement Rpc_def.Get_diff.V1.t (fun () query ->
+            let%map v2_diff = Db.Async.get_diff t.db ~ledger_hash:query in
             let v1_diff = Option.map v2_diff ~f:Diff.drop_time in
-            Async.return @@ v1_diff )
-      ; Async.Rpc.Rpc.implement Rpc.Get_diff.V2.t (fun () query ->
-            Async.return @@ Db.get_diff t.db ~ledger_hash:query )
+            v1_diff )
+      ; Rpc.Rpc.implement Rpc_def.Get_diff.V2.t (fun () query ->
+            Db.Async.get_diff t.db ~ledger_hash:query )
       ; (* Get_all_keys *)
-        Async.Rpc.Rpc.implement Rpc.Get_all_keys.V1.t (fun () () ->
-            Async.return @@ Db.get_index t.db )
+        Rpc.Rpc.implement Rpc_def.Get_all_keys.V1.t (fun () () ->
+            Db.Async.get_index t.db )
       ; (* Get_diff_source *)
-        Async.Rpc.Rpc.implement Rpc.Get_diff_source.V1.t (fun () query ->
-            Async.return @@ Diff.Stable.Latest.source_ledger_hash
-            @@ Option.value_exn
-                 ~error:
-                   ( Error.of_string
-                   @@ sprintf
-                        "Get_diff_source exception: Diff not found for ledger \
-                         hash %s"
-                        (Ledger_hash.to_decimal_string query) )
-            @@ Db.get_diff t.db ~ledger_hash:query )
+        Rpc.Rpc.implement Rpc_def.Get_diff_source.V1.t (fun () query ->
+            Db.Async.get_diff t.db ~ledger_hash:query
+            >>| fun diff ->
+            Option.value_exn
+              ~error:
+                ( Error.of_string
+                @@ sprintf
+                     "Get_diff_source exception: Diff not found for ledger \
+                      hash %s"
+                     (Ledger_hash.to_decimal_string query) )
+              diff
+            |> Diff.Stable.Latest.source_ledger_hash )
       ; (* Get_signed_public_key *)
-        Async.Rpc.Rpc.implement Rpc.Get_signer_public_key.V1.t (fun () () ->
-            Async.return @@ Public_key.compress @@ t.signer.public_key )
+        Rpc.Rpc.implement Rpc_def.Get_signer_public_key.V1.t (fun () () ->
+            return @@ Public_key.compress @@ t.signer.public_key )
       ; (* Get_signature *)
-        Async.Rpc.Rpc.implement Rpc.Get_signature.V1.t (fun () query ->
-            Async.return @@ get_signature t ~ledger_hash:query )
+        Rpc.Rpc.implement Rpc_def.Get_signature.V1.t (fun () query ->
+            return @@ get_signature t ~ledger_hash:query )
       ; (* Get_ledger_hashes_chain *)
-        Async.Rpc.Rpc.implement Rpc.Get_ledger_hashes_chain.V1.t
-          (fun () query -> Async.return @@ get_ledger_hashes_chain t query)
+        Rpc.Rpc.implement Rpc_def.Get_ledger_hashes_chain.V1.t (fun () query ->
+            get_ledger_hashes_chain t query )
       ; (* Get_diffs_chain *)
-        Async.Rpc.Rpc.implement Rpc.Get_diffs_chain.V1.t
+        Rpc.Rpc.implement Rpc_def.Get_diffs_chain.V1.t
           (fun () { source; target; max_length } ->
-            let chain =
+            let%bind chain =
               get_ledger_hashes_chain t { source; target; max_length }
             in
-            Async.return
-            @@ List.map chain ~f:(fun ledger_hash ->
-                   Db.get_diff ~ledger_hash t.db
-                   |> Option.value_exn ~here:[%here] ~message:"Diff not found" ) )
+            Deferred.List.map ~how:`Parallel chain ~f:(fun ledger_hash ->
+                Db.Async.get_diff ~ledger_hash t.db
+                >>| fun diff ->
+                Option.value_exn ~here:[%here] ~message:"Diff not found" diff ) )
       ]
 
 let create_server ~sync_arg ~port ~logger ~db_dir ~signer_sk ~no_migrations () =
-  let open Async in
   let where_to_listen =
     Tcp.Where_to_listen.bind_to All_addresses (On_port port)
   in

--- a/src/app/zeko/da_layer/lib/rpc.ml
+++ b/src/app/zeko/da_layer/lib/rpc.ml
@@ -98,6 +98,7 @@ module Get_ledger_hashes_chain = struct
       type t =
         { source : [ `Genesis | `Specific of Ledger_hash.Stable.V1.t ]
         ; target : Ledger_hash.Stable.V1.t
+        ; max_length : int option
         }
       [@@deriving bin_io_unversioned]
     end
@@ -119,6 +120,7 @@ module Get_diffs_chain = struct
       type t =
         { source : [ `Genesis | `Specific of Ledger_hash.Stable.V1.t ]
         ; target : Ledger_hash.Stable.V1.t
+        ; max_length : int option
         }
       [@@deriving bin_io_unversioned]
     end

--- a/src/app/zeko/kvdb_base/kvdb_base.ml
+++ b/src/app/zeko/kvdb_base/kvdb_base.ml
@@ -27,3 +27,45 @@ struct
     get_raw t ~key:(Key_value.serialize_key pair_type key)
     |> Option.map ~f:(Key_value.deserialize_value pair_type)
 end
+
+module Make_singleton (Inputs : sig
+  type t
+
+  val to_yojson : t -> Yojson.Safe.t
+
+  val of_yojson : Yojson.Safe.t -> (t, string) result
+
+  val key : string
+end) =
+struct
+  module Key_value = struct
+    type _ t = Singleton : (unit * Inputs.t) t
+
+    let serialize_key : type k v. (k * v) t -> k -> Bigstring.t =
+     fun pair_type _ ->
+      match pair_type with Singleton -> Bigstring.of_string Inputs.key
+
+    let serialize_value : type k v. (k * v) t -> v -> Bigstring.t =
+     fun pair_type value ->
+      match pair_type with
+      | Singleton ->
+          Bigstring.of_string @@ Yojson.Safe.to_string @@ Inputs.to_yojson value
+
+    let deserialize_value : type k v. (k * v) t -> Bigstring.t -> v =
+      let ok_exn x =
+        let open Ppx_deriving_yojson_runtime.Result in
+        match x with Ok x -> x | Error e -> failwith e
+      in
+      fun pair_type data ->
+        match pair_type with
+        | Singleton ->
+            ok_exn @@ Inputs.of_yojson @@ Yojson.Safe.from_string
+            @@ Bigstring.to_string data
+  end
+
+  open Make (Key_value)
+
+  let set t = set t Singleton ~key:()
+
+  let get t = get t Singleton ~key:()
+end

--- a/src/app/zeko/parallel_merger/parallel_merger.ml
+++ b/src/app/zeko/parallel_merger/parallel_merger.ml
@@ -5,6 +5,8 @@ let generate_id () = Uuid_unix.create () |> Uuid.to_string
 
 module Make (Context : sig
   type t
+
+  val created_new_tree : t -> unit
 end) (Merge : sig
   type t [@@deriving yojson]
 
@@ -173,11 +175,13 @@ struct
 
   let create () = { trees = [] }
 
-  let start_new_tree t = t.trees <- t.trees @ [ Tree.create () ]
+  let start_new_tree t ctx =
+    Context.created_new_tree ctx ;
+    t.trees <- t.trees @ [ Tree.create () ]
 
   let commit_exn t ctx ~commit_witness =
     (* Create new tree before waiting, so new transactions go there *)
-    start_new_tree t ;
+    start_new_tree t ctx ;
     match List.rev t.trees with
     | _just_created :: last :: rest ->
         Tree.close last ;
@@ -193,7 +197,7 @@ struct
   let rec add_job t context ~(data : Base.t) =
     match List.last t.trees with
     | None ->
-        start_new_tree t ; add_job t context ~data
+        start_new_tree t context ; add_job t context ~data
     | Some last ->
         Tree.add_job_exn last context ~id:(generate_id ()) ~data
 
@@ -227,6 +231,8 @@ let%test_module "parallel_merge on (+)" =
       (* let pp () = printf !"%{sexp: int list}\n%!" (get ()) *)
 
       let add t x = t := !t @ [ x ]
+
+      let created_new_tree _ = ()
     end
 
     module Merge = struct

--- a/src/app/zeko/sequencer/.gitignore
+++ b/src/app/zeko/sequencer/.gitignore
@@ -1,3 +1,4 @@
 db/
 l1_db/
 da_db/
+ledger_cache/

--- a/src/app/zeko/sequencer/archive_relay/run.ml
+++ b/src/app/zeko/sequencer/archive_relay/run.ml
@@ -146,10 +146,15 @@ let sync_archive (t : t) ~hash =
           with
           | Ok () ->
               [%log info]
-                "Synced diff to archive with hash: %s, progress %.0f%%"
-                (Ledger_hash.to_decimal_string @@ Ledger.merkle_root ledger)
+                "Synced diff to archive with hash: $hash, progress %.0f%%"
                 ( Float.of_int current_chunk /. Float.of_int chunks_length
-                *. 100.0 ) ;
+                *. 100.0 )
+                ~metadata:
+                  [ ( "hash"
+                    , `String
+                        ( Ledger_hash.to_decimal_string
+                        @@ Ledger.merkle_root ledger ) )
+                  ] ;
               return ()
           | Error e ->
               raise (Error.to_exn e) ) )
@@ -212,8 +217,9 @@ let sync (t : t) () =
       let%bind ledger_hash =
         match%bind fetch_current_ledger_hash ~zeko_uri:t.zeko_uri () with
         | Ok hash ->
-            [%log info] "Fetched ledger hash: %s"
-              (Ledger_hash.to_decimal_string hash) ;
+            [%log info] "Fetched ledger hash: $hash"
+              ~metadata:
+                [ ("hash", `String (Ledger_hash.to_decimal_string hash)) ] ;
             return hash
         | Error e ->
             failwith e
@@ -230,7 +236,8 @@ let rec run (t : t) ~sync_period () =
             after (Time.Span.of_sec sync_period) )
     | Error e ->
         (* ledger_hash_invalidated *)
-        [%log error] "Error syncing: %s" (Error.to_string_hum e) ;
+        [%log error] "Error syncing: $error"
+          ~metadata:[ ("error", `String (Error.to_string_hum e)) ] ;
         [%log warn] "Invalidating ledger cache" ;
         reset_ledger_cache t ()
   in

--- a/src/app/zeko/sequencer/archive_relay/run.ml
+++ b/src/app/zeko/sequencer/archive_relay/run.ml
@@ -35,8 +35,7 @@ let time ~logger label (d : 'a Deferred.t) =
   let start = Time.now () in
   let%bind x = d in
   let stop = Time.now () in
-  [%log info] "%s: %s\n%!" label
-    (Time.Span.to_string_hum @@ Time.diff stop start) ;
+  [%log info] "%s: %s" label (Time.Span.to_string_hum @@ Time.diff stop start) ;
   return x
 
 module State = struct
@@ -102,8 +101,8 @@ let sync_archive (t : t) ~hash =
   Da_layer.Client.map_diffs ~logger ~config:t.da_config
     ~depth:constraint_constants.ledger_depth
     ~source_ledger_hash:(`Specific (Ledger.Db.merkle_root t.db))
-    ~target_ledger_hash:hash ~print_progress:true
-    ~f:(fun diff ->
+    ~target_ledger_hash:hash
+    ~f:(fun ~current_chunk ~chunks_length diff ->
       let ledger = Ledger.of_database t.db in
       match Da_layer.Diff.Stable.Latest.command_with_action_step_flags diff with
       | None ->
@@ -146,9 +145,12 @@ let sync_archive (t : t) ~hash =
               (Archive_lib.Diff.Transition_frontier diff)
           with
           | Ok () ->
-              return
-              @@ [%log info] "Synced diff to archive with hash: %s\n%!"
-                   (Ledger_hash.to_decimal_string @@ Ledger.merkle_root ledger)
+              [%log info]
+                "Synced diff to archive with hash: %s, progress %.0f%%"
+                (Ledger_hash.to_decimal_string @@ Ledger.merkle_root ledger)
+                ( Float.of_int current_chunk /. Float.of_int chunks_length
+                *. 100.0 ) ;
+              return ()
           | Error e ->
               raise (Error.to_exn e) ) )
   >>| Result.map ~f:ignore
@@ -210,7 +212,7 @@ let sync (t : t) () =
       let%bind ledger_hash =
         match%bind fetch_current_ledger_hash ~zeko_uri:t.zeko_uri () with
         | Ok hash ->
-            [%log info] "Fetched ledger hash: %s\n%!"
+            [%log info] "Fetched ledger hash: %s"
               (Ledger_hash.to_decimal_string hash) ;
             return hash
         | Error e ->
@@ -228,7 +230,7 @@ let rec run (t : t) ~sync_period () =
             after (Time.Span.of_sec sync_period) )
     | Error e ->
         (* ledger_hash_invalidated *)
-        [%log error] "Error syncing: %s\n%!" (Error.to_string_hum e) ;
+        [%log error] "Error syncing: %s" (Error.to_string_hum e) ;
         [%log warn] "Invalidating ledger cache" ;
         reset_ledger_cache t ()
   in
@@ -249,7 +251,7 @@ let () =
           flag "--archive-port" (required int) ~doc:"Archive node port"
         and sync_period =
           flag "--sync-period"
-            (optional_with_default 60. float)
+            (optional_with_default 30. float)
             ~doc:"Sync period"
         and ledger_cache =
           flag "--ledger-cache"

--- a/src/app/zeko/sequencer/archive_relay/run.ml
+++ b/src/app/zeko/sequencer/archive_relay/run.ml
@@ -83,9 +83,8 @@ let sync_archive ~(state : State.t) ~hash =
   Da_layer.Client.map_diffs ~logger ~config:state.da_config
     ~depth:constraint_constants.ledger_depth
     ~source_ledger_hash:(`Specific (Ledger.Db.merkle_root state.ledger_cache))
-    ~target_ledger_hash:hash
-    ~f:(fun progress diff ->
-      Zeko_util.progress_bar progress ;
+    ~target_ledger_hash:hash ~print_progress:true
+    ~f:(fun diff ->
       match Da_layer.Diff.Stable.Latest.command_with_action_step_flags diff with
       | None ->
           (* Apply accounts diff *)

--- a/src/app/zeko/sequencer/archive_relay/run.ml
+++ b/src/app/zeko/sequencer/archive_relay/run.ml
@@ -39,52 +39,71 @@ let time ~logger label (d : 'a Deferred.t) =
   return x
 
 module State = struct
-  type t =
-    { logger : Logger.t
-    ; archive_uri : Host_and_port.t Cli_lib.Flag.Types.with_name
-    ; zeko_uri : Uri.t
-    ; da_config : Da_layer.Client.Config.t
-    ; mutable ledger_cache : Ledger.Db.t
-    ; mutable already_relayed_hashes : Ledger_hash.Set.t
-    }
+  type _t = { mutable protocol_state : Mina_state.Protocol_state.value }
+  [@@deriving yojson]
 
-  let create ~logger ~archive_uri ~zeko_uri ~da_nodes ~ledger_cache =
-    { logger
-    ; archive_uri
-    ; zeko_uri
-    ; da_config = Da_layer.Client.Config.of_string_list da_nodes
-    ; ledger_cache =
-        Ledger.Db.create ~directory_name:ledger_cache
-          ~depth:constraint_constants.ledger_depth ()
-    ; already_relayed_hashes = Ledger_hash.Set.empty
-    }
+  type t = _t
 
-  let add_hash t hash =
-    t.already_relayed_hashes <- Set.add t.already_relayed_hashes hash
+  module Db = Kvdb_base.Make_singleton (struct
+    type t = _t [@@deriving yojson]
 
-  let has_been_relayed t hash = Set.mem t.already_relayed_hashes hash
+    let key = "archive_relay_state"
+  end)
 
-  let reset_ledger_cache t () =
-    let directory_name =
-      Option.value_exn ~message:"No ledger_cache directory"
-      @@ Ledger.Db.get_directory t.ledger_cache
-    in
-    Ledger.Db.close t.ledger_cache ;
-    rmrf directory_name ;
-    t.ledger_cache <-
-      Ledger.Db.create ~directory_name ~depth:constraint_constants.ledger_depth
-        ()
+  let save kvdb t = Db.set ~data:t kvdb
+
+  let load kvdb =
+    match Db.get kvdb with
+    | Some state ->
+        state
+    | None ->
+        { protocol_state = compile_time_genesis_state }
+
+  let set_protocol_state t kvdb protocol_state =
+    t.protocol_state <- protocol_state ;
+    save kvdb t
 end
 
-let sync_archive ~(state : State.t) ~hash =
-  let logger = state.logger in
-  let protocol_state = ref compile_time_genesis_state in
-  Da_layer.Client.map_diffs ~logger ~config:state.da_config
+type t =
+  { logger : Logger.t
+  ; archive_uri : Host_and_port.t Cli_lib.Flag.Types.with_name
+  ; zeko_uri : Uri.t
+  ; da_config : Da_layer.Client.Config.t
+  ; state : State.t
+  ; mutable db : Ledger.Db.t
+  }
+
+let create ~logger ~archive_uri ~zeko_uri ~da_nodes ~ledger_cache =
+  let db =
+    Ledger.Db.create ~directory_name:ledger_cache
+      ~depth:constraint_constants.ledger_depth ()
+  in
+  { logger
+  ; archive_uri
+  ; zeko_uri
+  ; da_config = Da_layer.Client.Config.of_string_list da_nodes
+  ; state = State.load (Ledger.Db.zeko_kvdb db)
+  ; db
+  }
+
+let reset_ledger_cache t () =
+  let directory_name =
+    Option.value_exn ~message:"No ledger_cache directory"
+    @@ Ledger.Db.get_directory t.db
+  in
+  Ledger.Db.close t.db ;
+  rmrf directory_name ;
+  t.db <-
+    Ledger.Db.create ~directory_name ~depth:constraint_constants.ledger_depth ()
+
+let sync_archive (t : t) ~hash =
+  let logger = t.logger in
+  Da_layer.Client.map_diffs ~logger ~config:t.da_config
     ~depth:constraint_constants.ledger_depth
-    ~source_ledger_hash:(`Specific (Ledger.Db.merkle_root state.ledger_cache))
+    ~source_ledger_hash:(`Specific (Ledger.Db.merkle_root t.db))
     ~target_ledger_hash:hash ~print_progress:true
     ~f:(fun diff ->
-      let ledger = Ledger.of_database state.ledger_cache in
+      let ledger = Ledger.of_database t.db in
       match Da_layer.Diff.Stable.Latest.command_with_action_step_flags diff with
       | None ->
           (* Apply accounts diff *)
@@ -114,26 +133,23 @@ let sync_archive ~(state : State.t) ~hash =
               ~accounts_created:
                 (Ledger.Transaction_applied.new_accounts txn_applied)
               ~new_state_hash:(Ledger.merkle_root ledger)
-              ~protocol_state:!protocol_state ~ledger
+              ~protocol_state:t.state.protocol_state ~ledger
               ~txn:(Ledger.Transaction_applied.transaction txn_applied)
               ~dummy_fee_payer:Zkapps_rollup.inner_public_key
               ~timestamp:(Da_layer.Diff.Stable.Latest.timestamp diff)
           in
-          protocol_state := new_protocol_state ;
-          if State.has_been_relayed state (Ledger.merkle_root ledger) then
-            return ()
-          else
-            match%bind
-              Archive_client.dispatch ~logger state.archive_uri
-                (Archive_lib.Diff.Transition_frontier diff)
-            with
-            | Ok () ->
-                State.add_hash state (Ledger.merkle_root ledger) ;
-                return
-                @@ [%log info] "Synced diff to archive with hash: %s\n%!"
-                     (Ledger_hash.to_decimal_string @@ Ledger.merkle_root ledger)
-            | Error e ->
-                raise (Error.to_exn e) ) )
+          State.set_protocol_state t.state (Ledger.Db.zeko_kvdb t.db)
+            new_protocol_state ;
+          match%bind
+            Archive_client.dispatch ~logger t.archive_uri
+              (Archive_lib.Diff.Transition_frontier diff)
+          with
+          | Ok () ->
+              return
+              @@ [%log info] "Synced diff to archive with hash: %s\n%!"
+                   (Ledger_hash.to_decimal_string @@ Ledger.merkle_root ledger)
+          | Error e ->
+              raise (Error.to_exn e) ) )
   >>| Result.map ~f:ignore
 
 let fetch_current_ledger_hash ~zeko_uri () =
@@ -187,11 +203,11 @@ let fetch_current_ledger_hash ~zeko_uri () =
       in
       return (Ok unproved_ledger_hash)
 
-let sync ~(state : State.t) () =
-  let logger = state.logger in
+let sync (t : t) () =
+  let logger = t.logger in
   Thread_safe.block_on_async_exn (fun () ->
       let%bind ledger_hash =
-        match%bind fetch_current_ledger_hash ~zeko_uri:state.zeko_uri () with
+        match%bind fetch_current_ledger_hash ~zeko_uri:t.zeko_uri () with
         | Ok hash ->
             [%log info] "Fetched ledger hash: %s\n%!"
               (Ledger_hash.to_decimal_string hash) ;
@@ -199,12 +215,12 @@ let sync ~(state : State.t) () =
         | Error e ->
             failwith e
       in
-      time ~logger "Synced" (sync_archive ~state ~hash:ledger_hash) )
+      time ~logger "Synced" (sync_archive t ~hash:ledger_hash) )
 
-let rec run ~(state : State.t) ~sync_period () =
-  let logger = state.logger in
+let rec run (t : t) ~sync_period () =
+  let logger = t.logger in
   let () =
-    match sync ~state () with
+    match sync t () with
     | Ok () ->
         (* wait *)
         Thread_safe.block_on_async_exn (fun () ->
@@ -213,10 +229,10 @@ let rec run ~(state : State.t) ~sync_period () =
         (* ledger_hash_invalidated *)
         [%log error] "Error syncing: %s\n%!" (Error.to_string_hum e) ;
         [%log warn] "Invalidating ledger cache" ;
-        State.reset_ledger_cache state ()
+        reset_ledger_cache t ()
   in
   (* go again *)
-  run ~state ~sync_period ()
+  run t ~sync_period ()
 
 let () =
   Command_unix.run
@@ -246,7 +262,5 @@ let () =
             }
         in
 
-        let state =
-          State.create ~logger ~archive_uri ~zeko_uri ~da_nodes ~ledger_cache
-        in
-        run ~state ~sync_period )
+        let t = create ~logger ~archive_uri ~zeko_uri ~da_nodes ~ledger_cache in
+        run t ~sync_period )

--- a/src/app/zeko/sequencer/archive_relay/run.ml
+++ b/src/app/zeko/sequencer/archive_relay/run.ml
@@ -78,13 +78,13 @@ end
 
 let sync_archive ~(state : State.t) ~hash =
   let logger = state.logger in
-  let ledger = Ledger.of_database state.ledger_cache in
   let protocol_state = ref compile_time_genesis_state in
   Da_layer.Client.map_diffs ~logger ~config:state.da_config
     ~depth:constraint_constants.ledger_depth
     ~source_ledger_hash:(`Specific (Ledger.Db.merkle_root state.ledger_cache))
     ~target_ledger_hash:hash ~print_progress:true
     ~f:(fun diff ->
+      let ledger = Ledger.of_database state.ledger_cache in
       match Da_layer.Diff.Stable.Latest.command_with_action_step_flags diff with
       | None ->
           (* Apply accounts diff *)

--- a/src/app/zeko/sequencer/archive_relay/run.ml
+++ b/src/app/zeko/sequencer/archive_relay/run.ml
@@ -3,6 +3,7 @@ open Core_kernel
 open Mina_base
 open Mina_lib
 open Mina_ledger
+open Cli_lib
 
 let constraint_constants = Genesis_constants.Constraint_constants.compiled
 
@@ -237,7 +238,9 @@ let rec run (t : t) ~sync_period () =
 let () =
   Command_unix.run
   @@ Command.basic ~summary:"Run archive adapter for zeko"
-       (let%map_open.Command zeko_uri =
+       (let%map_open.Command log_json = Flag.Log.json
+        and log_level = Flag.Log.level
+        and zeko_uri =
           flag "--zeko-uri" (required string) ~doc:"Zeko sequencer graphql uri"
         and da_nodes = flag "--da-node" (listed string) ~doc:"DA node uri"
         and archive_host =
@@ -254,6 +257,7 @@ let () =
             ~doc:"Ledger cache"
         in
         let logger = Logger.create () in
+        Stdout_log.setup log_json log_level ;
         let zeko_uri = Uri.of_string zeko_uri in
         let archive_uri =
           Cli_lib.Flag.Types.

--- a/src/app/zeko/sequencer/archive_relay/run.ml
+++ b/src/app/zeko/sequencer/archive_relay/run.ml
@@ -78,71 +78,64 @@ end
 
 let sync_archive ~(state : State.t) ~hash =
   let logger = state.logger in
-  let%bind.Deferred.Result lazy_chunks =
-    Da_layer.Client.get_lazy_diffs_chunks ~logger ~config:state.da_config
-      ~depth:constraint_constants.ledger_depth
-      ~source_ledger_hash:(`Specific (Ledger.Db.merkle_root state.ledger_cache))
-      ~target_ledger_hash:hash ()
-  in
   let ledger = Ledger.of_database state.ledger_cache in
   let protocol_state = ref compile_time_genesis_state in
-  Deferred.List.mapi ~how:`Sequential lazy_chunks ~f:(fun i lazy_chunk ->
-      let%bind.Deferred.Result diffs = Lazy.force lazy_chunk in
-      Deferred.List.iter ~how:`Sequential diffs ~f:(fun diff ->
-          match
-            Da_layer.Diff.Stable.Latest.command_with_action_step_flags diff
-          with
-          | None ->
-              (* Apply accounts diff *)
-              let changed_accounts =
-                Da_layer.Diff.Stable.Latest.changed_accounts diff
-              in
-              List.iter changed_accounts ~f:(fun (index, account) ->
-                  Ledger.set_at_index_exn ledger index account ) ;
-              Ledger.commit ledger ;
-              return ()
-          | Some (command, _) -> (
-              let txn_applied =
-                Or_error.ok_exn
-                @@ Result.( >>= )
-                     (Ledger.apply_transaction_first_pass ~constraint_constants
-                        ~global_slot:Mina_numbers.Global_slot_since_genesis.zero
-                        ~txn_state_view:
-                          Mina_state.Protocol_state.(
-                            Body.view @@ body compile_time_genesis_state)
-                        ledger (Command command) )
-                     (Ledger.apply_transaction_second_pass ledger)
-              in
-              Ledger.commit ledger ;
-              let new_protocol_state, diff =
-                Archive_lib.Diff.Builder.zeko_transaction_added
-                  ~constraint_constants
-                  ~accounts_created:
-                    (Ledger.Transaction_applied.new_accounts txn_applied)
-                  ~new_state_hash:(Ledger.merkle_root ledger)
-                  ~protocol_state:!protocol_state ~ledger
-                  ~txn:(Ledger.Transaction_applied.transaction txn_applied)
-                  ~dummy_fee_payer:Zkapps_rollup.inner_public_key
-                  ~timestamp:(Da_layer.Diff.Stable.Latest.timestamp diff)
-              in
-              protocol_state := new_protocol_state ;
-              if State.has_been_relayed state (Ledger.merkle_root ledger) then
-                return ()
-              else
-                match%bind
-                  Archive_client.dispatch ~logger state.archive_uri
-                    (Archive_lib.Diff.Transition_frontier diff)
-                with
-                | Ok () ->
-                    State.add_hash state (Ledger.merkle_root ledger) ;
-                    return
-                    @@ [%log info] "Synced diff to archive with hash: %s\n%!"
-                         ( Ledger_hash.to_decimal_string
-                         @@ Ledger.merkle_root ledger )
-                | Error e ->
-                    raise (Error.to_exn e) ) )
-      >>| Result.return )
-  >>| Result.all_unit
+  Da_layer.Client.map_diffs ~logger ~config:state.da_config
+    ~depth:constraint_constants.ledger_depth
+    ~source_ledger_hash:(`Specific (Ledger.Db.merkle_root state.ledger_cache))
+    ~target_ledger_hash:hash
+    ~f:(fun progress diff ->
+      Zeko_util.progress_bar progress ;
+      match Da_layer.Diff.Stable.Latest.command_with_action_step_flags diff with
+      | None ->
+          (* Apply accounts diff *)
+          let changed_accounts =
+            Da_layer.Diff.Stable.Latest.changed_accounts diff
+          in
+          List.iter changed_accounts ~f:(fun (index, account) ->
+              Ledger.set_at_index_exn ledger index account ) ;
+          Ledger.commit ledger ;
+          return ()
+      | Some (command, _) -> (
+          let txn_applied =
+            Or_error.ok_exn
+            @@ Result.( >>= )
+                 (Ledger.apply_transaction_first_pass ~constraint_constants
+                    ~global_slot:Mina_numbers.Global_slot_since_genesis.zero
+                    ~txn_state_view:
+                      Mina_state.Protocol_state.(
+                        Body.view @@ body compile_time_genesis_state)
+                    ledger (Command command) )
+                 (Ledger.apply_transaction_second_pass ledger)
+          in
+          Ledger.commit ledger ;
+          let new_protocol_state, diff =
+            Archive_lib.Diff.Builder.zeko_transaction_added
+              ~constraint_constants
+              ~accounts_created:
+                (Ledger.Transaction_applied.new_accounts txn_applied)
+              ~new_state_hash:(Ledger.merkle_root ledger)
+              ~protocol_state:!protocol_state ~ledger
+              ~txn:(Ledger.Transaction_applied.transaction txn_applied)
+              ~dummy_fee_payer:Zkapps_rollup.inner_public_key
+              ~timestamp:(Da_layer.Diff.Stable.Latest.timestamp diff)
+          in
+          protocol_state := new_protocol_state ;
+          if State.has_been_relayed state (Ledger.merkle_root ledger) then
+            return ()
+          else
+            match%bind
+              Archive_client.dispatch ~logger state.archive_uri
+                (Archive_lib.Diff.Transition_frontier diff)
+            with
+            | Ok () ->
+                State.add_hash state (Ledger.merkle_root ledger) ;
+                return
+                @@ [%log info] "Synced diff to archive with hash: %s\n%!"
+                     (Ledger_hash.to_decimal_string @@ Ledger.merkle_root ledger)
+            | Error e ->
+                raise (Error.to_exn e) ) )
+  >>| Result.map ~f:ignore
 
 let fetch_current_ledger_hash ~zeko_uri () =
   let query =

--- a/src/app/zeko/sequencer/archive_relay/run.ml
+++ b/src/app/zeko/sequencer/archive_relay/run.ml
@@ -78,14 +78,17 @@ end
 
 let sync_archive ~(state : State.t) ~hash =
   let logger = state.logger in
-  let%bind.Deferred.Result diffs =
-    Da_layer.Client.get_diffs_chain ~logger ~config:state.da_config
+  let%bind.Deferred.Result lazy_chunks =
+    Da_layer.Client.get_lazy_diffs_chunks ~logger ~config:state.da_config
+      ~depth:constraint_constants.ledger_depth
       ~source_ledger_hash:(`Specific (Ledger.Db.merkle_root state.ledger_cache))
-      ~target_ledger_hash:hash
+      ~target_ledger_hash:hash ()
   in
-  Ledger.with_ledger ~depth:constraint_constants.ledger_depth ~f:(fun ledger ->
-      let protocol_state = ref compile_time_genesis_state in
-      Deferred.List.iter diffs ~f:(fun diff ->
+  let ledger = Ledger.of_database state.ledger_cache in
+  let protocol_state = ref compile_time_genesis_state in
+  Deferred.List.mapi ~how:`Sequential lazy_chunks ~f:(fun i lazy_chunk ->
+      let%bind.Deferred.Result diffs = Lazy.force lazy_chunk in
+      Deferred.List.iter ~how:`Sequential diffs ~f:(fun diff ->
           match
             Da_layer.Diff.Stable.Latest.command_with_action_step_flags diff
           with
@@ -137,8 +140,9 @@ let sync_archive ~(state : State.t) ~hash =
                          ( Ledger_hash.to_decimal_string
                          @@ Ledger.merkle_root ledger )
                 | Error e ->
-                    raise (Error.to_exn e) ) ) )
-  |> Deferred.map ~f:Result.return
+                    raise (Error.to_exn e) ) )
+      >>| Result.return )
+  >>| Result.all_unit
 
 let fetch_current_ledger_hash ~zeko_uri () =
   let query =

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -173,9 +173,8 @@ module Sequencer = struct
     let prove_signed_command provers ~sparse_ledger ~user_command_in_block
         ~statement =
       let%bind txn_snark =
-        Utils.print_time "Transaction_snark.of_signed_command"
-          (Zeko_prover.Client.transaction_snark_of_signed_command provers
-             ~statement ~user_command_in_block ~sparse_ledger )
+        Zeko_prover.Client.transaction_snark_of_signed_command provers
+          ~statement ~user_command_in_block ~sparse_ledger
       in
       wrap provers txn_snark
 
@@ -186,23 +185,18 @@ module Sequencer = struct
             failwith "No witnesses"
         | (witness, spec, statement) :: rest ->
             let%bind p1 =
-              Utils.print_time "Transaction_snark.of_zkapp_command_segment"
-                (Zeko_prover.Client.transaction_snark_of_zkapp_command_segment
-                   provers ~statement ~witness ~spec )
+              Zeko_prover.Client.transaction_snark_of_zkapp_command_segment
+                provers ~statement ~witness ~spec
             in
             Deferred.List.fold ~init:p1 rest
               ~f:(fun acc (witness, spec, statement) ->
                 let%bind prev = return acc in
                 let%bind curr =
-                  Utils.print_time "Transaction_snark.of_zkapp_command_segment"
-                    (Zeko_prover.Client
-                     .transaction_snark_of_zkapp_command_segment provers
-                       ~statement ~witness ~spec )
+                  Zeko_prover.Client.transaction_snark_of_zkapp_command_segment
+                    provers ~statement ~witness ~spec
                 in
                 let%bind merged =
-                  Utils.print_time "Transaction_snark.merge"
-                    (Zeko_prover.Client.transaction_snark_merge provers curr
-                       prev )
+                  Zeko_prover.Client.transaction_snark_merge provers curr prev
                 in
                 return merged )
       in
@@ -224,37 +218,11 @@ module Sequencer = struct
           }
       end
 
-      module Db = struct
-        module Key_value = struct
-          type _ t = Context_state : (unit * State.t) t
+      module Db = Kvdb_base.Make_singleton (struct
+        type t = State.t [@@deriving yojson]
 
-          let serialize_key : type k v. (k * v) t -> k -> Bigstring.t =
-           fun pair_type key ->
-            match pair_type with
-            | Context_state ->
-                Bigstring.of_string "context_state"
-
-          let serialize_value : type k v. (k * v) t -> v -> Bigstring.t =
-           fun pair_type value ->
-            match pair_type with
-            | Context_state ->
-                Bigstring.of_string @@ Yojson.Safe.to_string
-                @@ State.to_yojson value
-
-          let deserialize_value : type k v. (k * v) t -> Bigstring.t -> v =
-            let ok_exn x =
-              let open Ppx_deriving_yojson_runtime.Result in
-              match x with Ok x -> x | Error e -> failwith e
-            in
-            fun pair_type data ->
-              match pair_type with
-              | Context_state ->
-                  ok_exn @@ State.of_yojson @@ Yojson.Safe.from_string
-                  @@ Bigstring.to_string data
-        end
-
-        include Kvdb_base.Make (Key_value)
-      end
+        let key = "context_state"
+      end)
 
       type t =
         { provers : Zeko_prover.Client.State.t
@@ -265,15 +233,10 @@ module Sequencer = struct
         ; state : State.t
         }
 
-      let save_state t =
-        Db.set t.kvdb Db.Key_value.Context_state ~key:() ~data:t.state
+      let save_state t = Db.set t.kvdb ~data:t.state
 
       let load_state kvdb =
-        match Db.get kvdb Db.Key_value.Context_state ~key:() with
-        | Some state ->
-            state
-        | None ->
-            State.create ()
+        match Db.get kvdb with Some state -> state | None -> State.create ()
 
       let reset_state t ledger =
         t.state.commands <- [] ;

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -343,7 +343,8 @@ module Sequencer = struct
         |> List.join
       in
       (* Adding jobs will repopulate the list *)
-      ctx.state.commands <- [ ref [||] ] ;
+      assert (phys_equal (P.current_tree t) None) ;
+      ctx.state.commands <- [] ;
       printf "Requeueing %d commands\n%!" (List.length commands_to_requeue) ;
       List.iter commands_to_requeue ~f:(fun command ->
           don't_wait_for @@ P.add_job t ctx ~data:command )

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -207,7 +207,7 @@ module Sequencer = struct
         type t =
           { mutable previous_committed_ledger : Sparse_ledger.t option
           ; mutable previous_committed_ledger_hash : Ledger_hash.t option
-          ; mutable commands : Command_witness.t list
+          ; mutable commands : Command_witness.t array ref list
           }
         [@@deriving yojson]
 
@@ -238,15 +238,26 @@ module Sequencer = struct
       let load_state kvdb =
         match Db.get kvdb with Some state -> state | None -> State.create ()
 
-      let reset_state t ledger =
-        t.state.commands <- [] ;
+      let committed t ledger =
+        t.state.commands <- List.tl_exn t.state.commands ;
+        t.state.previous_committed_ledger <- Some ledger ;
+        t.state.previous_committed_ledger_hash <-
+          Some (Sparse_ledger.merkle_root ledger) ;
+        save_state t
+
+      let set_last_committed_ledger t ledger =
         t.state.previous_committed_ledger <- Some ledger ;
         t.state.previous_committed_ledger_hash <-
           Some (Sparse_ledger.merkle_root ledger) ;
         save_state t
 
       let add_command t command =
-        t.state.commands <- t.state.commands @ [ command ] ;
+        let arr = List.last_exn t.state.commands in
+        arr := Array.append !arr [| command |] ;
+        save_state t
+
+      let created_new_tree t =
+        t.state.commands <- t.state.commands @ [ ref [||] ] ;
         save_state t
     end
 
@@ -319,16 +330,20 @@ module Sequencer = struct
             ~archive_uri:config.archive_uri commit_witness
         in
         let%bind () = Executor.send_zkapp_command executor command in
-        Context.reset_state ctx new_inner_ledger ;
+        Context.committed ctx new_inner_ledger ;
         return ()
     end
 
     module P = Parallel_merger.Make (Context) (Merge) (Base) (Commit)
 
     let requeue_after_restart t (ctx : Context.t) =
-      let commands_to_requeue = ctx.state.commands in
+      let commands_to_requeue =
+        ctx.state.commands
+        |> List.map ~f:(fun arr -> Array.to_list !arr)
+        |> List.join
+      in
       (* Adding jobs will repopulate the list *)
-      ctx.state.commands <- [] ;
+      ctx.state.commands <- [ ref [||] ] ;
       printf "Requeueing %d commands\n%!" (List.length commands_to_requeue) ;
       List.iter commands_to_requeue ~f:(fun command ->
           don't_wait_for @@ P.add_job t ctx ~data:command )
@@ -811,7 +826,7 @@ module Sequencer = struct
         L.(of_database t.db)
         [ Zkapps_rollup.inner_account_id ]
     in
-    Merger.Context.reset_state t.merger_ctx sparse_ledger ;
+    Merger.Context.set_last_committed_ledger t.merger_ctx sparse_ledger ;
     return ()
 
   let create ~logger ~zkapp_pk ~max_pool_size ~commitment_period_sec ~da_config

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -519,7 +519,11 @@ module Sequencer = struct
                      command
               in
               match%bind
-                Verifier.verify_command { data = verifiable; status = Applied }
+                try_with (fun () ->
+                    Verifier.verify_command
+                      { data = verifiable; status = Applied } )
+                >>| Result.map_error ~f:Error.of_exn
+                >>| Result.join
               with
               | Ok (`Valid _) ->
                   return (Ok ())

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -817,6 +817,8 @@ module Sequencer = struct
   let create ~logger ~zkapp_pk ~max_pool_size ~commitment_period_sec ~da_config
       ~da_quorum ~db_dir ~l1_uri ~archive_uri ~signer ~network_id
       ~deposit_delay_blocks ~provers =
+    print_endline "Precomputing srs" ;
+    Pickles.Side_loaded.srs_precomputation () ;
     let db =
       L.Db.create ?directory_name:db_dir
         ~depth:constraint_constants.ledger_depth ()

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -787,57 +787,45 @@ module Sequencer = struct
     printf "Init root: %s\n%!" Ledger_hash.(to_decimal_string (get_root t)) ;
 
     (* apply diffs from DA layer *)
-    let%bind lazy_chunks =
-      Da_layer.Client.get_lazy_diffs_chunks ~logger ~config:da_config
-        ~depth:constraint_constants.ledger_depth ~source_ledger_hash:`Genesis
-        ~target_ledger_hash:committed_ledger_hash ()
-      |> Deferred.map ~f:Or_error.ok_exn
-    in
-    let l = List.length lazy_chunks in
     let%bind () =
-      Deferred.List.iteri ~how:`Sequential lazy_chunks ~f:(fun i lazy_chunk ->
-          Zeko_util.progress_bar (Float.of_int i /. Float.of_int l) ;
-          let%bind diffs =
-            Lazy.force lazy_chunk |> Deferred.map ~f:Or_error.ok_exn
-          in
-          return
-          @@ List.iter diffs ~f:(fun diff ->
-                 assert (
-                   Ledger_hash.equal
-                     (Da_layer.Diff.Stable.Latest.source_ledger_hash diff)
-                     (get_root t) ) ;
-                 match
-                   Da_layer.Diff.Stable.Latest.command_with_action_step_flags
-                     diff
-                 with
-                 | None ->
-                     (* Apply accounts diff *)
-                     let mask = L.of_database t.db in
-                     let changed_accounts =
-                       Da_layer.Diff.Stable.Latest.changed_accounts diff
-                     in
-                     printf "Setting %d accounts\n%!"
-                       (List.length changed_accounts) ;
-                     List.iter changed_accounts ~f:(fun (index, account) ->
-                         L.set_at_index_exn mask index account ) ;
-                     L.Mask.Attached.commit mask
-                 | Some (command, _) ->
-                     (* Apply command *)
-                     let mask = L.of_database t.db in
-                     let global_slot =
-                       Mina_numbers.Global_slot_since_genesis.zero
-                     in
-                     let state_body =
-                       Mina_state.Protocol_state.body compile_time_genesis_state
-                     in
-                     let _, _, _, _, analytics_state =
-                       apply_user_command_without_check mask t.archive command
-                         ~global_slot ~state_body
-                         ~analytics_state:t.analytics_state
-                       |> Or_error.ok_exn
-                     in
-                     t.analytics_state <- analytics_state ;
-                     L.Mask.Attached.commit mask ) )
+      Da_layer.Client.map_diffs ~logger ~config:da_config
+        ~depth:constraint_constants.ledger_depth ~source_ledger_hash:`Genesis
+        ~target_ledger_hash:committed_ledger_hash ~f:(fun progress diff ->
+          Zeko_util.progress_bar progress ;
+          assert (
+            Ledger_hash.equal
+              (Da_layer.Diff.Stable.Latest.source_ledger_hash diff)
+              (get_root t) ) ;
+          match
+            Da_layer.Diff.Stable.Latest.command_with_action_step_flags diff
+          with
+          | None ->
+              (* Apply accounts diff *)
+              let mask = L.of_database t.db in
+              let changed_accounts =
+                Da_layer.Diff.Stable.Latest.changed_accounts diff
+              in
+              printf "Setting %d accounts\n%!" (List.length changed_accounts) ;
+              List.iter changed_accounts ~f:(fun (index, account) ->
+                  L.set_at_index_exn mask index account ) ;
+              L.Mask.Attached.commit mask ;
+              return ()
+          | Some (command, _) ->
+              (* Apply command *)
+              let mask = L.of_database t.db in
+              let global_slot = Mina_numbers.Global_slot_since_genesis.zero in
+              let state_body =
+                Mina_state.Protocol_state.body compile_time_genesis_state
+              in
+              let _, _, _, _, analytics_state =
+                apply_user_command_without_check mask t.archive command
+                  ~global_slot ~state_body ~analytics_state:t.analytics_state
+                |> Or_error.ok_exn
+              in
+              t.analytics_state <- analytics_state ;
+              L.Mask.Attached.commit mask ;
+              return () )
+      >>| Or_error.ok_exn >>| ignore
     in
 
     let current_root = get_root t in

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -904,15 +904,8 @@ module Sequencer = struct
         ~archive_uri:config.archive_uri
     in
     let%bind () =
-      match%bind
-        Da_layer.Client.sync_nodes ~logger ~config:da_config
-          ~depth:constraint_constants.ledger_depth
-          ~target_ledger_hash:(get_root t)
-      with
-      | Ok _ ->
-          return ()
-      | Error e ->
-          Error.raise e
+      Da_layer.Client.check_synced_nodes ~logger ~config:da_config
+        ~target_ledger_hash:(get_root t)
     in
     return t
 end

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -787,46 +787,57 @@ module Sequencer = struct
     printf "Init root: %s\n%!" Ledger_hash.(to_decimal_string (get_root t)) ;
 
     (* apply diffs from DA layer *)
-    let%bind diffs =
-      Da_layer.Client.get_diffs_chain ~logger ~config:da_config
-        ~source_ledger_hash:`Genesis ~target_ledger_hash:committed_ledger_hash
+    let%bind lazy_chunks =
+      Da_layer.Client.get_lazy_diffs_chunks ~logger ~config:da_config
+        ~depth:constraint_constants.ledger_depth ~source_ledger_hash:`Genesis
+        ~target_ledger_hash:committed_ledger_hash ()
       |> Deferred.map ~f:Or_error.ok_exn
     in
+    let l = List.length lazy_chunks in
     let%bind () =
-      Deferred.List.iter ~how:`Sequential diffs ~f:(fun diff ->
-          assert (
-            Ledger_hash.equal
-              (Da_layer.Diff.Stable.Latest.source_ledger_hash diff)
-              (get_root t) ) ;
-          match
-            Da_layer.Diff.Stable.Latest.command_with_action_step_flags diff
-          with
-          | None ->
-              (* Apply accounts diff *)
-              let mask = L.of_database t.db in
-              let changed_accounts =
-                Da_layer.Diff.Stable.Latest.changed_accounts diff
-              in
-              printf "Setting %d accounts\n%!" (List.length changed_accounts) ;
-              List.iter changed_accounts ~f:(fun (index, account) ->
-                  L.set_at_index_exn mask index account ) ;
-              L.Mask.Attached.commit mask ;
-              return ()
-          | Some (command, _) ->
-              (* Apply command *)
-              let mask = L.of_database t.db in
-              let global_slot = Mina_numbers.Global_slot_since_genesis.zero in
-              let state_body =
-                Mina_state.Protocol_state.body compile_time_genesis_state
-              in
-              let _, _, _, _, analytics_state =
-                apply_user_command_without_check mask t.archive command
-                  ~global_slot ~state_body ~analytics_state:t.analytics_state
-                |> Or_error.ok_exn
-              in
-              t.analytics_state <- analytics_state ;
-              L.Mask.Attached.commit mask ;
-              return () )
+      Deferred.List.iteri ~how:`Sequential lazy_chunks ~f:(fun i lazy_chunk ->
+          Zeko_util.progress_bar (Float.of_int i /. Float.of_int l) ;
+          let%bind diffs =
+            Lazy.force lazy_chunk |> Deferred.map ~f:Or_error.ok_exn
+          in
+          return
+          @@ List.iter diffs ~f:(fun diff ->
+                 assert (
+                   Ledger_hash.equal
+                     (Da_layer.Diff.Stable.Latest.source_ledger_hash diff)
+                     (get_root t) ) ;
+                 match
+                   Da_layer.Diff.Stable.Latest.command_with_action_step_flags
+                     diff
+                 with
+                 | None ->
+                     (* Apply accounts diff *)
+                     let mask = L.of_database t.db in
+                     let changed_accounts =
+                       Da_layer.Diff.Stable.Latest.changed_accounts diff
+                     in
+                     printf "Setting %d accounts\n%!"
+                       (List.length changed_accounts) ;
+                     List.iter changed_accounts ~f:(fun (index, account) ->
+                         L.set_at_index_exn mask index account ) ;
+                     L.Mask.Attached.commit mask
+                 | Some (command, _) ->
+                     (* Apply command *)
+                     let mask = L.of_database t.db in
+                     let global_slot =
+                       Mina_numbers.Global_slot_since_genesis.zero
+                     in
+                     let state_body =
+                       Mina_state.Protocol_state.body compile_time_genesis_state
+                     in
+                     let _, _, _, _, analytics_state =
+                       apply_user_command_without_check mask t.archive command
+                         ~global_slot ~state_body
+                         ~analytics_state:t.analytics_state
+                       |> Or_error.ok_exn
+                     in
+                     t.analytics_state <- analytics_state ;
+                     L.Mask.Attached.commit mask ) )
     in
 
     let current_root = get_root t in

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -69,7 +69,7 @@ module Sequencer = struct
       { q : unit Throttle.t
       ; config : Config.t
       ; transfers_memory : Transfers_memory.t
-      ; provers : Zeko_prover.Client.State.t
+      ; provers : Zeko_prover.Client.t
       }
 
     let create ~config ~provers =
@@ -225,7 +225,7 @@ module Sequencer = struct
       end)
 
       type t =
-        { provers : Zeko_prover.Client.State.t
+        { provers : Zeko_prover.Client.t
         ; da_client : Da_layer.Client.Sequencer.t
         ; executor : Executor.t
         ; config : Config.t
@@ -507,10 +507,15 @@ module Sequencer = struct
     else
       Throttle.enqueue t.apply_q (fun () ->
           let%bind.Deferred.Result () =
+            let weight = User_command.weight command in
             return
             @@
-            if Merger.P.number_of_wip_jobs t.merger >= t.config.max_pool_size
-            then Error (Error.of_string "Maximum pool size reached, try later")
+            if
+              Zeko_prover.Client.queue_size t.merger_ctx.provers + weight
+              > t.config.max_pool_size
+            then
+              Error
+                (Error.of_string "Maximum proof queue size reached, try later")
             else Ok ()
           in
 
@@ -857,7 +862,7 @@ module Sequencer = struct
     in
     let kvdb = L.Db.zeko_kvdb db in
     let provers =
-      Zeko_prover.Client.State.create
+      Zeko_prover.Client.create
         (List.map provers ~f:Tcp.Where_to_connect.of_host_and_port)
     in
     let executor = Executor.create ~l1_uri:config.l1_uri ~signer ~kvdb () in

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -754,12 +754,16 @@ module Sequencer = struct
     let%bind () =
       Da_layer.Client.map_diffs ~logger ~config:da_config
         ~depth:constraint_constants.ledger_depth ~source_ledger_hash:`Genesis
-        ~print_progress:true ~target_ledger_hash:committed_ledger_hash
-        ~f:(fun diff ->
+        ~target_ledger_hash:committed_ledger_hash
+        ~f:(fun ~current_chunk ~chunks_length diff ->
           assert (
             Ledger_hash.equal
               (Da_layer.Diff.Stable.Latest.source_ledger_hash diff)
               (get_root t) ) ;
+          [%log info] "Applying diff with hash %s, progress: %.0f%%"
+            (Ledger_hash.to_decimal_string
+               (Da_layer.Diff.Stable.Latest.source_ledger_hash diff) )
+            (Float.of_int current_chunk /. Float.of_int chunks_length *. 100.0) ;
           match
             Da_layer.Diff.Stable.Latest.command_with_action_step_flags diff
           with

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -304,13 +304,15 @@ module Sequencer = struct
         let%bind signatures =
           Da_layer.Client.Sequencer.get_signatures da_client
             ~ledger_hash:(Sparse_ledger.merkle_root new_inner_ledger)
-          |> Deferred.map ~f:(fun x -> Option.value_exn x)
+          |> Deferred.map ~f:(fun x ->
+                 Option.value_exn x ~message:"No signatures" )
         in
         printf "Received %d signatures from da layer\n%!"
           (List.length signatures) ;
 
         let old_inner_ledger =
           Option.value_exn state.previous_committed_ledger
+            ~message:"No previous committed ledger"
         in
         let commit_witness : Committer.Commit_witness.t =
           { old_inner_ledger
@@ -475,9 +477,10 @@ module Sequencer = struct
                       (Account_update.token_id update)
                   in
                   let location =
-                    L.location_of_account l account_id |> Option.value_exn
+                    L.location_of_account l account_id
+                    |> Option.value_exn ~message:"No location"
                   in
-                  L.get l location |> Option.value_exn
+                  L.get l location |> Option.value_exn ~message:"No account"
                 in
                 Archive.add_account_update archive update account
                   (Some
@@ -620,6 +623,7 @@ module Sequencer = struct
                 { Transaction_protocol_state.Poly.transaction =
                     Signed_command.check_only_for_signature signed_command
                     |> Option.value_exn
+                         ~message:"check_only_for_signature failed"
                 ; block_data = state_body
                 ; global_slot
                 }

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -777,6 +777,7 @@ module Sequencer = struct
           don't_wait_for @@ Deferred.ignore_m @@ commit t )
 
   let bootstrap ~logger ({ config; _ } as t) da_config =
+    print_endline "Bootstrapping" ;
     let%bind committed_ledger_hash =
       Gql_client.infer_committed_state config.l1_uri ~zkapp_pk:config.zkapp_pk
         ~signer_pk:(Public_key.compress config.signer.public_key)
@@ -790,8 +791,8 @@ module Sequencer = struct
     let%bind () =
       Da_layer.Client.map_diffs ~logger ~config:da_config
         ~depth:constraint_constants.ledger_depth ~source_ledger_hash:`Genesis
-        ~target_ledger_hash:committed_ledger_hash ~f:(fun progress diff ->
-          Zeko_util.progress_bar progress ;
+        ~print_progress:true ~target_ledger_hash:committed_ledger_hash
+        ~f:(fun diff ->
           assert (
             Ledger_hash.equal
               (Da_layer.Diff.Stable.Latest.source_ledger_hash diff)

--- a/src/app/zeko/sequencer/prover/cli.ml
+++ b/src/app/zeko/sequencer/prover/cli.ml
@@ -1,15 +1,17 @@
 open Core
 open Async
 open Signature_lib
+open Cli_lib
 module Server = Zeko_prover.Prover
 
 let run_server =
   ( "run-server"
   , Command.async ~summary:"Run prover server"
-      (let%map_open.Command port =
-         flag "--port" (required int) ~doc:"int Port to listen on"
-       in
+      (let%map_open.Command log_json = Flag.Log.json
+       and log_level = Flag.Log.level
+       and port = flag "--port" (required int) ~doc:"int Port to listen on" in
        let logger = Logger.create () in
+       Stdout_log.setup log_json log_level ;
        [%log info] "Compiling circuits" ;
        let module T = Transaction_snark.Make (struct
          let constraint_constants = Server.constraint_constants

--- a/src/app/zeko/sequencer/prover/lib/client.ml
+++ b/src/app/zeko/sequencer/prover/lib/client.ml
@@ -8,126 +8,91 @@ let try_connect where_to_connect =
   | Error exn ->
       return (Error (Error.of_exn exn))
 
-module State = struct
-  type lazy_connection =
-    ( ([ `Active ], Socket.Address.Inet.t) Socket.t * Reader.t * Writer.t
-    , Error.t )
-    Result.t
-    Deferred.t
-    lazy_t
+type lazy_connection =
+  ( ([ `Active ], Socket.Address.Inet.t) Socket.t * Reader.t * Writer.t
+  , Error.t )
+  Result.t
+  Deferred.t
 
-  type prover_state = [ `In_use | `Available ]
+type prover = lazy_connection ref * Tcp.Where_to_connect.inet
 
-  type t =
-    { provers :
-        (lazy_connection ref * Tcp.Where_to_connect.inet * prover_state ref)
-        list
-    ; mutable next : int
-    }
+type t = { q : prover Throttle.t }
 
-  let create ?(ping_interval = 10.) ?(ping_timeout = 10.) provers =
-    let connections =
-      List.map provers ~f:(fun x ->
-          (ref (lazy (try_connect x)), x, ref `Available) )
-    in
-    let rec ping_loop () =
-      let%bind () = after (Time.Span.of_sec ping_interval) in
-      Deferred.List.iter ~how:`Parallel connections
-        ~f:(fun (connection_ref, _, status) ->
-          if Lazy.is_val !connection_ref && phys_equal !status `Available then (
-            status := `In_use ;
-            match%bind Lazy.force !connection_ref with
-            | Error _ ->
-                return ()
-            | Ok (_, r, w) ->
-                let () =
-                  Prover.Input.to_yojson Prover.Input.Ping
-                  |> Yojson.Safe.to_string |> Writer.write_line w
-                in
-                let%bind _result =
-                  Reader.really_read_line
-                    ~wait_time:(Time.Span.of_sec ping_timeout)
-                    r
-                in
-                return (status := `Available) )
-          else return () )
-    in
-    don't_wait_for @@ ping_loop () ;
-    { provers = connections; next = 0 }
+let create ?(ping_interval = 15.) ?(ping_timeout = 10.) provers =
+  let connections = List.map provers ~f:(fun x -> (ref (try_connect x), x)) in
+  let q = Throttle.create_with ~continue_on_error:true connections in
+  (* Start pinging *)
+  let rec ping_loop () =
+    let%map () = after (Time.Span.of_sec ping_interval) in
+    List.iter connections ~f:(fun _ ->
+        don't_wait_for
+        @@ Throttle.enqueue q (fun (connection_ref, _) ->
+               match%bind !connection_ref with
+               | Error _ ->
+                   return ()
+               | Ok (_, r, w) ->
+                   let () =
+                     Prover.Input.to_yojson Prover.Input.Ping
+                     |> Yojson.Safe.to_string |> Writer.write_line w
+                   in
+                   let%map _result =
+                     Reader.really_read_line
+                       ~wait_time:(Time.Span.of_sec ping_timeout)
+                       r
+                   in
+                   () ) )
+  in
+  don't_wait_for @@ ping_loop () ;
+  { q }
 
-  let rec next_prover (t : t) =
-    let rotate l n =
-      let left, right = List.split_n l n in
-      right @ left
-    in
-    t.next <- (t.next + 1) mod List.length t.provers ;
-    match
-      rotate t.provers t.next
-      |> List.find ~f:(fun (_, _, status) ->
-             match !status with `Available -> true | `In_use -> false )
-    with
-    | Some prover ->
-        let status = trd3 prover in
-        status := `In_use ;
-        return (prover, fun () -> status := `Available)
-    | None ->
-        let%bind () = Clock.after (Time.Span.of_sec 1.) in
-        next_prover t
-end
+let queue_size t = Throttle.num_jobs_waiting_to_start t.q
 
 (* Get the reference of next available prover.
    If it fails to connect or times out, replace the reference with new connection and try whole thing again *)
-let rec send ?(proving_timeout = 20.) ?(wait_for_prover_timeout = 60. *. 30.)
-    ?(attempts = 5) t (input : Prover.Input.t) : Prover.Output.t Deferred.t =
-  let%bind (connection_ref, where_to_connect, status), release_prover =
-    match%bind
-      Async.with_timeout
-        (Time.Span.of_sec wait_for_prover_timeout)
-        (State.next_prover t)
-    with
-    | `Result x ->
-        return x
-    | `Timeout ->
-        failwith "Timeout while getting prover"
-  in
-  match%bind
-    Async.with_timeout
-      (Time.Span.of_sec proving_timeout)
-      ( match%bind Lazy.force !connection_ref with
-      | Error err ->
-          printf "Error connecting to prover: %s\n%!" (Error.to_string_hum err) ;
-          return `Connection_error
-      | Ok (_, r, w) -> (
-          match%bind
-            let () =
-              Prover.Input.to_yojson input
-              |> Yojson.Safe.to_string |> Writer.write_line w
-            in
-            Reader.really_read_line
-              ~wait_time:(Time.Span.of_sec proving_timeout)
-              r
-          with
-          | Some response -> (
-              match
-                Yojson.Safe.from_string response |> Prover.Output.of_yojson
+let rec send ?(proving_timeout = 20.) ?(attempts = 5) ?(cooldown = 2.) t
+    (input : Prover.Input.t) : Prover.Output.t Deferred.t =
+  Throttle.enqueue t.q (fun (connection_ref, where_to_connect) ->
+      let rec go ~attempts =
+        let%bind result =
+          match%bind !connection_ref with
+          | Error err ->
+              printf "Error connecting to prover: %s\n%!"
+                (Error.to_string_hum err) ;
+              return `Connnection_error
+          | Ok (s, r, w) -> (
+              match%map
+                Async.with_timeout
+                  (Time.Span.of_sec proving_timeout)
+                  ( Prover.Input.to_yojson input
+                    |> Yojson.Safe.to_string |> Writer.write_line w ;
+                    Reader.really_read_line
+                      ~wait_time:(Time.Span.of_sec proving_timeout)
+                      r )
               with
-              | Ok output ->
-                  return (`Ok output)
-              | Error _ ->
-                  failwith "Error parsing response" )
-          | None ->
-              return `Timeout ) )
-    >>| fun r -> release_prover () ; r
-  with
-  | `Result (`Ok r) ->
-      return r
-  | `Timeout | `Result `Connection_error | `Result `Timeout ->
-      printf "Timeout while proving %f, retrying attempts remaining: %d\n%!"
-        proving_timeout attempts ;
-      if attempts > 0 then (
-        connection_ref := lazy (try_connect where_to_connect) ;
-        send ~proving_timeout ~attempts:(attempts - 1) t input )
-      else failwith "Timeout while proving"
+              | `Result (Some response) -> (
+                  match
+                    Yojson.Safe.from_string response |> Prover.Output.of_yojson
+                  with
+                  | Ok output ->
+                      `Ok output
+                  | Error _ ->
+                      print_endline "Error parsing response from prover" ;
+                      `Parsing_error )
+              | `Timeout | `Result None ->
+                  Socket.shutdown s `Both ;
+                  printf "Timeout from prover, remaining attempts: %d\n%!"
+                    (attempts - 1) ;
+                  `Timeout )
+        in
+        match result with
+        | `Timeout | `Connnection_error | `Parsing_error ->
+            let%bind () = after (Time.Span.of_sec cooldown) in
+            connection_ref := try_connect where_to_connect ;
+            go ~attempts:(attempts - 1)
+        | `Ok result ->
+            return result
+      in
+      go ~attempts )
 
 let wrapper_wrap ?proving_timeout t ~txn_snark =
   send ?proving_timeout t (Prover.Input.Wrapper_wrap txn_snark)

--- a/src/app/zeko/sequencer/prover/lib/client.ml
+++ b/src/app/zeko/sequencer/prover/lib/client.ml
@@ -54,7 +54,7 @@ end
 
 (* Get the reference of next available prover.
    If it fails to connect or times out, replace the reference with new connection and try whole thing again *)
-let rec send ?(proving_timeout = 10.) ?(wait_for_prover_timeout = 600.)
+let rec send ?(proving_timeout = 20.) ?(wait_for_prover_timeout = 600.)
     ?(attempts = 5) t (input : Prover.Input.t) : Prover.Output.t Deferred.t =
   let%bind (connection_ref, where_to_connect, status), release_prover =
     match%bind

--- a/src/app/zeko/sequencer/prover/lib/client.ml
+++ b/src/app/zeko/sequencer/prover/lib/client.ml
@@ -44,7 +44,9 @@ module State = struct
              match !status with `Available -> true | `In_use -> false )
     with
     | Some prover ->
-        return prover
+        let status = trd3 prover in
+        status := `In_use ;
+        return (prover, fun () -> status := `Available)
     | None ->
         let%bind () = Clock.after (Time.Span.of_sec 1.) in
         next_prover t
@@ -54,7 +56,7 @@ end
    If it fails to connect or times out, replace the reference with new connection and try whole thing again *)
 let rec send ?(proving_timeout = 10.) ?(wait_for_prover_timeout = 600.)
     ?(attempts = 5) t (input : Prover.Input.t) : Prover.Output.t Deferred.t =
-  let%bind connection_ref, where_to_connect, status =
+  let%bind (connection_ref, where_to_connect, status), release_prover =
     match%bind
       Async.with_timeout
         (Time.Span.of_sec wait_for_prover_timeout)
@@ -65,7 +67,6 @@ let rec send ?(proving_timeout = 10.) ?(wait_for_prover_timeout = 600.)
     | `Timeout ->
         failwith "Timeout while getting prover"
   in
-  status := `In_use ;
   match%bind
     Async.with_timeout
       (Time.Span.of_sec proving_timeout)
@@ -91,12 +92,11 @@ let rec send ?(proving_timeout = 10.) ?(wait_for_prover_timeout = 600.)
                   failwith "Error parsing response" )
           | None ->
               failwith "Timeout while proving" ) )
+    >>| fun r -> release_prover () ; r
   with
   | `Result (`Ok r) ->
-      status := `Available ;
       return r
   | `Timeout | `Result `Connection_error ->
-      status := `Available ;
       printf "Timeout while proving %f, retrying attempts remaining: %d\n%!"
         proving_timeout attempts ;
       if attempts > 0 then (

--- a/src/app/zeko/sequencer/prover/lib/client.ml
+++ b/src/app/zeko/sequencer/prover/lib/client.ml
@@ -80,7 +80,9 @@ let rec send ?(proving_timeout = 20.) ?(wait_for_prover_timeout = 600.)
               Prover.Input.to_yojson input
               |> Yojson.Safe.to_string |> Writer.write_line w
             in
-            Reader.really_read_line ~wait_time:(Time.Span.of_sec 1.) r
+            Reader.really_read_line
+              ~wait_time:(Time.Span.of_sec proving_timeout)
+              r
           with
           | Some response -> (
               match
@@ -91,12 +93,12 @@ let rec send ?(proving_timeout = 20.) ?(wait_for_prover_timeout = 600.)
               | Error _ ->
                   failwith "Error parsing response" )
           | None ->
-              failwith "Timeout while proving" ) )
+              return `Timeout ) )
     >>| fun r -> release_prover () ; r
   with
   | `Result (`Ok r) ->
       return r
-  | `Timeout | `Result `Connection_error ->
+  | `Timeout | `Result `Connection_error | `Result `Timeout ->
       printf "Timeout while proving %f, retrying attempts remaining: %d\n%!"
         proving_timeout attempts ;
       if attempts > 0 then (

--- a/src/app/zeko/sequencer/prover/lib/client.ml
+++ b/src/app/zeko/sequencer/prover/lib/client.ml
@@ -25,11 +25,34 @@ module State = struct
     ; mutable next : int
     }
 
-  let create provers =
+  let create ?(ping_interval = 10.) ?(ping_timeout = 10.) provers =
     let connections =
       List.map provers ~f:(fun x ->
           (ref (lazy (try_connect x)), x, ref `Available) )
     in
+    let rec ping_loop () =
+      let%bind () = after (Time.Span.of_sec ping_interval) in
+      Deferred.List.iter ~how:`Parallel connections
+        ~f:(fun (connection_ref, _, status) ->
+          if Lazy.is_val !connection_ref && phys_equal !status `Available then (
+            status := `In_use ;
+            match%bind Lazy.force !connection_ref with
+            | Error _ ->
+                return ()
+            | Ok (_, r, w) ->
+                let () =
+                  Prover.Input.to_yojson Prover.Input.Ping
+                  |> Yojson.Safe.to_string |> Writer.write_line w
+                in
+                let%bind _result =
+                  Reader.really_read_line
+                    ~wait_time:(Time.Span.of_sec ping_timeout)
+                    r
+                in
+                return (status := `Available) )
+          else return () )
+    in
+    don't_wait_for @@ ping_loop () ;
     { provers = connections; next = 0 }
 
   let rec next_prover (t : t) =

--- a/src/app/zeko/sequencer/prover/lib/client.ml
+++ b/src/app/zeko/sequencer/prover/lib/client.ml
@@ -80,7 +80,7 @@ let rec send ?(proving_timeout = 20.) ?(wait_for_prover_timeout = 600.)
               Prover.Input.to_yojson input
               |> Yojson.Safe.to_string |> Writer.write_line w
             in
-            Reader.really_read_line ~wait_time:(Time.Span.of_sec 60.) r
+            Reader.really_read_line ~wait_time:(Time.Span.of_sec 1.) r
           with
           | Some response -> (
               match

--- a/src/app/zeko/sequencer/prover/lib/client.ml
+++ b/src/app/zeko/sequencer/prover/lib/client.ml
@@ -77,7 +77,7 @@ end
 
 (* Get the reference of next available prover.
    If it fails to connect or times out, replace the reference with new connection and try whole thing again *)
-let rec send ?(proving_timeout = 20.) ?(wait_for_prover_timeout = 600.)
+let rec send ?(proving_timeout = 20.) ?(wait_for_prover_timeout = 60. *. 30.)
     ?(attempts = 5) t (input : Prover.Input.t) : Prover.Output.t Deferred.t =
   let%bind (connection_ref, where_to_connect, status), release_prover =
     match%bind

--- a/src/app/zeko/sequencer/prover/lib/prover.ml
+++ b/src/app/zeko/sequencer/prover/lib/prover.ml
@@ -30,6 +30,7 @@ let dummy_sok =
 (* Unfortunately yojson doesn't support GADTs so it can't be one type, or maybe I'm just bad *)
 module Input = struct
   type t =
+    | Ping
     | Wrapper_wrap of Transaction_snark.t
     | Wrapper_merge of (Zkapps_rollup.t * Zkapps_rollup.t)
     | Transaction_snark_of_signed_command of
@@ -71,6 +72,7 @@ let asd = Ledger_hash.to_yojson
 
 module Output = struct
   type t =
+    | Pong
     | Wrapper_wrap of Zkapps_rollup.t
     | Wrapper_merge of Zkapps_rollup.t
     | Transaction_snark_of_signed_command of Transaction_snark.t
@@ -87,6 +89,8 @@ end
 
 module Make (T : Transaction_snark.S) (M : Zkapps_rollup.S) = struct
   let prove ~logger : Input.t -> Output.t Deferred.t = function
+    | Ping ->
+        return Output.Pong
     | Wrapper_wrap txn_snark ->
         time ~logger "Wrapper.wrap" (M.Wrapper.wrap txn_snark)
         >>| fun x -> Output.Wrapper_wrap x
@@ -148,25 +152,32 @@ module Make (T : Transaction_snark.S) (M : Zkapps_rollup.S) = struct
          ~on_handler_error:`Ignore (fun s r w ->
            [%log info] "Accepted connection from %s"
              (Socket.Address.Inet.to_string s) ;
-           let%bind () =
-             Pipe.transfer' ~max_queue_length:1 (Reader.pipe r) (Writer.pipe w)
-               ~f:
-                 (Deferred.Queue.map ~how:`Sequential ~f:(fun input ->
-                      Yojson.Safe.from_string input
-                      |> Input.of_yojson
-                      |> function
+           let rec loop () =
+             match%bind
+               Reader.really_read_line ~wait_time:(Time.Span.of_sec 30.) r
+             with
+             | None ->
+                 return ()
+             | Some input ->
+                 Yojson.Safe.from_string input
+                 |> Input.of_yojson
+                 |> (function
                       | Ok input -> (
                           match%bind
                             try_with (fun () -> prove ~logger input)
                           with
                           | Ok output ->
-                              Output.to_yojson output |> Yojson.Safe.to_string
-                              |> fun s -> String.concat [ s; "\n" ] |> return
+                              return
+                                ( Yojson.Safe.to_string
+                                @@ Output.to_yojson output )
                           | Error e ->
                               return (Exn.to_string e) )
                       | Error e ->
-                          return e ) )
+                          return e )
+                 >>| Writer.write_line w
+                 >>= fun () -> loop ()
            in
+           let%bind () = loop () in
            return
              ([%log info] "Closed connection from %s"
                 (Socket.Address.Inet.to_string s) ) ) ;

--- a/src/app/zeko/sequencer/run.ml
+++ b/src/app/zeko/sequencer/run.ml
@@ -63,7 +63,7 @@ let () =
          ~doc:"float Commitment period in seconds"
      and max_pool_size =
        flag "--max-pool-size"
-         (optional_with_default 10 int)
+         (optional_with_default 20 int)
          ~doc:"int Maximum transaction pool size"
      and da_nodes =
        flag "--da-node" (listed string)

--- a/src/app/zeko/zeko_util.ml
+++ b/src/app/zeko/zeko_util.ml
@@ -336,5 +336,7 @@ let progress_bar ?(width = 30) progress =
   let bar =
     String.make filled_length '#' ^ String.make (width - filled_length) '-'
   in
-  Printf.printf "\r[%s] %.0f%%%!" bar (progress *. 100.0) ;
+  let no_bar = Sys.getenv_opt "ZEKO_NO_PROGRESS_BAR" in
+  if Option.is_some no_bar then Printf.printf "%.0f%%%!" (progress *. 100.0)
+  else Printf.printf "\r[%s] %.0f%%%!" bar (progress *. 100.0) ;
   if Float.(progress >= 1.0) then Printf.printf "\n%!"

--- a/src/app/zeko/zeko_util.ml
+++ b/src/app/zeko/zeko_util.ml
@@ -330,3 +330,11 @@ let compile_sync ?self ?cache ?storables ?proof_cache ?disk_keys
         Pickles.Side_loaded.Verification_key.of_compiled tag )
   in
   result
+
+let progress_bar ?(width = 30) progress =
+  let filled_length = int_of_float (float_of_int width *. progress) in
+  let bar =
+    String.make filled_length '#' ^ String.make (width - filled_length) '-'
+  in
+  Printf.printf "\r[%s] %.0f%%%!" bar (progress *. 100.0) ;
+  if Float.(progress >= 1.0) then Printf.printf "\n%!"

--- a/src/app/zeko/zeko_util.ml
+++ b/src/app/zeko/zeko_util.ml
@@ -336,7 +336,14 @@ let progress_bar ?(width = 30) progress =
   let bar =
     String.make filled_length '#' ^ String.make (width - filled_length) '-'
   in
-  let no_bar = Sys.getenv_opt "ZEKO_NO_PROGRESS_BAR" in
-  if Option.is_some no_bar then Printf.printf "%.0f%%%!" (progress *. 100.0)
-  else Printf.printf "\r[%s] %.0f%%%!" bar (progress *. 100.0) ;
+  let progress_style = Sys.getenv_opt "ZEKO_PROGRESS_STYLE" in
+  let () =
+    match progress_style with
+    | Some "percent" ->
+        Printf.printf "%.0f%%\n%!" (progress *. 100.0)
+    | Some "no" ->
+        ()
+    | Some "bar" | Some _ | None ->
+        Printf.printf "\r[%s] %.0f%%%!" bar (progress *. 100.0)
+  in
   if Float.(progress >= 1.0) then Printf.printf "\n%!"


### PR DESCRIPTION
When syncing the da node, do it in chunks of diffs. Currently the whole da layer is ~100MB so loading the all of the diffs to memory at once might will get out of hands in future. Doing all at the some time also timeouts the tcp connection currently, so it's not possible to do it.

Syncing currently takes ~10 minutes, so I've removed the syncing of da node out of sequencer into the cli command, so that it wouldn't block the sequencer from starting.

It takes that long even if the da node is missing only few diffs, this is because you need ledger openings to post a diff and to get ledger openings you need to sync the whole ledger from beginning. This is suboptimal, we might need to store some history of ledger checkpoints somewhere.