### PR TITLE
Move is_compile_simple_real out of compile_simple.mli

### DIFF
--- a/src/app/zeko/compile_simple/compile_simple.mli
+++ b/src/app/zeko/compile_simple/compile_simple.mli
@@ -49,12 +49,6 @@ val compile :
          and type out_var = 'out_var
          and type branches = ('first_input, 'branches) cons_branch )
 
-val is_compile_simple_real :
-  ( Proof.t * Verification_key.t
-  , Pickles.Side_loaded.Proof.t * Pickles.Side_loaded.Verification_key.t )
-  Base.Type_equal.t
-  option
-
 val add_plonk_constraint :
      label:string
   -> ( Snark_params.Tick.Field.Var.t

--- a/src/app/zeko/compile_simple/dune
+++ b/src/app/zeko/compile_simple/dune
@@ -14,5 +14,4 @@
  (modules
   compile_simple
   compile_simple_intf)
- (virtual_modules compile_simple)
- (default_implementation compile_simple_real))
+ (virtual_modules compile_simple))

--- a/src/app/zeko/compile_simple/fake/compile_simple.ml
+++ b/src/app/zeko/compile_simple/fake/compile_simple.ml
@@ -333,8 +333,6 @@ let compile (type out_t out_var first_input branches n_available_branches)
   in
   r
 
-let is_compile_simple_real = None
-
 (* FIXME: check constraint *)
 let add_plonk_constraint ~label c =
   assert_ ~label

--- a/src/app/zeko/compile_simple/real/compile_simple.ml
+++ b/src/app/zeko/compile_simple/real/compile_simple.ml
@@ -787,13 +787,6 @@ let compile (type out_t out_var first_input branches n_available_branches)
       in
       r
 
-let is_compile_simple_real :
-    ( Proof.t * Verification_key.t
-    , Pickles.Side_loaded.Proof.t * Pickles.Side_loaded.Verification_key.t )
-    Base.Type_equal.t
-    option =
-  Some T
-
 let add_plonk_constraint ~label c =
   ( match !bad_fixme_feature_flags with
   | None ->

--- a/src/app/zeko/compile_simple/real/compile_simple_real.ml
+++ b/src/app/zeko/compile_simple/real/compile_simple_real.ml
@@ -1,0 +1,5 @@
+let compile_simple_real :
+    ( Compile_simple.Proof.t * Compile_simple.Verification_key.t
+    , Pickles.Side_loaded.Proof.t * Pickles.Side_loaded.Verification_key.t )
+    Base.Type_equal.t =
+  Obj.magic Base.Type_equal.T

--- a/src/app/zeko/compile_simple/real/dune
+++ b/src/app/zeko/compile_simple/real/dune
@@ -3,7 +3,7 @@
   (flags (:standard -w @a-42-40-44-70-45-41))))
 
 (library
- (name compile_simple_real)
+ (name compile_simple_real_impl)
  (implements compile_simple)
  (libraries
   ;; opam libraries
@@ -13,7 +13,6 @@
   v
   random_oracle
   hash_prefix_states)
- (inline_tests)
  (instrumentation
   (backend bisect_ppx))
  (preprocess
@@ -25,3 +24,20 @@
    ppx_compare
    h_list.ppx))
  (modules compile_simple))
+
+(library
+ (name compile_simple_real)
+ (libraries
+  core_kernel
+  compile_simple_real_impl)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps
+   ppx_deriving.show
+   ppx_deriving_snarky
+   ppx_mina
+   ppx_jane
+   ppx_compare
+   h_list.ppx))
+ (modules compile_simple_real))

