### PR TITLE
Minor Code Cleanup: Typo Fixes in Comments and Error Messages

### DIFF
--- a/src/lib/consensus/proof_of_stake_fuzzer.ml
+++ b/src/lib/consensus/proof_of_stake_fuzzer.ml
@@ -18,7 +18,7 @@ let rec fold_until_none ~init ~f =
   | Some init' ->
       fold_until_none ~init:init' ~f
 
-(* TODO: optimize epoch ledgers? (many duplcate copies right now *)
+(* TODO: optimize epoch ledgers? (many duplicate copies right now *)
 module Staker = struct
   type t =
     { keypair : Keypair.And_compressed_pk.t; local_state : Local_state.t }

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -1052,7 +1052,7 @@ module Mutations = struct
           in
           let%bind.Result () =
             let open Currency.Fee in
-            Result.ok_if_true ~error:"Maximum fee less than mininum fee"
+            Result.ok_if_true ~error:"Maximum fee less than minimum fee"
               (payment_details.max_fee >= payment_details.min_fee)
           in
           let logger = Mina_lib.top_level_logger mina in


### PR DESCRIPTION


Description:  
This pull request makes minor improvements to the codebase by correcting typos in comments and error messages. Specifically:
- Fixed the spelling of "duplicate" in a comment within `proof_of_stake_fuzzer.ml`.
- Fixed the spelling of "minimum" in an error message within `mina_graphql.ml`.

These changes are purely cosmetic and do not affect the functionality of the code.
