### PR TITLE
Calculate sequencer fees based on queue size

### DIFF
--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -1793,6 +1793,13 @@ module Queries = struct
       ~resolve:(fun { ctx = sequencer; _ } () ->
         "zeko:" ^ Zeko_sequencer.(sequencer.config.network_id) )
 
+  let fee_per_weight_unit =
+    field "feePerWeightUnit" ~doc:"Current fee per weight unit"
+      ~args:Arg.[]
+      ~typ:(non_null int)
+      ~resolve:(fun { ctx = sequencer; _ } () ->
+        Zeko_sequencer.current_fee_per_weight_unit sequencer )
+
   let account =
     field "account" ~doc:"Find any account via a public key and token"
       ~typ:Types.AccountObj.account
@@ -1950,6 +1957,7 @@ module Queries = struct
     ; state_hashes
     ; token_owner
     ; network_id
+    ; fee_per_weight_unit
     ]
     @ Archive.commands
 end

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -1796,7 +1796,7 @@ module Queries = struct
   let fee_per_weight_unit =
     field "feePerWeightUnit" ~doc:"Current fee per weight unit"
       ~args:Arg.[]
-      ~typ:(non_null int)
+      ~typ:(non_null float)
       ~resolve:(fun { ctx = sequencer; _ } () ->
         Zeko_sequencer.current_fee_per_weight_unit sequencer )
 

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -24,6 +24,8 @@ module Sequencer = struct
       ; network_id : string
       ; deposit_delay_blocks : int
       ; da_key : Even_PC.t
+      ; fee_modifier : float
+      ; minimum_fee : float
       }
   end
 
@@ -278,6 +280,18 @@ module Sequencer = struct
                      } ) ) )
     |> Or_error.combine_errors |> Result.map ~f:ignore
 
+  (** weight * minimum_fee * e^(q * 0.1 * modifier) *)
+  let calculate_fee t command =
+    let jobs_in_queue =
+      Zeko_prover.Client.queue_size t.merger_ctx.provers |> Float.of_int
+    in
+    let weight = User_command.weight command |> Float.of_int in
+    weight *. t.config.minimum_fee
+    *. exp (jobs_in_queue *. 0.1 *. t.config.fee_modifier)
+    (* convert to nanomina *)
+    *. 10e8
+    |> Float.to_int |> Currency.Fee.of_nanomina_int
+
   (** Apply user command to the sequencer's state, including the check of command validity *)
   let apply_user_command t ?(skip_validity_check = false)
       (command : User_command.t) =
@@ -288,19 +302,22 @@ module Sequencer = struct
     else
       Throttle.enqueue t.apply_q (fun () ->
           let%bind.Deferred.Result () =
-            let weight = User_command.weight command in
-            return
-            @@
-            if
-              Zeko_prover.Client.queue_size t.merger_ctx.provers + weight
-              > t.config.max_pool_size
-            then
-              Error
-                (Error.of_string "Maximum proof queue size reached, try later")
-            else Ok ()
+            if skip_validity_check then return (Ok ())
+            else
+              match calculate_fee t command with
+              | None ->
+                  return (Error (Error.of_string "Fee calculation overflow"))
+              | Some fee when Currency.Fee.(User_command.fee command < fee) ->
+                  return
+                    (Error
+                       (Error.of_string
+                          (Format.asprintf "Fee is too low, expected %s, got %s"
+                             (Currency.Fee.to_string fee)
+                             (Currency.Fee.to_string (User_command.fee command)) ) )
+                    )
+              | Some _ ->
+                  return (Ok ())
           in
-
-          (* TODO: Check if fee is sufficient *)
 
           (* the protocol state from sequencer has dummy values which wouldn't pass the txn snark *)
           let global_slot = Mina_numbers.Global_slot_since_genesis.zero in
@@ -668,7 +685,8 @@ module Sequencer = struct
 
   let create ~logger ~zkapp_pk ~max_pool_size ~commitment_period_sec ~da_config
       ~da_quorum ~db_dir ~postgres_uri ~l1_uri ~archive_uri ~signer
-      ~l1_network_id ~l2_network_id ~deposit_delay_blocks ~provers ~da_key =
+      ~l1_network_id ~l2_network_id ~deposit_delay_blocks ~provers ~da_key
+      ~fee_modifier ~minimum_fee =
     [%log info] "Precomputing srs" ;
     Pickles.Side_loaded.srs_precomputation () ;
     let ledger =
@@ -695,6 +713,8 @@ module Sequencer = struct
         ; network_id = l2_network_id
         ; deposit_delay_blocks
         ; da_key
+        ; fee_modifier
+        ; minimum_fee
         }
     in
     let%bind db_pool = Db.create_and_migrate ~postgres_uri ~logger in

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -280,17 +280,16 @@ module Sequencer = struct
                      } ) ) )
     |> Or_error.combine_errors |> Result.map ~f:ignore
 
