### PR TITLE
Fix real sideloaded proofs verification in fake compile_simple

### DIFF
--- a/src/app/zeko/compile_simple/fake/compile_simple.ml
+++ b/src/app/zeko/compile_simple/fake/compile_simple.ml
@@ -125,8 +125,6 @@ module Proof_valid = struct
 
   type t = bool t_
 
-  let return x = Immediate x
-
   let immediate x = Immediate x
 
   let to_promise : 'a t_ -> 'a Promise.t = function
@@ -135,22 +133,12 @@ module Proof_valid = struct
     | Sideloaded dv ->
         dv
 
-  let bind (m : 'a t_) ~(f : 'a -> 'b t_) : 'b t_ =
+  let map (m : 'a t_) ~(f : 'a -> 'b) : 'b t_ =
     match m with
     | Immediate v ->
-        f v
+        Immediate (f v)
     | Sideloaded dv ->
-        Sideloaded (Promise.bind dv ~f:(fun v -> to_promise (f v)))
-
-  include Monad.Make (struct
-    type nonrec 'a t = 'a t_
-
-    let return = return
-
-    let bind = bind
-
-    let map = `Define_using_bind
-  end)
+        Sideloaded (Promise.map dv ~f)
 
   let ( &&& ) (a : t) (b : t) =
     match (a, b) with

--- a/src/app/zeko/compile_simple/fake/compile_simple.ml
+++ b/src/app/zeko/compile_simple/fake/compile_simple.ml
@@ -120,11 +120,56 @@ let match_tag_prev : 'var tag -> 'var prev -> bool As_prover.t =
         let open Field in
         equal circuit_hash circuit_hash' && equal out_hash out_hash' )
 
+module Proof_valid = struct
+  type 'a t_ = Immediate of 'a | Sideloaded of 'a Promise.t
+
+  type t = bool t_
+
+  let return x = Immediate x
+
+  let immediate x = Immediate x
+
+  let to_promise : 'a t_ -> 'a Promise.t = function
+    | Immediate v ->
+        Promise.return v
+    | Sideloaded dv ->
+        dv
+
+  let bind (m : 'a t_) ~(f : 'a -> 'b t_) : 'b t_ =
+    match m with
+    | Immediate v ->
+        f v
+    | Sideloaded dv ->
+        Sideloaded (Promise.bind dv ~f:(fun v -> to_promise (f v)))
+
+  include Monad.Make (struct
+    type nonrec 'a t = 'a t_
+
+    let return = return
+
+    let bind = bind
+
+    let map = `Define_using_bind
+  end)
+
+  let ( &&& ) (a : t) (b : t) =
+    match (a, b) with
+    | Immediate x, Immediate y ->
+        Immediate (x && y)
+    | Immediate _, Sideloaded _
+    | Sideloaded _, Immediate _
+    | Sideloaded _, Sideloaded _ ->
+        let open Promise.Let_syntax in
+        Sideloaded
+          ( Promise.all [ to_promise a; to_promise b ]
+          >>| function [ x; y ] -> x && y | _ -> failwith "Unreachable" )
+end
+
 let match_sideloaded_tag_prev :
        'input
     -> ('var, 't, 'input) sideloaded_tag
     -> 'var prev_sideloaded
-    -> bool As_prover.t =
+    -> Proof_valid.t As_prover.t =
  fun input { typ = Typ typ; extract_vk; _ }
      { public_input; proof; proof_must_verify; vk } ->
   let open As_prover in
@@ -137,34 +182,36 @@ let match_sideloaded_tag_prev :
   read Verification_key.typ vk
   >>= fun vk ->
   As_prover.return
-    ( (not proof_must_verify)
-    ||
-    match (vk, proof, extract_vk input) with
-    | Real_vk vk, Real_proof proof, Real_vk vk' ->
-        Or_error.is_ok
-          ( Promise.block_on_async_exn
-          @@ fun () ->
-          Pickles.Side_loaded.verify_promise ~typ:(Typ typ)
-            [ (vk, public_input, proof) ] )
-        && Pickles.Side_loaded.Verification_key.equal vk vk'
-    | ( Fake_vk { circuit_hash }
-      , Fake_proof { circuit_hash = circuit_hash'; out_hash }
-      , Fake_vk { circuit_hash = circuit_hash'' } ) ->
-        let fields, _aux = typ.value_to_fields public_input in
-        let out_hash' =
-          Random_oracle.hash
-            ~init:(Hash_prefix_create.salt "fake proof hash")
-            fields
-        in
-        let open Field in
-        equal circuit_hash circuit_hash'
-        && equal circuit_hash circuit_hash''
-        && equal out_hash out_hash'
-    | Fake_vk _, Real_proof _, _
-    | Real_vk _, Fake_proof _, _
-    | Fake_vk _, _, Real_vk _
-    | Real_vk _, _, Fake_vk _ ->
-        false )
+    (Proof_valid.map
+       ~f:(fun proof_valid -> (not proof_must_verify) || proof_valid)
+       ( match (vk, proof, extract_vk input) with
+       | Real_vk vk, Real_proof proof, Real_vk vk' ->
+           let open Promise.Let_syntax in
+           Proof_valid.Sideloaded
+             ( Pickles.Side_loaded.verify_promise ~typ:(Typ typ)
+                 [ (vk, public_input, proof) ]
+             >>| fun proof_valid ->
+             Or_error.is_ok proof_valid
+             && Pickles.Side_loaded.Verification_key.equal vk vk' )
+       | ( Fake_vk { circuit_hash }
+         , Fake_proof { circuit_hash = circuit_hash'; out_hash }
+         , Fake_vk { circuit_hash = circuit_hash'' } ) ->
+           let fields, _aux = typ.value_to_fields public_input in
+           let out_hash' =
+             Random_oracle.hash
+               ~init:(Hash_prefix_create.salt "fake proof hash")
+               fields
+           in
+           let open Field in
+           Immediate
+             ( equal circuit_hash circuit_hash'
+             && equal circuit_hash circuit_hash''
+             && equal out_hash out_hash' )
+       | Fake_vk _, Real_proof _, _
+       | Real_vk _, Fake_proof _, _
+       | Fake_vk _, _, Real_vk _
+       | Real_vk _, _, Fake_vk _ ->
+           Immediate false ) )
 
 let match_tags_prevs :
       'self_var 'prevs 'input.
@@ -172,44 +219,48 @@ let match_tags_prevs :
       -> 'self_var tag
       -> ('self_var, 'prevs, 'input) tags
       -> 'prevs prevs
-      -> bool As_prover.t =
+      -> Proof_valid.t As_prover.t =
   fun (type self_var prevs_ input) (input : input) (self_tag : self_var tag)
       (tags : (self_var, prevs_, input) tags) (prevs : prevs_ prevs) :
-      bool As_prover.t ->
+      Proof_valid.t As_prover.t ->
    match (tags, prevs) with
    | No_tags, No_prevs ->
-       As_prover.return true
+       As_prover.return (Proof_valid.immediate true)
    | One_tag tag, One_prev prev ->
-       match_tag_prev tag prev
+       match_tag_prev tag prev |> As_prover.map ~f:Proof_valid.immediate
    | One_tag_own, One_prev prev ->
-       match_tag_prev self_tag prev
+       match_tag_prev self_tag prev |> As_prover.map ~f:Proof_valid.immediate
    | One_tag_sideloaded tag, One_prev_sideloaded prev ->
        match_sideloaded_tag_prev input tag prev
    | Two_tags (tag0, tag1), Two_prevs (prev0, prev1) ->
        As_prover.map2 ~f:( && )
          (match_tag_prev tag0 prev0)
          (match_tag_prev tag1 prev1)
+       |> As_prover.map ~f:Proof_valid.immediate
    | Two_tags_one_own tag1, Two_prevs (prev0, prev1) ->
        As_prover.map2 ~f:( && )
          (match_tag_prev self_tag prev0)
          (match_tag_prev tag1 prev1)
+       |> As_prover.map ~f:Proof_valid.immediate
    | ( Two_tags_one_sideloaded (tag0, tag1)
      , Two_prevs_one_sideloaded (prev0, prev1) ) ->
-       As_prover.map2 ~f:( && )
+       As_prover.map2 ~f:Proof_valid.( &&& )
          (match_sideloaded_tag_prev input tag0 prev0)
-         (match_tag_prev tag1 prev1)
+         (match_tag_prev tag1 prev1 |> As_prover.map ~f:Proof_valid.immediate)
    | Two_tags_own, Two_prevs (prev0, prev1) ->
        As_prover.map2 ~f:( && )
          (match_tag_prev self_tag prev0)
          (match_tag_prev self_tag prev1)
+       |> As_prover.map ~f:Proof_valid.immediate
    | Two_tags_sideloaded (tag0, tag1), Two_prevs_sideloaded (prev0, prev1) ->
-       As_prover.map2 ~f:( && )
+       As_prover.map2 ~f:Proof_valid.( &&& )
          (match_sideloaded_tag_prev input tag0 prev0)
          (match_sideloaded_tag_prev input tag1 prev1)
    | Two_tags_sideloaded_own tag0, Two_prevs_one_sideloaded (prev0, prev1) ->
-       As_prover.map2 ~f:( && )
+       As_prover.map2 ~f:Proof_valid.( &&& )
          (match_sideloaded_tag_prev input tag0 prev0)
-         (match_tag_prev self_tag prev1)
+         ( match_tag_prev self_tag prev1
+         |> As_prover.map ~f:Proof_valid.immediate )
 
 let branches_to_provers name tag out_typ =
   let rec go :
@@ -230,11 +281,13 @@ let branches_to_provers name tag out_typ =
             >>= fun recursion_valid ->
             read out_typ out >>= fun out -> return (recursion_valid, out)
           in
+          let open Promise.Let_syntax in
+          let%map recursion_valid = Proof_valid.to_promise recursion_valid in
           if not recursion_valid then
             failwith "compile_simple [fake]: recursive proof invalid" ;
           printf "Fake proving %s.%s done\n" name branch_name ;
           let fake_proof = make_fake_proof tag out_typ out in
-          Promise.return (out, fake_proof)
+          (out, fake_proof)
         in
         prover :: go rest
     | [] ->

--- a/src/app/zeko/sequencer/tests/dune
+++ b/src/app/zeko/sequencer/tests/dune
@@ -1,13 +1,13 @@
 (executable
  (name sequencer_test)
- (libraries sequencer_lib is_compile_simple_real_real)
+ (libraries sequencer_lib is_compile_simple_real_real initialize_state)
  (preprocess
   (pps ppx_let ppx_jane ppx_mina))
  (modules sequencer_test))
 
 (executable
  (name sequencer_test_fake)
- (libraries sequencer_lib is_compile_simple_real_fake)
+ (libraries sequencer_lib is_compile_simple_real_fake initialize_state)
  (preprocess
   (pps ppx_let ppx_jane ppx_mina))
  (modules sequencer_test_fake))

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -49,6 +49,7 @@ module Sequencer_test_spec = struct
           (* Transaction specs *)
     ; sequencer : Sequencer.t
     ; da_key : Even_PC.t
+    ; accounts : Keypair.t list
     }
 
   let gen ?(delay_deposit = 0) ?db_dir ~postgres_uri () =
@@ -72,18 +73,23 @@ module Sequencer_test_spec = struct
       Mina_transaction_logic.For_tests.Test_spec.mk_gen
         ~num_transactions:number_of_transactions ()
     in
+    let funded_accounts =
+      Array.init 10 ~f:(fun _ ->
+          (Keypair.create (), Int64.of_float (1000. *. 1e8)) )
+    in
 
     let initial_inner_account = run Deploy.Z.Inner.initial_account in
     let genesis_accounts =
       (Zeko_constants.inner_account_id, initial_inner_account)
-      :: ( Array.map init_ledger ~f:(fun (keypair, balance) ->
-               let pk = Signature_lib.Public_key.compress keypair.public_key in
-               let account_id = Account_id.create pk Token_id.default in
-               let balance = Unsigned.UInt64.of_int64 balance in
-               let account =
-                 Account.create account_id (Currency.Balance.of_uint64 balance)
-               in
-               (account_id, account) )
+      :: ( Array.concat [ init_ledger; funded_accounts ]
+         |> Array.map ~f:(fun (keypair, balance) ->
+                let pk = Signature_lib.Public_key.compress keypair.public_key in
+                let account_id = Account_id.create pk Token_id.default in
+                let balance = Unsigned.UInt64.of_int64 balance in
+                let account =
+                  Account.create account_id (Currency.Balance.of_uint64 balance)
+                in
+                (account_id, account) )
          |> Array.to_list )
     in
 
@@ -159,7 +165,14 @@ module Sequencer_test_spec = struct
     in
 
     Quickcheck.Generator.return
-      { zkapp_keypair; signer; ephemeral_ledger; specs; sequencer; da_key }
+      { zkapp_keypair
+      ; signer
+      ; ephemeral_ledger
+      ; specs
+      ; sequencer
+      ; da_key
+      ; accounts = Array.map funded_accounts ~f:fst |> Array.to_list
+      }
 end
 
 let () =
@@ -176,31 +189,70 @@ let () =
 
   Quickcheck.test ~trials:1
     (Sequencer_test_spec.gen ~postgres_uri:postgres_uri1 ())
-    ~f:(fun { zkapp_keypair; signer; specs; sequencer; da_key; _ } ->
-      let batch1, batch2 = List.split_n specs 3 in
+    ~f:(fun { zkapp_keypair; signer; specs; sequencer; da_key; accounts; _ } ->
+      let commands =
+        List.mapi specs ~f:(fun i spec ->
+            if i % 2 = 0 then
+              User_command.Zkapp_command
+                (Mina_transaction_logic.For_tests.account_update_send
+                   ~chain:l2_signature_kind spec )
+            else
+              Signed_command
+                (Mina_transaction_logic.For_tests.command_send
+                   ~chain:l2_signature_kind spec ) )
+      in
+      let zkapp_command_with_real_proof =
+        let fee_signer = List.hd_exn accounts in
+        let account_creation_fee =
+          Account_update.
+            { body =
+                { Account_update.Body.dummy with
+                  public_key = Public_key.compress fee_signer.public_key
+                ; balance_change =
+                    Currency.Amount.Signed.of_fee @@ Currency.Fee.Signed.negate
+                    @@ Currency.Fee.Signed.of_unsigned
+                         constraint_constants.account_creation_fee
+                ; authorization_kind = Signature
+                ; use_full_commitment = true
+                }
+            ; authorization = Signature Signature.dummy
+            }
+        in
+        let open Initialize_state.Test_module in
+        (* First one is the inner account *)
+        let call_forest =
+          Zkapp_command.Call_forest.cons account_creation_fee
+          @@ Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+          @@ Zkapp_command.Call_forest.cons_tree
+               Initialize_account_update.account_update
+          @@ Zkapp_command.Call_forest.cons_tree
+               Update_state_account_update.account_update []
+        in
+        User_command.Zkapp_command
+          (Utils.sign_zkapp_command ~signature_kind:l2_signature_kind
+             Zkapp_command.
+               { fee_payer =
+                   { body =
+                       { Account_update.Body.Fee_payer.dummy with
+                         public_key = Public_key.compress fee_signer.public_key
+                       ; fee = Currency.Fee.of_mina_int_exn 1
+                       }
+                   ; authorization = Signature.dummy
+                   }
+               ; account_updates = call_forest
+               ; memo = Signed_command_memo.empty
+               }
+             [ fee_signer; Keypair.of_private_key_exn sk ] )
+      in
+      let batch1, batch2 = List.split_n commands 3 in
+      let batch1 = zkapp_command_with_real_proof :: batch1 in
 
       print_endline "(* Apply first batch *)" ;
       let () =
         run (fun () ->
             let%bind () =
-              Deferred.List.iteri batch1 ~f:(fun i spec ->
-                  let%bind result =
-                    match i % 2 = 0 with
-                    | true ->
-                        let command =
-                          Mina_transaction_logic.For_tests.account_update_send
-                            ~chain:l2_signature_kind spec
-                        in
-                        printf "Applying zkapp command\n%!" ;
-                        apply_user_command sequencer (Zkapp_command command)
-                    | false ->
-                        let command =
-                          Mina_transaction_logic.For_tests.command_send
-                            ~chain:l2_signature_kind spec
-                        in
-                        printf "Applying signed command\n%!" ;
-                        apply_user_command sequencer (Signed_command command)
-                  in
+              Deferred.List.iter batch1 ~f:(fun command ->
+                  let%bind result = apply_user_command sequencer command in
                   let witnesses =
                     match result with
                     | Ok result ->
@@ -248,25 +300,8 @@ let () =
       print_endline "(* Apply second batch *)" ;
       run (fun () ->
           let%bind () =
-            Deferred.List.iteri batch2 ~f:(fun i spec ->
-                let%bind result =
-                  match i % 2 = 0 with
-                  | true ->
-                      let command =
-                        Mina_transaction_logic.For_tests.account_update_send
-                          ~chain:l2_signature_kind spec
-                      in
-                      printf "Applying zkapp command\n%!" ;
-                      apply_user_command sequencer (Zkapp_command command)
-                  | false ->
-                      let command =
-                        Mina_transaction_logic.For_tests.command_send
-                          ~chain:l2_signature_kind spec
-                      in
-                      printf "Applying signed command\n%!" ;
-                      apply_user_command sequencer (Signed_command command)
-                in
-
+            Deferred.List.iter batch2 ~f:(fun command ->
+                let%bind result = apply_user_command sequencer command in
                 let witnesses =
                   match result with
                   | Ok result ->
@@ -274,7 +309,6 @@ let () =
                   | Error e ->
                       Error.raise e
                 in
-
                 match%map
                   Deferred.List.map ~how:`Sequential witnesses
                     ~f:(fun witness ->
@@ -399,27 +433,22 @@ let () =
   in
   Quickcheck.test ~trials:1 (Sequencer_test_spec.gen ~db_dir ~postgres_uri ())
     ~f:(fun { zkapp_keypair; signer; specs; sequencer; da_key; _ } ->
+      let commands =
+        List.mapi specs ~f:(fun i spec ->
+            if i % 2 = 0 then
+              User_command.Zkapp_command
+                (Mina_transaction_logic.For_tests.account_update_send
+                   ~chain:l2_signature_kind spec )
+            else
+              Signed_command
+                (Mina_transaction_logic.For_tests.command_send
+                   ~chain:l2_signature_kind spec ) )
+      in
       let () =
         run (fun () ->
             let%bind () =
-              Deferred.List.iteri specs ~f:(fun i spec ->
-                  let%bind result =
-                    match i % 2 = 0 with
-                    | true ->
-                        let command =
-                          Mina_transaction_logic.For_tests.account_update_send
-                            ~chain:l2_signature_kind spec
-                        in
-                        printf "Applying zkapp command\n%!" ;
-                        apply_user_command sequencer (Zkapp_command command)
-                    | false ->
-                        let command =
-                          Mina_transaction_logic.For_tests.command_send
-                            ~chain:l2_signature_kind spec
-                        in
-                        printf "Applying signed command\n%!" ;
-                        apply_user_command sequencer (Signed_command command)
-                  in
+              Deferred.List.iter commands ~f:(fun command ->
+                  let%bind result = apply_user_command sequencer command in
                   let witnesses =
                     match result with
                     | Ok result ->
@@ -509,31 +538,26 @@ let () =
   in
   Quickcheck.test ~trials:1 (Sequencer_test_spec.gen ~db_dir ~postgres_uri ())
     ~f:(fun { zkapp_keypair; signer; specs; sequencer; da_key; _ } ->
-      let batch1, batch2 = List.split_n specs 3 in
+      let commands =
+        List.mapi specs ~f:(fun i spec ->
+            if i % 2 = 0 then
+              User_command.Zkapp_command
+                (Mina_transaction_logic.For_tests.account_update_send
+                   ~chain:l2_signature_kind spec )
+            else
+              Signed_command
+                (Mina_transaction_logic.For_tests.command_send
+                   ~chain:l2_signature_kind spec ) )
+      in
+      let batch1, batch2 = List.split_n commands 3 in
       let initial_ledger_hash = get_root sequencer in
 
       print_endline "(* Apply first batch *)" ;
       let () =
         run (fun () ->
             let%bind () =
-              Deferred.List.iteri batch1 ~f:(fun i spec ->
-                  let%bind result =
-                    match i % 2 = 0 with
-                    | true ->
-                        let command =
-                          Mina_transaction_logic.For_tests.account_update_send
-                            ~chain:l2_signature_kind spec
-                        in
-                        printf "Applying zkapp command\n%!" ;
-                        apply_user_command sequencer (Zkapp_command command)
-                    | false ->
-                        let command =
-                          Mina_transaction_logic.For_tests.command_send
-                            ~chain:l2_signature_kind spec
-                        in
-                        printf "Applying signed command\n%!" ;
-                        apply_user_command sequencer (Signed_command command)
-                  in
+              Deferred.List.iter batch1 ~f:(fun command ->
+                  let%bind result = apply_user_command sequencer command in
                   let witnesses =
                     match result with
                     | Ok result ->
@@ -566,25 +590,8 @@ let () =
       print_endline "(* Apply second batch *)" ;
       run (fun () ->
           let%bind () =
-            Deferred.List.iteri batch2 ~f:(fun i spec ->
-                let%bind result =
-                  match i % 2 = 0 with
-                  | true ->
-                      let command =
-                        Mina_transaction_logic.For_tests.account_update_send
-                          ~chain:l2_signature_kind spec
-                      in
-                      printf "Applying zkapp command\n%!" ;
-                      apply_user_command sequencer (Zkapp_command command)
-                  | false ->
-                      let command =
-                        Mina_transaction_logic.For_tests.command_send
-                          ~chain:l2_signature_kind spec
-                      in
-                      printf "Applying signed command\n%!" ;
-                      apply_user_command sequencer (Signed_command command)
-                in
-
+            Deferred.List.iter batch2 ~f:(fun command ->
+                let%bind result = apply_user_command sequencer command in
                 let witnesses =
                   match result with
                   | Ok result ->
@@ -592,7 +599,6 @@ let () =
                   | Error e ->
                       Error.raise e
                 in
-
                 match%map
                   Deferred.List.map ~how:`Sequential witnesses
                     ~f:(fun witness ->

--- a/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
+++ b/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
@@ -9,291 +9,289 @@ module Local_state = Mina_state.Local_state
 module Zkapp_command_segment = Transaction_snark.Zkapp_command_segment
 module Statement = Transaction_snark.Statement
 
-let%test_module "Initialize state test" =
-  ( module struct
-    let () = Base.Backtrace.elide := false
+module Test_module = struct
+  let () = Base.Backtrace.elide := false
 
-    let sk = Private_key.create ()
+  let sk = Private_key.create ()
 
-    let pk = Public_key.of_private_key_exn sk
+  let pk = Public_key.of_private_key_exn sk
 
-    let pk_compressed = Public_key.compress pk
+  let pk_compressed = Public_key.compress pk
 
-    let account_id = Account_id.create pk_compressed Token_id.default
+  let account_id = Account_id.create pk_compressed Token_id.default
 
-    let ( tag
-        , _
-        , p_module
-        , Pickles.Provers.[ initialize_prover; update_state_prover ] ) =
-      Zkapps_examples.compile () ~cache:Cache_dir.cache
-        ~auxiliary_typ:Impl.Typ.unit
-        ~branches:(module Nat.N2)
-        ~max_proofs_verified:(module Nat.N0)
-        ~name:"empty_update"
-        ~constraint_constants:
-          (Genesis_constants.Constraint_constants.to_snark_keys_header
-             constraint_constants )
-        ~choices:(fun ~self:_ ->
-          [ Zkapps_initialize_state.initialize_rule pk_compressed
-          ; Zkapps_initialize_state.update_state_rule pk_compressed
-          ] )
+  let ( tag
+      , _
+      , p_module
+      , Pickles.Provers.[ initialize_prover; update_state_prover ] ) =
+    Zkapps_examples.compile () ~cache:Cache_dir.cache
+      ~auxiliary_typ:Impl.Typ.unit
+      ~branches:(module Nat.N2)
+      ~max_proofs_verified:(module Nat.N0)
+      ~name:"empty_update"
+      ~constraint_constants:
+        (Genesis_constants.Constraint_constants.to_snark_keys_header
+           constraint_constants )
+      ~choices:(fun ~self:_ ->
+        [ Zkapps_initialize_state.initialize_rule pk_compressed
+        ; Zkapps_initialize_state.update_state_rule pk_compressed
+        ] )
 
-    module P = (val p_module)
+  module P = (val p_module)
 
-    let vk =
-      Async.Thread_safe.block_on_async_exn (fun () ->
-          Pickles.Side_loaded.Verification_key.of_compiled tag )
+  let vk =
+    Async.Thread_safe.block_on_async_exn (fun () ->
+        Pickles.Side_loaded.Verification_key.of_compiled tag )
 
-    module Deploy_account_update = struct
-      let account_update_body : Account_update.Body.t =
-        { Account_update.Body.dummy with
-          public_key = pk_compressed
-        ; update =
-            { Account_update.Update.dummy with
-              verification_key =
-                Set
-                  { data = vk
-                  ; hash =
-                      (* TODO: This function should live in
-                         [Side_loaded_verification_key].
-                      *)
-                      Zkapp_account.digest_vk vk
-                  }
-            ; permissions =
-                Set
-                  { edit_state = Proof
-                  ; send = Proof
-                  ; receive = Proof
-                  ; access = None
-                  ; set_delegate = Proof
-                  ; set_permissions = Proof
-                  ; set_verification_key =
-                      (Proof, Mina_numbers.Txn_version.current)
-                  ; set_zkapp_uri = Proof
-                  ; edit_action_state = Proof
-                  ; set_token_symbol = Proof
-                  ; increment_nonce = Proof
-                  ; set_voting_for = Proof
-                  ; set_timing = Proof
-                  }
-            }
-        ; use_full_commitment = true
-        ; preconditions =
-            { Account_update.Preconditions.network =
-                Zkapp_precondition.Protocol_state.accept
-            ; account = Zkapp_precondition.Account.accept
-            ; valid_while = Ignore
-            }
-        ; authorization_kind = Signature
-        }
-
-      let account_update : Account_update.t =
-        (* TODO: This is a pain. *)
-        { body = account_update_body
-        ; authorization = Signature Signature.dummy
-        }
-    end
-
-    module Initialize_account_update = struct
-      let account_update, () =
-        Async.Thread_safe.block_on_async_exn initialize_prover
-    end
-
-    module Update_state_account_update = struct
-      let new_state = List.init 8 ~f:(fun _ -> Snark_params.Tick.Field.one)
-
-      let account_update, () =
-        Async.Thread_safe.block_on_async_exn
-          (update_state_prover
-             ~handler:(Zkapps_initialize_state.update_state_handler new_state) )
-    end
-
-    let test_zkapp_command ?expected_failure zkapp_command =
-      let memo = Signed_command_memo.empty in
-      let transaction_commitment : Zkapp_command.Transaction_commitment.t =
-        (* TODO: This is a pain. *)
-        let account_updates_hash =
-          Zkapp_command.Call_forest.hash zkapp_command
-        in
-        Zkapp_command.Transaction_commitment.create ~account_updates_hash
-      in
-      let fee_payer : Account_update.Fee_payer.t =
-        { body =
-            { Account_update.Body.Fee_payer.dummy with
-              public_key = pk_compressed
-            ; fee = Currency.Fee.(of_nanomina_int_exn 100)
-            }
-        ; authorization = Signature.dummy
-        }
-      in
-      let memo_hash = Signed_command_memo.hash memo in
-      let full_commitment =
-        Zkapp_command.Transaction_commitment.create_complete
-          transaction_commitment ~memo_hash
-          ~fee_payer_hash:
-            (Zkapp_command.Call_forest.Digest.Account_update.create
-               (Account_update.of_fee_payer fee_payer) )
-      in
-      let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
-          Zkapp_command.t =
-        let fee_payer =
-          match fee_payer with
-          | { body = { public_key; _ }; _ }
-            when Public_key.Compressed.equal public_key pk_compressed ->
-              { fee_payer with
-                authorization =
-                  Schnorr.Chunked.sign sk
-                    (Random_oracle.Input.Chunked.field full_commitment)
-              }
-          | fee_payer ->
-              fee_payer
-        in
-        let account_updates =
-          Zkapp_command.Call_forest.map account_updates ~f:(function
-            | ({ body = { public_key; use_full_commitment; _ }
-               ; authorization = Signature _
-               } as account_update :
-                Account_update.t )
-              when Public_key.Compressed.equal public_key pk_compressed ->
-                let commitment =
-                  if use_full_commitment then full_commitment
-                  else transaction_commitment
-                in
-                { account_update with
-                  authorization =
-                    Signature
-                      (Schnorr.Chunked.sign sk
-                         (Random_oracle.Input.Chunked.field commitment) )
+  module Deploy_account_update = struct
+    let account_update_body : Account_update.Body.t =
+      { Account_update.Body.dummy with
+        public_key = pk_compressed
+      ; update =
+          { Account_update.Update.dummy with
+            verification_key =
+              Set
+                { data = vk
+                ; hash =
+                    (* TODO: This function should live in
+                       [Side_loaded_verification_key].
+                    *)
+                    Zkapp_account.digest_vk vk
                 }
-            | account_update ->
-                account_update )
+          ; permissions =
+              Set
+                { edit_state = Proof
+                ; send = Proof
+                ; receive = Proof
+                ; access = None
+                ; set_delegate = Proof
+                ; set_permissions = Proof
+                ; set_verification_key =
+                    (Proof, Mina_numbers.Txn_version.current)
+                ; set_zkapp_uri = Proof
+                ; edit_action_state = Proof
+                ; set_token_symbol = Proof
+                ; increment_nonce = Proof
+                ; set_voting_for = Proof
+                ; set_timing = Proof
+                }
+          }
+      ; use_full_commitment = true
+      ; preconditions =
+          { Account_update.Preconditions.network =
+              Zkapp_precondition.Protocol_state.accept
+          ; account = Zkapp_precondition.Account.accept
+          ; valid_while = Ignore
+          }
+      ; authorization_kind = Signature
+      ; implicit_account_creation_fee = false
+      }
+
+    let account_update : Account_update.t =
+      (* TODO: This is a pain. *)
+      { body = account_update_body; authorization = Signature Signature.dummy }
+  end
+
+  module Initialize_account_update = struct
+    let account_update, () =
+      Async.Thread_safe.block_on_async_exn initialize_prover
+  end
+
+  module Update_state_account_update = struct
+    let new_state = List.init 8 ~f:(fun _ -> Snark_params.Tick.Field.one)
+
+    let account_update, () =
+      Async.Thread_safe.block_on_async_exn
+        (update_state_prover
+           ~handler:(Zkapps_initialize_state.update_state_handler new_state) )
+  end
+
+  let test_zkapp_command ?expected_failure zkapp_command =
+    let memo = Signed_command_memo.empty in
+    let transaction_commitment : Zkapp_command.Transaction_commitment.t =
+      (* TODO: This is a pain. *)
+      let account_updates_hash = Zkapp_command.Call_forest.hash zkapp_command in
+      Zkapp_command.Transaction_commitment.create ~account_updates_hash
+    in
+    let fee_payer : Account_update.Fee_payer.t =
+      { body =
+          { Account_update.Body.Fee_payer.dummy with
+            public_key = pk_compressed
+          ; fee = Currency.Fee.(of_nanomina_int_exn 100)
+          }
+      ; authorization = Signature.dummy
+      }
+    in
+    let memo_hash = Signed_command_memo.hash memo in
+    let full_commitment =
+      Zkapp_command.Transaction_commitment.create_complete
+        transaction_commitment ~memo_hash
+        ~fee_payer_hash:
+          (Zkapp_command.Call_forest.Digest.Account_update.create
+             (Account_update.of_fee_payer fee_payer) )
+    in
+    let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
+        Zkapp_command.t =
+      let fee_payer =
+        match fee_payer with
+        | { body = { public_key; _ }; _ }
+          when Public_key.Compressed.equal public_key pk_compressed ->
+            { fee_payer with
+              authorization =
+                Schnorr.Chunked.sign sk
+                  (Random_oracle.Input.Chunked.field full_commitment)
+            }
+        | fee_payer ->
+            fee_payer
+      in
+      let account_updates =
+        Zkapp_command.Call_forest.map account_updates ~f:(function
+          | ({ body = { public_key; use_full_commitment; _ }
+             ; authorization = Signature _
+             } as account_update :
+              Account_update.t )
+            when Public_key.Compressed.equal public_key pk_compressed ->
+              let commitment =
+                if use_full_commitment then full_commitment
+                else transaction_commitment
+              in
+              { account_update with
+                authorization =
+                  Signature
+                    (Schnorr.Chunked.sign sk
+                       (Random_oracle.Input.Chunked.field commitment) )
+              }
+          | account_update ->
+              account_update )
+      in
+      { fee_payer; account_updates; memo }
+    in
+    let zkapp_command : Zkapp_command.t =
+      sign_all { fee_payer; account_updates = zkapp_command; memo }
+    in
+    Ledger.with_ledger ~depth:ledger_depth ~f:(fun ledger ->
+        let account =
+          Account.create account_id
+            Currency.Balance.(
+              Option.value_exn
+                (add_amount zero (Currency.Amount.of_nanomina_int_exn 500)))
         in
-        { fee_payer; account_updates; memo }
-      in
-      let zkapp_command : Zkapp_command.t =
-        sign_all { fee_payer; account_updates = zkapp_command; memo }
-      in
-      Ledger.with_ledger ~depth:ledger_depth ~f:(fun ledger ->
-          let account =
-            Account.create account_id
-              Currency.Balance.(
-                Option.value_exn
-                  (add_amount zero (Currency.Amount.of_nanomina_int_exn 500)))
-          in
-          let _, loc =
-            Ledger.get_or_create_account ledger account_id account
-            |> Or_error.ok_exn
-          in
-          Async.Thread_safe.block_on_async_exn (fun () ->
-              check_zkapp_command_with_merges_exn ?expected_failure ledger
-                [ zkapp_command ] ) ;
-          Ledger.get ledger loc )
+        let _, loc =
+          Ledger.get_or_create_account ledger account_id account
+          |> Or_error.ok_exn
+        in
+        Async.Thread_safe.block_on_async_exn (fun () ->
+            check_zkapp_command_with_merges_exn ?expected_failure ledger
+              [ zkapp_command ] ) ;
+        Ledger.get ledger loc )
 
-    let%test_unit "Initialize" =
-      let account =
-        []
-        |> Zkapp_command.Call_forest.cons_tree
-             Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
-        |> test_zkapp_command
-      in
-      let zkapp_state =
-        (Option.value_exn (Option.value_exn account).zkapp).app_state
-      in
-      Pickles_types.Vector.iter
-        ~f:(fun x -> assert (Snark_params.Tick.Field.(equal zero) x))
-        zkapp_state
+  let%test_unit "Initialize" =
+    let account =
+      []
+      |> Zkapp_command.Call_forest.cons_tree
+           Initialize_account_update.account_update
+      |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+      |> test_zkapp_command
+    in
+    let zkapp_state =
+      (Option.value_exn (Option.value_exn account).zkapp).app_state
+    in
+    Pickles_types.Vector.iter
+      ~f:(fun x -> assert (Snark_params.Tick.Field.(equal zero) x))
+      zkapp_state
 
-    let%test_unit "Initialize and update" =
-      let account =
-        []
-        |> Zkapp_command.Call_forest.cons_tree
-             Update_state_account_update.account_update
-        |> Zkapp_command.Call_forest.cons_tree
-             Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
-        |> test_zkapp_command
-      in
-      let zkapp_state =
-        (Option.value_exn (Option.value_exn account).zkapp).app_state
-      in
-      Pickles_types.Vector.iter
-        ~f:(fun x -> assert (Snark_params.Tick.Field.(equal one) x))
-        zkapp_state
+  let%test_unit "Initialize and update" =
+    let account =
+      []
+      |> Zkapp_command.Call_forest.cons_tree
+           Update_state_account_update.account_update
+      |> Zkapp_command.Call_forest.cons_tree
+           Initialize_account_update.account_update
+      |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+      |> test_zkapp_command
+    in
+    let zkapp_state =
+      (Option.value_exn (Option.value_exn account).zkapp).app_state
+    in
+    Pickles_types.Vector.iter
+      ~f:(fun x -> assert (Snark_params.Tick.Field.(equal one) x))
+      zkapp_state
 
-    let%test_unit "Initialize and multiple update" =
-      let account =
-        []
-        |> Zkapp_command.Call_forest.cons_tree
-             Update_state_account_update.account_update
-        |> Zkapp_command.Call_forest.cons_tree
-             Update_state_account_update.account_update
-        |> Zkapp_command.Call_forest.cons_tree
-             Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
-        |> test_zkapp_command
-      in
-      let zkapp_state =
-        (Option.value_exn (Option.value_exn account).zkapp).app_state
-      in
-      Pickles_types.Vector.iter
-        ~f:(fun x -> assert (Snark_params.Tick.Field.(equal one) x))
-        zkapp_state
+  let%test_unit "Initialize and multiple update" =
+    let account =
+      []
+      |> Zkapp_command.Call_forest.cons_tree
+           Update_state_account_update.account_update
+      |> Zkapp_command.Call_forest.cons_tree
+           Update_state_account_update.account_update
+      |> Zkapp_command.Call_forest.cons_tree
+           Initialize_account_update.account_update
+      |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+      |> test_zkapp_command
+    in
+    let zkapp_state =
+      (Option.value_exn (Option.value_exn account).zkapp).app_state
+    in
+    Pickles_types.Vector.iter
+      ~f:(fun x -> assert (Snark_params.Tick.Field.(equal one) x))
+      zkapp_state
 
-    let%test_unit "Update without initialize fails" =
-      let account =
-        []
-        |> Zkapp_command.Call_forest.cons_tree
-             Update_state_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
-        |> test_zkapp_command
-             ~expected_failure:
-               (Account_proved_state_precondition_unsatisfied, Pass_2)
-      in
-      assert (Option.is_none (Option.value_exn account).zkapp)
+  let%test_unit "Update without initialize fails" =
+    let account =
+      []
+      |> Zkapp_command.Call_forest.cons_tree
+           Update_state_account_update.account_update
+      |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+      |> test_zkapp_command
+           ~expected_failure:
+             (Account_proved_state_precondition_unsatisfied, Pass_2)
+    in
+    assert (Option.is_none (Option.value_exn account).zkapp)
 
-    let%test_unit "Double initialize fails" =
-      let account =
-        []
-        |> Zkapp_command.Call_forest.cons_tree
-             Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons_tree
-             Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
-        |> test_zkapp_command
-             ~expected_failure:
-               (Account_proved_state_precondition_unsatisfied, Pass_2)
-      in
-      assert (Option.is_none (Option.value_exn account).zkapp)
+  let%test_unit "Double initialize fails" =
+    let account =
+      []
+      |> Zkapp_command.Call_forest.cons_tree
+           Initialize_account_update.account_update
+      |> Zkapp_command.Call_forest.cons_tree
+           Initialize_account_update.account_update
+      |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+      |> test_zkapp_command
+           ~expected_failure:
+             (Account_proved_state_precondition_unsatisfied, Pass_2)
+    in
+    assert (Option.is_none (Option.value_exn account).zkapp)
 
-    let%test_unit "Initialize after update fails" =
-      let account =
-        []
-        |> Zkapp_command.Call_forest.cons_tree
-             Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons_tree
-             Update_state_account_update.account_update
-        |> Zkapp_command.Call_forest.cons_tree
-             Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
-        |> test_zkapp_command
-             ~expected_failure:
-               (Account_proved_state_precondition_unsatisfied, Pass_2)
-      in
-      assert (Option.is_none (Option.value_exn account).zkapp)
+  let%test_unit "Initialize after update fails" =
+    let account =
+      []
+      |> Zkapp_command.Call_forest.cons_tree
+           Initialize_account_update.account_update
+      |> Zkapp_command.Call_forest.cons_tree
+           Update_state_account_update.account_update
+      |> Zkapp_command.Call_forest.cons_tree
+           Initialize_account_update.account_update
+      |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+      |> test_zkapp_command
+           ~expected_failure:
+             (Account_proved_state_precondition_unsatisfied, Pass_2)
+    in
+    assert (Option.is_none (Option.value_exn account).zkapp)
 
-    let%test_unit "Initialize without deploy fails" =
-      let account =
-        Or_error.try_with (fun () ->
-            (* Raises an exception due to verifying a proof without a valid vk
-               in the account.
-            *)
-            []
-            |> Zkapp_command.Call_forest.cons_tree
-                 Update_state_account_update.account_update
-            |> Zkapp_command.Call_forest.cons_tree
-                 Initialize_account_update.account_update
-            |> test_zkapp_command )
-      in
-      assert (Or_error.is_error account)
-  end )
+  let%test_unit "Initialize without deploy fails" =
+    let account =
+      Or_error.try_with (fun () ->
+          (* Raises an exception due to verifying a proof without a valid vk
+             in the account.
+          *)
+          []
+          |> Zkapp_command.Call_forest.cons_tree
+               Update_state_account_update.account_update
+          |> Zkapp_command.Call_forest.cons_tree
+               Initialize_account_update.account_update
+          |> test_zkapp_command )
+    in
+    assert (Or_error.is_error account)
+end
+
+let%test_module "Initialize state test" = (module Test_module)


### PR DESCRIPTION
Real sideloaded proof verification is calling block_on_async, which throws when called in async context.

fix ZK-267