### PR TITLE
Fix segfault in sequencer tests

### DIFF
--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -404,6 +404,8 @@ let () =
             return () )
       in
 
+      Gc.full_major () ;
+
       print_endline "(* Restart sequencer *)" ;
       let new_sequencer =
         run (fun () ->


### PR DESCRIPTION
Sequencer tests are testing the recovery of sequencer after restart, for that I am creating new object for rocksdb.

Iterator was calling free after rocksdb object has been closed, which was causing segfault since the pointer has been already rewritten.