-  (** weight * minimum_fee * e^(q * 0.1 * modifier) *)
-  let calculate_fee t command =
+  (** minimum_fee * e^(q * 0.1 * modifier) *)
+  let current_fee_per_weight_unit t =
     let jobs_in_queue =
       Zeko_prover.Client.queue_size t.merger_ctx.provers |> Float.of_int
     in
-    let weight = User_command.weight command |> Float.of_int in
-    weight *. t.config.minimum_fee
+    t.config.minimum_fee
     *. exp (jobs_in_queue *. 0.1 *. t.config.fee_modifier)
     (* convert to nanomina *)
     *. 10e8
-    |> Float.to_int |> Currency.Fee.of_nanomina_int
+    |> Float.to_int
 
   (** Apply user command to the sequencer's state, including the check of command validity *)
   let apply_user_command t ?(skip_validity_check = false)
@@ -304,19 +303,18 @@ module Sequencer = struct
           let%bind.Deferred.Result () =
             if skip_validity_check then return (Ok ())
             else
-              match calculate_fee t command with
-              | None ->
-                  return (Error (Error.of_string "Fee calculation overflow"))
-              | Some fee when Currency.Fee.(User_command.fee command < fee) ->
-                  return
-                    (Error
-                       (Error.of_string
-                          (Format.asprintf "Fee is too low, expected %s, got %s"
-                             (Currency.Fee.to_string fee)
-                             (Currency.Fee.to_string (User_command.fee command)) ) )
-                    )
-              | Some _ ->
-                  return (Ok ())
+              let weight = User_command.weight command in
+              let required_fee = weight * current_fee_per_weight_unit t in
+              let command_fee =
+                User_command.fee command |> Currency.Fee.to_nanomina_int
+              in
+              if command_fee < required_fee then
+                return
+                  (Error
+                     (Error.of_string
+                        (Format.asprintf "Fee is too low, expected %d, got %d"
+                           required_fee command_fee ) ) )
+              else return (Ok ())
           in
 
           (* the protocol state from sequencer has dummy values which wouldn't pass the txn snark *)

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -289,7 +289,6 @@ module Sequencer = struct
     *. exp (jobs_in_queue *. 0.1 *. t.config.fee_modifier)
     (* convert to nanomina *)
     *. 10e8
-    |> Float.to_int
 
   (** Apply user command to the sequencer's state, including the check of command validity *)
   let apply_user_command t ?(skip_validity_check = false)
@@ -303,17 +302,18 @@ module Sequencer = struct
           let%bind.Deferred.Result () =
             if skip_validity_check then return (Ok ())
             else
-              let weight = User_command.weight command in
-              let required_fee = weight * current_fee_per_weight_unit t in
+              let weight = User_command.weight command |> Float.of_int in
+              let required_fee = weight *. current_fee_per_weight_unit t in
               let command_fee =
                 User_command.fee command |> Currency.Fee.to_nanomina_int
+                |> Float.of_int
               in
-              if command_fee < required_fee then
+              if Float.(command_fee < required_fee) then
                 return
                   (Error
                      (Error.of_string
-                        (Format.asprintf "Fee is too low, expected %d, got %d"
-                           required_fee command_fee ) ) )
+                        (Format.asprintf "Fee is too low, expected %f, got %f"
+                           (required_fee /. 10e8) (command_fee /. 10e8) ) ) )
               else return (Ok ())
           in
 

--- a/src/app/zeko/sequencer/run.ml
+++ b/src/app/zeko/sequencer/run.ml
@@ -11,7 +11,8 @@ module Sequencer = Zeko_sequencer.Sequencer
 
 let run ~logger ~port ~zkapp_pk ~max_pool_size ~commitment_period ~da_config
     ~da_quorum ~db_dir ~postgres_uri ~l1_uri ~archive_uri ~signer ~l1_network_id
-    ~l2_network_id ~deposit_delay_blocks ~provers ~da_key () =
+    ~l2_network_id ~deposit_delay_blocks ~provers ~da_key ~fee_modifier
+    ~minimum_fee () =
   let zkapp_pk =
     Option.(
       value ~default:Signature_lib.Public_key.Compressed.empty
@@ -27,7 +28,7 @@ let run ~logger ~port ~zkapp_pk ~max_pool_size ~commitment_period ~da_config
             Signature_lib.(
               Keypair.of_private_key_exn
               @@ Private_key.of_base58_check_exn signer)
-          ~provers ~da_key )
+          ~provers ~da_key ~fee_modifier ~minimum_fee )
   in
 
   Sequencer.run_committer sequencer ;