--- a/src/app/zeko/sequencer/dune
+++ b/src/app/zeko/sequencer/dune
@@ -1,8 +1,14 @@
+(library
+ (name is_compile_simple_real)
+ (libraries core_kernel compile_simple)
+ (modules is_compile_simple_real)
+ (virtual_modules is_compile_simple_real))
+
 (executable
  (name run)
  (libraries
   sequencer_lib
-  compile_simple_real
+  is_compile_simple_real_real
   ;; mina ;;
   init
   signature_lib
@@ -26,7 +32,7 @@
  (name run_fake)
  (libraries
   sequencer_lib
-  compile_simple_fake
+  is_compile_simple_real_fake
   ;; mina ;;
   init
   signature_lib
@@ -50,7 +56,7 @@
  (name deploy)
  (libraries
   sequencer_lib
-  compile_simple_real
+  is_compile_simple_real_real
   ;; mina ;;
   mina_base
   mina_numbers
@@ -84,7 +90,7 @@
  (name deploy_fake)
  (libraries
   sequencer_lib
-  compile_simple_fake
+  is_compile_simple_real_fake
   ;; mina ;;
   mina_base
   mina_numbers
@@ -118,7 +124,7 @@
  (name cli)
  (libraries
   sequencer_lib
-  compile_simple_fake
+  is_compile_simple_real_fake
   ;; mina ;;
   init
   signature_lib

--- a/src/app/zeko/sequencer/is_compile_simple_real.mli
+++ b/src/app/zeko/sequencer/is_compile_simple_real.mli
@@ -1,0 +1,5 @@
+val is_compile_simple_real :
+  ( Compile_simple.Proof.t * Compile_simple.Verification_key.t
+  , Pickles.Side_loaded.Proof.t * Pickles.Side_loaded.Verification_key.t )
+  Base.Type_equal.t
+  option

--- a/src/app/zeko/sequencer/is_compile_simple_real_fake/dune
+++ b/src/app/zeko/sequencer/is_compile_simple_real_fake/dune
@@ -1,0 +1,5 @@
+(library
+ (name is_compile_simple_real_fake)
+ (implements is_compile_simple_real)
+ (libraries compile_simple_fake)
+ (modules is_compile_simple_real))

--- a/src/app/zeko/sequencer/is_compile_simple_real_fake/is_compile_simple_real.ml
+++ b/src/app/zeko/sequencer/is_compile_simple_real_fake/is_compile_simple_real.ml
@@ -1,0 +1,1 @@
+let is_compile_simple_real = None

--- a/src/app/zeko/sequencer/is_compile_simple_real_real/dune
+++ b/src/app/zeko/sequencer/is_compile_simple_real_real/dune
@@ -1,0 +1,5 @@
+(library
+ (name is_compile_simple_real_real)
+ (implements is_compile_simple_real)
+ (libraries compile_simple_real)
+ (modules is_compile_simple_real))

--- a/src/app/zeko/sequencer/is_compile_simple_real_real/is_compile_simple_real.ml
+++ b/src/app/zeko/sequencer/is_compile_simple_real_real/is_compile_simple_real.ml
@@ -1,0 +1,6 @@
+let is_compile_simple_real :
+    ( Compile_simple.Proof.t * Compile_simple.Verification_key.t
+    , Pickles.Side_loaded.Proof.t * Pickles.Side_loaded.Verification_key.t )
+    Base.Type_equal.t
+    option =
+  Some Compile_simple_real.compile_simple_real

--- a/src/app/zeko/sequencer/lib/committer.ml
+++ b/src/app/zeko/sequencer/lib/committer.ml
@@ -122,7 +122,7 @@ let prove_commit ~provers ~(executor : Executor.t) ~(archive : Archive.t)
         ~da_key:(Even_PC.create_exn da_key)
     in
     (* see #286 *)
-    match Compile_simple.is_compile_simple_real with
+    match Is_compile_simple_real.is_compile_simple_real with
     | Some eq ->
         let proof_eq, _ = Type_equal.detuple2 eq in
         let account_update : Account_update.t =

--- a/src/app/zeko/sequencer/lib/deploy.ml
+++ b/src/app/zeko/sequencer/lib/deploy.ml
@@ -55,7 +55,7 @@ module Z = struct
         ; permissions =
             { ( if
                 (* see #286 *)
-                Option.is_some Compile_simple.is_compile_simple_real
+                Option.is_some Is_compile_simple_real.is_compile_simple_real
               then proof_permissions
               else none_permissions )
               with
@@ -70,7 +70,7 @@ module Z = struct
               ; verification_key =
                   Some
                     (Verification_key_wire.Stable.Latest.M.of_binable
-                       ( match Compile_simple.is_compile_simple_real with
+                       ( match Is_compile_simple_real.is_compile_simple_real with
                        | Some eq ->
                            let _, vk_eq = Type_equal.detuple2 eq in
                            Type_equal.conv vk_eq vk
@@ -107,7 +107,7 @@ module Z = struct
         ; verification_key =
             Set
               (Verification_key_wire.Stable.Latest.M.of_binable
-                 ( match Compile_simple.is_compile_simple_real with
+                 ( match Is_compile_simple_real.is_compile_simple_real with
                  | Some eq ->
                      let _, vk_eq = Type_equal.detuple2 eq in
                      Type_equal.conv vk_eq vk
@@ -117,7 +117,7 @@ module Z = struct
             Set
               ( if
                 (* see #286 *)
-                Option.is_some Compile_simple.is_compile_simple_real
+                Option.is_some Is_compile_simple_real.is_compile_simple_real
               then proof_permissions
               else none_permissions )
         }

--- a/src/app/zeko/sequencer/lib/dune
+++ b/src/app/zeko/sequencer/lib/dune
@@ -2,6 +2,7 @@
  (name sequencer_lib)
  (inline_tests)
  (libraries
+  is_compile_simple_real
   kvdb_base
   da_layer
   zeko_prover

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -488,7 +488,7 @@ module Sequencer = struct
                 : C.Ase.With_length.Stmt.t )
         in
         (* see #286 *)
-        match Compile_simple.is_compile_simple_real with
+        match Is_compile_simple_real.is_compile_simple_real with
         | Some eq ->
             let proof_eq, _ = Type_equal.detuple2 eq in
             let account_update : Account_update.t =

--- a/src/app/zeko/sequencer/prover/dune
+++ b/src/app/zeko/sequencer/prover/dune
@@ -8,7 +8,8 @@
   signature_lib
   ;; opam ;;
   async
-  core_unix.command_unix)
+  core_unix.command_unix
+  is_compile_simple_real_real)
  (preprocess
   (pps ppx_jane ppx_mina))
  (modules cli))
@@ -17,7 +18,7 @@
  (name cli_fake)
  (libraries
   zeko_prover
-  compile_simple_fake
+  is_compile_simple_real_fake
   ;; mina ;;
   mina_base
   cli_lib

--- a/src/app/zeko/sequencer/tests/dune
+++ b/src/app/zeko/sequencer/tests/dune
@@ -1,20 +1,20 @@
 (executable
  (name sequencer_test)
- (libraries sequencer_lib)
+ (libraries sequencer_lib is_compile_simple_real_real)
  (preprocess
   (pps ppx_let ppx_jane ppx_mina))
  (modules sequencer_test))
 
 (executable
  (name sequencer_test_fake)
- (libraries sequencer_lib compile_simple_fake)
+ (libraries sequencer_lib is_compile_simple_real_fake)
  (preprocess
   (pps ppx_let ppx_jane ppx_mina))
  (modules sequencer_test_fake))
 
 (executable
  (name relational_db_test)
- (libraries sequencer_lib)
+ (libraries sequencer_lib is_compile_simple_real_real)
  (preprocess
   (pps ppx_let ppx_jane ppx_mina))
  (modules relational_db_test))

--- a/src/app/zeko/sequencer/tests/testing_ledger/dune
+++ b/src/app/zeko/sequencer/tests/testing_ledger/dune
@@ -2,6 +2,7 @@
  (name run)
  (libraries
   sequencer_lib
+  is_compile_simple_real_real
   ;; opam ;;
   core_unix.command_unix)
  (preprocess


### PR DESCRIPTION
What we really wanted originally is an extra public module for the real implementation, which has now been done correctly, but unfortunately using Obj.magic because of lack of direct support from dune. 