### PR TITLE
Minor fixes

### DIFF
--- a/src/app/zeko/circuits/ase.ml
+++ b/src/app/zeko/circuits/ase.ml
@@ -22,7 +22,7 @@ module M_with_length = struct
     let*| action_state = push_actions_var action_state ~actions in
     Stmt.{ action_state; length }
 
-  let name = "action state extension"
+  let name = "action state extension with length"
 
   let leaf_iterations = Int.pow 2 11
 
@@ -47,7 +47,7 @@ module M_without_length = struct
 
   let step actions action_state = push_actions_var action_state ~actions
 
-  let name = "action state extension with length"
+  let name = "action state extension without length"
 
   let leaf_iterations = Int.pow 2 12
 

--- a/src/app/zeko/circuits/compile_simple.ml
+++ b/src/app/zeko/circuits/compile_simple.ml
@@ -23,6 +23,8 @@ module Verification_key = struct
   let var_of_pickles x = x
 
   let of_tag (Tag tag) = of_compiled_promise tag
+
+  let to_pickles_lossy x = x
 end
 
 let force_tag tag = Promise.map ~f:(fun _ -> ()) (Verification_key.of_tag tag)

--- a/src/app/zeko/circuits/compile_simple.mli
+++ b/src/app/zeko/circuits/compile_simple.mli
@@ -20,6 +20,8 @@ module Verification_key : sig
   val var_of_pickles : Pickles.Side_loaded.Verification_key.Checked.t -> var
 
   val of_tag : 'tag_var tag -> t Promise.t
+
+  val to_pickles_lossy : t -> Pickles.Side_loaded.Verification_key.t
 end
 
 include module type of Compile_simple_intf.Make (struct

--- a/src/app/zeko/circuits/zeko_transaction_snark.ml
+++ b/src/app/zeko/circuits/zeko_transaction_snark.ml
@@ -312,20 +312,20 @@ module Account_set = Indexed_merkle_tree.Make (struct
       Checked.return ()
   end
 
-  module Key = Account_id
+  module Key = struct
+    type t = Token_id.t
 
-  let assert_x_less_than_y_less_than_z ~(x : Account_id.var)
-      ~(y : Account_id.var) ~(z : Account_id.var) =
+    type var = Token_id.Checked.t
+
+    let typ = Token_id.typ
+  end
+
+  let assert_x_less_than_y_less_than_z ~(x : Key.var) ~(y : Key.var)
+      ~(z : Key.var) =
     (* pretty sure of_field is supposed to be of_field_unsafe, and to_field_unsafe is supposed to be to_field *)
-    let f owner =
-      make_checked
-      @@ fun () ->
-      Account_id.Checked.derive_token_id ~owner
-      |> Token_id.Checked.to_field_unsafe
-    in
-    let* x = f x in
-    let* y = f y in
-    let* z = f z in
+    let x = Token_id.Checked.to_field_unsafe x in
+    let y = Token_id.Checked.to_field_unsafe y in
+    let z = Token_id.Checked.to_field_unsafe z in
     let* () = assert_greater_than_full ~check:Boolean.true_ z y in
     let*| () = assert_greater_than_full ~check:Boolean.true_ y x in
     ()
@@ -420,8 +420,8 @@ module T = struct
 end
 
 type update_acc_set_witness =
-  { get_account_set_x : unit -> Account_id.t
-  ; get_account_set_z : unit -> Account_id.t
+  { get_account_set_x : unit -> Token_id.t
+  ; get_account_set_z : unit -> Token_id.t
   ; get_account_set_x_path : unit -> Account_set.Path.t
   ; get_account_set_y_path : unit -> Account_set.Path.t
   }
@@ -633,12 +633,15 @@ let perform ~(shift_action_states : Boolean.var list)
             shift_action_states := xs ;
             x )
 
+let derive_token_id ~owner =
+  make_checked @@ fun () -> Account_id.Checked.derive_token_id ~owner
+
 let update_acc_set accounts init ~witness =
   Checked.List.fold accounts ~init
     ~f:(fun set (account_id, is_empty_and_writeable) ->
       let open As_prover in
       let* x =
-        exists Account_id.typ
+        exists Token_id.typ
           ~compute:(witness >>| fun x -> x.get_account_set_x ())
       in
       let* path_x =
@@ -650,11 +653,12 @@ let update_acc_set accounts init ~witness =
           ~compute:(witness >>| fun x -> x.get_account_set_y_path ())
       in
       let* z =
-        exists Account_id.typ
+        exists Token_id.typ
           ~compute:(witness >>| fun x -> x.get_account_set_z ())
       in
+      let* y = derive_token_id ~owner:account_id in
       let* `Before_adding_y set', `After_adding_y new_set =
-        Account_set.add_key_var ~x ~path_x ~y:account_id ~path_y ~z
+        Account_set.add_key_var ~x ~path_x ~y ~path_y ~z
           ~check:is_empty_and_writeable ()
       in
       let*| () = assert_equal ~label:__LOC__ Account_set.typ set set' in

--- a/src/app/zeko/circuits/zeko_transaction_snark.mli
+++ b/src/app/zeko/circuits/zeko_transaction_snark.mli
@@ -80,8 +80,8 @@ module T : sig
 end
 
 type update_acc_set_witness =
-  { get_account_set_x : unit -> Mina_base.Account_id.t
-  ; get_account_set_z : unit -> Mina_base.Account_id.t
+  { get_account_set_x : unit -> Mina_base.Token_id.t
+  ; get_account_set_z : unit -> Mina_base.Token_id.t
   ; get_account_set_x_path : unit -> Account_set.Path.t
   ; get_account_set_y_path : unit -> Account_set.Path.t
   }


### PR DESCRIPTION
- The names of the action state extension rules were wrong, leading to very confusing error messages.
- We might need the ability to lossily unwrap the verification key, now that I think about it, might be wrong way to go about things, might fix later again.
- Using account id as key for indexed merkle tree was problematic because to construct the initial indexed merkle tree you need to insert the smallest and biggest account id, but the comparison we were doing was comparing the hashes of the account ids. This meant that we needed to find an account id such that its hash is 0, which is of course not possible. Hence now we've switched to operating on the hashes (token ids) directly. Then the minimum element is 0, and the maximum is -1.