@@ -98,6 +99,14 @@ let () =
        flag "--deposit-delay-blocks"
          (optional_with_default 5 int)
          ~doc:"int Number of blocks to wait before processing deposits"
+     and fee_modifier =
+       flag "--fee-modifier"
+         (optional_with_default 1.0 float)
+         ~doc:"float Fee modifier for the sequencer"
+     and minimum_fee =
+       flag "--minimum-fee"
+         (optional_with_default 0.01 float)
+         ~doc:"float Minimum fee for the sequencer"
      in
      let signer = Sys.getenv_exn "MINA_PRIVATE_KEY" in
      let da_config = Da_layer.Client.Config.of_string_list da_nodes in
@@ -117,5 +126,6 @@ let () =
      Stdout_log.setup log_json log_level ;
      run ~logger ~port ~zkapp_pk ~max_pool_size ~commitment_period ~da_config
        ~da_quorum ~db_dir ~postgres_uri ~l1_uri ~archive_uri ~signer
-       ~l1_network_id ~l2_network_id ~deposit_delay_blocks ~provers ~da_key )
+       ~l1_network_id ~l2_network_id ~deposit_delay_blocks ~provers ~da_key
+       ~fee_modifier ~minimum_fee )
   |> Command_unix.run

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -155,7 +155,7 @@ module Sequencer_test_spec = struct
             ~max_pool_size:10 ~commitment_period_sec:0. ~da_config ~da_quorum:2
             ~db_dir ~postgres_uri ~l1_uri:gql_uri ~archive_uri:gql_uri ~signer
             ~l1_network_id ~l2_network_id ~deposit_delay_blocks:delay_deposit
-            ~provers ~da_key )
+            ~provers ~da_key ~fee_modifier:1.0 ~minimum_fee:0.01 )
     in
 
     Quickcheck.Generator.return
@@ -326,6 +326,7 @@ let () =
                 ~da_quorum:2 ~db_dir:None ~postgres_uri:postgres_uri2
                 ~l1_uri:gql_uri ~archive_uri:gql_uri ~signer ~l1_network_id
                 ~l2_network_id ~deposit_delay_blocks:0 ~provers ~da_key
+                ~fee_modifier:1.0 ~minimum_fee:0.01
             in
             [%test_eq: Frozen_ledger_hash.t] (get_root new_sequencer)
               final_ledger_hash ;
@@ -457,7 +458,8 @@ let () =
                    [ "127.0.0.1:8555"; "127.0.0.1:8556"; "127.0.0.1:8557" ] )
               ~da_quorum:3 ~db_dir:(Some db_dir) ~postgres_uri ~l1_uri:gql_uri
               ~archive_uri:gql_uri ~signer ~l1_network_id ~l2_network_id
-              ~deposit_delay_blocks:0 ~provers ~da_key )
+              ~deposit_delay_blocks:0 ~provers ~da_key ~fee_modifier:1.0
+              ~minimum_fee:0.01 )
       in
 
       print_endline "(* Requeue witnesses and commit with quorum 3 *)" ;


### PR DESCRIPTION
Calculate transaction based on the size of proving queue using following exponential function

![formula](https://latex.codecogs.com/png.image?\dpi{120}%7B%5Ccolor%7BWhite%7D%5Cbegin%7Balign%7D%5Ctext%7Bfee%7D%28w%2Cq%29%20%3D%20w%20%5Ccdot%20b%20%5Ccdot%20e%5E%7B0.1%20%5Ccdot%20q%20%5Ccdot%20m%7D%20%5Cquad%20%5Ctext%7Bwhere%20%7Db%26%3A%3D%5Ctext%7Bminimum%20fee%2C%20%7D%20%5C%5C%20%0Am%26%3A%3D%5Ctext%7Bfee%20growth%20modifier%2C%7D%20%5C%5C%0Aw%26%3A%3D%5Ctext%7Bweight%20of%20command%2C%7D%20%5C%5C%0Aq%26%3A%3D%5Ctext%7Bnumber%20of%20jobs%20in%20queue%7D%5Cend%7Balign%7D%7D)

which has following graph with default modifier 1 and minimum fee 0.01
![image](https://github.com/user-attachments/assets/18a39ab1-6719-4b63-be7b-7d916d2e745b)

We can readjust parameters as we go.
#
Closes #281
Closes #280 
fix ZK-208