### PR TITLE
Emergency commit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@
 - Action states are typed fields with optional length tracking (`rollup_state.ml`); inner app state stores the outer action state+length, outer app state stores the ledger hash, inner action state+length, sequencer key, pause key, DA multisig commitment, and account-set root.
 - Outer actions are either `Commit` (rollup step summary) or `Witness` (arbitrary action payload); inner actions are `Witness` only (`rollup_state.ml`).
 - `rule_commit.ml` verifies the transaction SNARK, DA multisig signatures over the target ledger hash, slot-range bounds, and action-state-extension proofs; it updates outer app state, emits a `Commit` action, and requires a sequencer signature as a child update.
+- `rule_commit.ml` has an emergency branch that verifies `Verify_emergency_folders` (Verify_both_ases + Count_commits), enforces a `max_sequencer_inactivity` gap, and allows commit without the sequencer precondition if no commits occurred since the last one.
 - `rule_action_witness.ml` posts a `Witness` action on L1 and forbids actions while paused; `rule_pause.ml` lets the pause key sign an update that sets `paused = true`.
 - `rule_inner_sync.ml` advances the inner account’s stored outer action state using an A.S.E. proof; `rule_inner_action_witness.ml` posts inner `Witness` actions.
 - `txn_rules.ml` builds the rollup transaction SNARK with branches for signed commands, zkapp commands (proved/unproved), and merge; the statement type is `Txn_state.Zeko_stmt`.
@@ -69,6 +70,7 @@
 - Zkapp action payloads are limited to ~100 field elements; large data should be compressed into hashes or split across transactions (emergency DA uses a single account per tx).
 - Action payload encoding is done via `zeko_util.var_to_actions`, which pushes a struct’s field elements into actions as data-as-hash.
 - Action-state extension proofs (A.S.E.) are built with `ase.ml` + `folder.ml`; these are the canonical way to prove action-state progression with bounded iterations.
+- Emergency commits rely on a counted-commit fold: `Count_commits` produces `{source_action_state; target_action_state; n_commits}` and the emergency rule requires `n_commits = 0` and that counting starts right after the last commit action.
 - Valid-while ranges are inclusive in Mina; commit rules enforce max window size and subset checks against transaction snark slot ranges.
 
 ## Mina zkApp model (transaction logic)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+# AGENTS.md
+
+## Repo overview
+- This is a fork of the Mina blockchain repository for the L2 project Zeko.
+- Zeko-specific code lives under `src/app/zeko`.
+- Changes to upstream Mina code are either prefixed with `zeko_` or marked by a `ZEKO NOTE` comment.
+
+## Key directories
+- `src/app/zeko/circuits`: zero-knowledge circuits for the rollup smart contract.
+- `src/app/zeko/circuits/design`: rollup and bridge design docs/specs (see notes below).
+- `src/app/zeko/da_layer`: multisig DA layer code.
+- `src/app/zeko/sequencer`: off-chain service that accepts transactions, proves them, sends to DA nodes, collects signatures, then submits to L1.
+- `src/app/zeko/sequencer/prover`: proving service used by the sequencer.
+
+## Build
+- Build the Zeko project with:
+  - `dune build ./src/app/zeko/sequencer`
+- The build can take longer than 10 seconds; prefer running with a longer timeout (e.g., 120s) in CI or local scripts.
+
+## Project language
+- OCaml (Dune build system).
+
+## Design docs (circuits)
+- Primary, current spec: `src/app/zeko/circuits/design/rollup-centralized-spec.md`.
+- `src/app/zeko/circuits/design/README.md` notes that other files may be out of date; treat `src/app/zeko/circuits/design/old` as historical context only.
+- Core rollup model: outer (L1) and inner (L2) accounts with action states; commits synchronize a prefix of the outer action state into the inner account; inner steps append to outer action state and advance its length.
+- Commit semantics: sequencer supplies a transaction SNARK and a `valid_while` range; commit action records ledger hash, inner action state, synchronized outer action state, and length; `valid_while` range must be bounded.
+- Rollup state includes `sequencer`, `pause_key`, `da_key`, and `acc_set`; pause is an emergency switch and can be updated via governance.
+- Transaction logic differences: failed transactions are not processed; time preconditions exist (currently unimplemented) and commits must use compatible slot ranges.
+- Bridge/token transfer (see `bridge-explanation.md`, `bridge-spec.md`): deposits are witnessed on the rollup outer account and finalized on L2 if followed by a commit before timeout; withdrawals are witnessed on L2 and finalized on L1 after a delay; helper accounts track last processed indices to prevent double spends; cancellations are handled via timeout and helper indices.
+- Bridge governance: may be separate from rollup governance; circuits can enforce vk hash matching across inner/outer bridge accounts; a failsafe design rotates multiple outer bank accounts to limit impact of a circuit bug.
+
+## Circuits (code concepts)
+- Action states are typed fields with optional length tracking (`rollup_state.ml`); inner app state stores the outer action state+length, outer app state stores the ledger hash, inner action state+length, sequencer key, pause key, DA multisig commitment, and account-set root.
+- Outer actions are either `Commit` (rollup step summary) or `Witness` (arbitrary action payload); inner actions are `Witness` only (`rollup_state.ml`).
+- `rule_commit.ml` verifies the transaction SNARK, DA multisig signatures over the target ledger hash, slot-range bounds, and action-state-extension proofs; it updates outer app state, emits a `Commit` action, and requires a sequencer signature as a child update.
+- `rule_action_witness.ml` posts a `Witness` action on L1 and forbids actions while paused; `rule_pause.ml` lets the pause key sign an update that sets `paused = true`.
+- `rule_inner_sync.ml` advances the inner account’s stored outer action state using an A.S.E. proof; `rule_inner_action_witness.ml` posts inner `Witness` actions.
+- `txn_rules.ml` builds the rollup transaction SNARK with branches for signed commands, zkapp commands (proved/unproved), and merge; the statement type is `Txn_state.Zeko_stmt`.
+- `txn_state.ml` defines the rollup SNARK statement, including source/target ledger hashes, account-set roots, slot ranges, and local zkapp state (must be empty at commit).
+- `ase.ml` implements action-state-extension folding circuits (with/without length) and is used by commit and inner sync to prove action-state progression.
+- `account_set.ml`/`indexed_merkle_tree.ml` implement the indexed merkle tree used for the account-set root recorded in the outer state.
+- `multisig.ml` defines DA-layer multisig checking; only the commitment hash is stored in the outer state (`da_key`).
+- Bridge circuits use `bridge_state.ml` for enable/disable window parameters and helper-user indices; `bridge_rules.ml` wires deposit/withdrawal/cancel/enable/disable rules for Mina and custom tokens.
+- `folder.ml`/`folder.mli` implement a generic recursive “state machine” folding circuit (leaf/extend/merge rules) used by action-state extension proofs; it folds arrays of elements with optional mid-proof selection and configurable iteration counts.
+
+## DA layer (code concepts)
+- Each DA node stores and signs diffs that deterministically transform a source ledger hash into a target ledger hash; signatures attest the node can reconstruct the target ledger.
+- `diff.ml` defines the DA diff format: source ledger hash, changed accounts (index + account), optional command with action-step flags, and a timestamp (V2 adds time; V1 is time-less).
+- `core.ml` validates a posted diff by checking source hash, DB presence/genesis, unique indices, and recomputed target hash; it also validates receipt-chain updates for included commands before signing the target hash and persisting the diff.
+- `rpc.ml` exposes Async.Rpc endpoints for posting diffs, fetching diffs, checking presence, listing keys, and fetching signatures/ledger-hash chains.
+- `node.ml` runs the server with a local KV DB, signs ledger hashes, supports syncing from other nodes, and can return the signature for a target hash.
+- `client.ml` provides RPC helpers with retry logic and (for sequencer usage) enforces ordered posting of diffs; it also includes optional relational DB tables for cached diffs/signatures.
+- `db.ml` is the KV storage for diffs plus an index and migration marker; `migrations.ml` handles version upgrades (e.g., adding the top-level version tag).
+
+## Sequencer (core flow)
+- `zeko_sequencer.ml` is the main orchestrator: it validates incoming user commands, applies them to the local ledger/IMT, queues proofs, posts DA diffs, and periodically commits to L1.
+- Transaction application uses `zeko_transaction_logic.ml`, which applies Mina signed payments and zkapp commands to the local ledger, updates the indexed merkle tree, and returns `Txn_snark_witness` segments plus a sparse source ledger for proof inputs.
+- Command validation checks pool capacity, minimum fee (dynamic based on prover queue size), slot-range bounds, and signature/proof validity via `verifier.ml` before applying to state.
+- Applied zkapp commands have events/actions persisted to the archive; fee accumulation is tracked in local KV state and periodically converted into a fee-transfer command.
+- DA integration: after applying a command, the sequencer builds a `Da_layer.Diff` from changed accounts and enqueues it to all DA nodes in order; commits use DA multisig signatures over the target ledger hash.
+- Proof generation uses a parallel merger (`Parallel_merger` via `zeko_sequencer.ml`) with three stages: `Base` creates per-transaction snarks, `Merge` combines two snarks into a larger proof, and `Commit` finalizes a batch into an L1 zkapp command.
+- `committer.ml` assembles the outer commit proof: it proves the txn snark, validates A.S.E. proofs, includes DA multisig witness, and constructs the rollup commit account update; it also persists commit witnesses for manual resend.
+- `update_inner_account` (in `zeko_sequencer.ml`) syncs L1 actions into the L2 inner account using an inner-sync proof, then applies a dummy-fee zkapp command locally to advance action state before committing.
+- `prover/lib/prover.ml` is the prover worker: it handles txn-snark branches (signed/zkapp/merge), folder/A.S.E. proofs, inner sync, and outer commit proofs; `prover/lib/client.ml` sends jobs via a message queue and caches A.S.E. proofs in Postgres.
+- `executor.ml` is the L1 sender: it signs zkapp commands, infers/refreshes nonce, retries on transient failures, and serializes submissions to avoid nonce races.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,3 +64,24 @@
 - `update_inner_account` (in `zeko_sequencer.ml`) syncs L1 actions into the L2 inner account using an inner-sync proof, then applies a dummy-fee zkapp command locally to advance action state before committing.
 - `prover/lib/prover.ml` is the prover worker: it handles txn-snark branches (signed/zkapp/merge), folder/A.S.E. proofs, inner sync, and outer commit proofs; `prover/lib/client.ml` sends jobs via a message queue and caches A.S.E. proofs in Postgres.
 - `executor.ml` is the L1 sender: it signs zkapp commands, infers/refreshes nonce, retries on transient failures, and serializes submissions to avoid nonce races.
+
+## Circuits (engineering knowhow)
+- Zkapp action payloads are limited to ~100 field elements; large data should be compressed into hashes or split across transactions (emergency DA uses a single account per tx).
+- Action payload encoding is done via `zeko_util.var_to_actions`, which pushes a struct’s field elements into actions as data-as-hash.
+- Action-state extension proofs (A.S.E.) are built with `ase.ml` + `folder.ml`; these are the canonical way to prove action-state progression with bounded iterations.
+- Valid-while ranges are inclusive in Mina; commit rules enforce max window size and subset checks against transaction snark slot ranges.
+
+## Mina zkApp model (transaction logic)
+- zkApp transactions are a call forest of account updates; execution walks the forest with a call stack, deriving `caller_id` based on `may_use_token` and parent relationships.
+- Each account update checks: account/ledger inclusion, account preconditions, protocol-state preconditions, valid-while range, and authorization (proof or signature) against the transaction commitment.
+- Transaction commitments are computed from the account-update call forest; `use_full_commitment` switches between transaction and full commitments for authorization and replay protection.
+- Permissions gate every field update (balance, app state, action state, permissions, delegate, nonce, voting-for, zkapp URI, verification key); updates are applied only when the corresponding permission controller authorizes.
+- Action state update logic pushes events into action slots and may shift slots; in Zeko this shift can be forced by the sequencer (no time-based shifting).
+- Receipt chain hashes are updated for account updates authorized by proof/signature, using the full transaction commitment and the account-update index.
+- Account creation fees are handled inside zkapp logic; they may be deducted from balance or from fee excess depending on flags.
+- Failed zkapp updates are disallowed on Zeko: local_state.success must hold for the last account update; failed transactions are rejected rather than partially applied.
+
+## Transaction SNARK structure
+- Transaction snarks support base proofs for signed commands and zkapp command segments, plus merge proofs that combine two proofs into one.
+- Zkapp command segments are categorized by authorization pattern: `Opt_signed`, `Opt_signed_opt_signed`, or `Proved`; proved segments require a side-loaded verification key.
+- The zkapp snark uses implied merkle roots from account+path to validate ledger inclusion and ensures consistent commitments across segments.

--- a/src/app/zeko/circuits/bridge_state.ml
+++ b/src/app/zeko/circuits/bridge_state.ml
@@ -319,10 +319,10 @@ let withdrawal_action (type withdrawal_params_var) ~chain_l2
         constant Account_update.May_use_token.typ Parents_own_token
     ; authorization_kind =
         (* FIXME: awful hack to get around the fact that in fake mode, we don't have a correct vk hash *)
-        ( match Sys.getenv_opt "ZEKO_CIRCUITS_CONFIG" with
-        | Some "test" ->
+        ( match Sys.getenv_opt "MODE" with
+        | Some "fake" ->
             constant Account_update.Authorization_kind.typ None_given
-        | _ ->
+        | Some "real" | _ ->
             { is_signed = Boolean.false_
             ; is_proved = Boolean.true_
             ; verification_key_hash = l2_holder_vk_hash

--- a/src/app/zeko/circuits/bridge_state.ml
+++ b/src/app/zeko/circuits/bridge_state.ml
@@ -318,10 +318,15 @@ let withdrawal_action (type withdrawal_params_var) ~chain_l2
     ; may_use_token =
         constant Account_update.May_use_token.typ Parents_own_token
     ; authorization_kind =
-        { is_signed = Boolean.false_
-        ; is_proved = Boolean.true_
-        ; verification_key_hash = l2_holder_vk_hash
-        }
+        (* FIXME: awful hack to get around the fact that in fake mode, we don't have a correct vk hash *)
+        ( match Sys.getenv_opt "ZEKO_CIRCUITS_CONFIG" with
+        | Some "test" ->
+            constant Account_update.Authorization_kind.typ None_given
+        | _ ->
+            { is_signed = Boolean.false_
+            ; is_proved = Boolean.true_
+            ; verification_key_hash = l2_holder_vk_hash
+            } )
     }
   in
   let a', (children : Calls.t) =

--- a/src/app/zeko/circuits/count_commits.ml
+++ b/src/app/zeko/circuits/count_commits.ml
@@ -1,0 +1,69 @@
+open Snark_params.Tick
+open Zeko_util
+
+module Definition = struct
+  module Stmt = struct
+    type t =
+      { source_action_state : Rollup_state.Outer_action_state.t
+      ; target_action_state : Rollup_state.Outer_action_state.t
+      ; n_commits : Checked32.t
+      }
+    [@@deriving snarky]
+  end
+
+  module Elem = Rollup_state.Outer_action
+
+  let dummy_elem =
+    Rollup_state.Outer_action.Witness
+      { aux = Field.zero
+      ; children_digest = Rollup_state.Zkapp_call_forest.Digest.empty
+      ; slot_range = Slot_range.infinite
+      }
+
+  module Init = struct
+    type t = { original_action_state : Rollup_state.Outer_action_state.t }
+    [@@deriving snarky]
+  end
+
+  let init ~check:_ ({ original_action_state } : Init.var) : Stmt.var Checked.t
+      =
+    Checked.return
+      ( { source_action_state = original_action_state
+        ; target_action_state = original_action_state
+        ; n_commits = Checked32.Checked.zero
+        }
+        : Stmt.var )
+
+  let step (action : Rollup_state.Outer_action.var)
+      ({ source_action_state; target_action_state; n_commits } : Stmt.var) =
+    let* target_action_state =
+      Rollup_state.Outer_action.push_var action target_action_state
+    in
+    let*| n_commits =
+      let* increment =
+        if_ ~typ:Checked32.typ action.is_commit
+          ~then_:Checked32.(Checked.constant one)
+          ~else_:Checked32.Checked.zero
+      in
+      Checked32.Checked.add n_commits increment
+    in
+    Stmt.{ source_action_state; target_action_state; n_commits }
+
+  let name = "count_commits"
+
+  let leaf_iterations =
+    Zeko_constants.Folder_iterations.Count_commits.leaf_iterations
+
+  let leaf_option_iterations =
+    Zeko_constants.Folder_iterations.Count_commits.leaf_option_iterations
+
+  let extend_iterations =
+    Zeko_constants.Folder_iterations.Count_commits.extend_iterations
+
+  let extend_option_iterations =
+    Zeko_constants.Folder_iterations.Count_commits.extend_option_iterations
+
+  let wrap_domain = Some `N14
+end
+
+include Folder.Make (Definition) ()

--- a/src/app/zeko/circuits/design/README.md
+++ b/src/app/zeko/circuits/design/README.md
@@ -1,8 +1,13 @@
 # Specs
 
-- (rollup-centralized-spec.md)[./rollup-centralized-spec.md]
+- [rollup-centralized-spec.md](./rollup-centralized-spec.md)
+- [rollup-centralized-explanation.md](./rollup-centralized-explanation.md)
+- [da-layer.md](./da-layer.md)
+- [prover.md](./prover.md)
+- [parallel-merger.md](./parallel-merger.md)
+- [sequencer.md](./sequencer.md)
 
-The other files are not up-to-date.
+Files in `old/` are historical and not up-to-date.
 
 Rough OCaml-y specs can be found in this directory.
 You are meant to read the account update generating functions

--- a/src/app/zeko/circuits/design/da-layer.md
+++ b/src/app/zeko/circuits/design/da-layer.md
@@ -1,0 +1,86 @@
+# DA layer (multisig) design
+
+This document describes the offchain data availability (DA) layer as used by
+Zeko. The DA layer is a committee of nodes that collectively attest to the
+availability of the ledger diffs that the sequencer applies.
+
+The core idea: each DA node only signs a ledger hash if it can reconstruct that
+ledger by applying a posted diff to a known source ledger hash. Signatures are
+collected by the sequencer and verified on L1 during normal commits.
+
+## Data model
+
+```ocaml
+type ledger_hash
+
+type diff =
+  { source_ledger_hash : ledger_hash
+  ; target_ledger_hash : ledger_hash
+  ; changed_accounts : (int * Account.t) list
+  ; command_with_action_step_flags : (User_command.t * bool list) option
+  ; time : int64 option
+  }
+```
+
+Notes:
+
+- `changed_accounts` is a sparse, index-addressed update list.
+- `command_with_action_step_flags` used for archival purposes, optional
+- `time` added by da node to indicate when the diff arrived
+
+## Node API (conceptual)
+
+```ocaml
+val post_diff : ledger_openings:Sparse_ledger.t -> diff -> Signature.t
+val get_diff : ledger_hash -> diff option
+```
+
+The production implementation uses Async.Rpc endpoints; the conceptual API
+matches the node semantics.
+
+## Node validation rules
+
+The core idea: provide sparse ledger that is already reconstructible, with openings to all the changed accounts.
+We provide those openings so that da node doesn't have to keep the whole ledger up to date in memory for every possible state.
+
+Given a `diff` and a `ledger_openings` witness for the source ledger:
+
+1. Check `ledger_openings.root = diff.source_ledger_hash`.
+2. Check `diff.source_ledger_hash` is known to the DB (or equals genesis).
+3. Check all indices in `changed_accounts` are unique.
+4. Apply each `(index, account)` to the sparse ledger openings to produce a
+   new ledger root, and assert it equals `diff.target_ledger_hash`.
+5. If `command_with_action_step_flags` is present, verify that updating receipt
+   chain hashes for the command matches the target ledger's receipt chain.
+6. Sign `diff.target_ledger_hash`.
+7. Store the diff under `diff.target_ledger_hash`.
+
+The receipt-chain check binds the diff to the transaction commitment history;
+it does not prove authorization (since transaction commitment excludes
+signatures), but it prevents signing a ledger hash that does not match the
+command's receipt-chain updates.
+
+## Sequencer-side client
+
+The sequencer posts diffs to all DA nodes and collects their signatures for a
+quorum. A strict ordering is required: a DA node will refuse a diff whose source
+ledger hash does not match its current known head. The sequencer therefore uses
+an ordered enqueueing client (`Da_layer.Client.Sequencer`) to serialize posting.
+
+At commit time, the sequencer requests signatures for the target ledger hash
+and includes the multisig witness in the L1 commit.
+
+## Availability and recovery
+
+DA nodes persist diffs keyed by `target_ledger_hash`. A new sequencer (or a
+restarted sequencer) can reconstruct ledger history by replaying diffs from DA
+nodes in order, starting from genesis or a known checkpoint.
+
+## Trust model
+
+- A DA node only signs if it can locally reconstruct the target ledger hash.
+- The L1 circuit only checks the multisig signature over the target ledger
+  hash, so the availability and integrity of the diff data is guaranteed by
+  the DA committee's signing policy.
+- Emergency mode (actions-based DA) bypasses the multisig by proving ledger
+  transitions directly in-circuit from per-account diffs.

--- a/src/app/zeko/circuits/design/parallel-merger.md
+++ b/src/app/zeko/circuits/design/parallel-merger.md
@@ -1,0 +1,92 @@
+# Parallel merger
+
+This document describes the parallel merger used by the sequencer to merge
+transaction SNARKs and to coordinate commits.
+
+## Abstraction
+
+The merger is a generic library that does not know about Zeko-specific logic.
+It is instantiated with four modules:
+
+```ocaml
+module Context : sig
+  type t
+end
+
+module Base : sig
+  type t
+  val process : Context.t -> t -> Merge.t Deferred.t
+end
+
+module Merge : sig
+  type t
+  val process : Context.t -> t -> t -> t Deferred.t
+end
+
+module Commit : sig
+  type t
+  type out
+  val process : Context.t -> t -> Merge.t -> out Deferred.t
+end
+```
+
+The sequencer supplies the real implementations (e.g., `Base.process` proves a
+transaction SNARK, `Merge.process` merges two proofs, and `Commit.process`
+constructs and submits the L1 commit).
+
+## Data structure
+
+A _forest_ of _trees_ tracks batches to be committed. Each tree is a list of
+jobs; only actionable jobs are kept in the list.
+
+```ocaml
+module Job_status = struct
+  type t = Todo of Available_job.t | Done of Merge.t
+end
+
+type tree =
+  { jobs : Job_status.t list
+  ; closed : bool
+  ; finished : Merge.t Ivar.t
+  ; ready_to_commit : unit Ivar.t
+  ; base_jobs : int
+  }
+```
+
+Two rules define the algorithm:
+
+1. If there is a `Todo` job, process it.
+2. If there are two adjacent `Done` jobs, merge them into a new `Todo Merge`.
+
+## Adding a base job
+
+When a base witness is added:
+
+1. Append a `Todo (Base witness)` job to the current tree.
+2. Run `Base.process` asynchronously.
+3. Mark the job as `Done` and check if a merge opportunity exists.
+4. If two adjacent `Done` jobs exist, create a new `Todo Merge` job and process
+   it; repeat until no merge opportunity remains.
+
+## Committing
+
+The sequencer can request a commit at any time:
+
+1. Close the current tree (no new jobs can be added to it).
+2. Create a new tree for subsequent base jobs.
+3. Wait for all earlier trees to finish (commit ordering).
+4. Wait for the closed tree to reduce to a single `Done` job.
+5. Call `Commit.process` with the commit witness and the final merged proof.
+
+## Persistence and restart
+
+`Parallel_merger.Persisted` wraps the in-memory merger with a DB-backed queue:
+
+- Each base witness is serialized to JSON and stored in a `parallel_merger`
+  table with its `tree_id`.
+- On restart, `create_and_requeue` loads stored witnesses and replays them into
+  the in-memory merger, merging them into a single tree.
+- After a successful commit, the corresponding tree is removed from the DB.
+
+This ensures that sequencer restarts do not lose proving progress and that
+commit ordering is preserved.

--- a/src/app/zeko/circuits/design/prover.md
+++ b/src/app/zeko/circuits/design/prover.md
@@ -1,0 +1,56 @@
+# Prover service and message queue
+
+This document describes the prover service used by the sequencer and how jobs
+flow through the message queue.
+
+## High-level flow
+
+- The sequencer produces witnesses for circuit proofs.
+- It sends a JSON-serialized request to the prover message queue.
+- A prover worker consumes the request, runs the corresponding circuit prover,
+  and replies with a JSON-serialized output.
+- The sequencer uses the output (proofs and/or account update call forests) to
+  advance the parallel merger and to construct commits.
+
+## Message queue
+
+The prover uses RabbitMQ (AMQP) via the `Message_queue` module.
+
+## Prover input/output
+
+The prover input is a JSON sum type that covers all supported witnesses.
+The output is a JSON sum type with corresponding variants. This is required
+because `yojson` does not support the GADT encoding of all variants.
+
+## Prover worker
+
+`Zeko_prover.Prover.run`:
+
+1. Compiles circuits on startup.
+2. Starts a message-queue worker.
+3. For each message, decodes JSON -> `Input.t`.
+4. Runs the corresponding prover.
+5. Encodes `Output.t` -> JSON and responds.
+
+Errors are caught and returned as `Output.Error` so the sequencer can retry or
+surface the failure.
+
+## Prover client
+
+`Zeko_prover.Client` wraps the message queue with retry logic:
+
+- Retries failed sends up to 5 times with 1s delay.
+- Tracks queue size (single-producer counter).
+- Supports priority jobs.
+
+It also optionally caches action-state-extension (ASE) proofs in Postgres:
+
+- `ase_cache_with_length` keyed by `(source_hash, target_hash)` plus length.
+- `ase_cache_without_length` keyed by `(source_hash, target_hash)`.
+
+This cache is an optimization only; the system remains correct without it.
+
+## Testing hooks
+
+The prover can be run with `--fake-proving-time` to simulate long proofs without
+spending CPU. This is used in fake/test setups.

--- a/src/app/zeko/circuits/design/rollup-centralized-explanation.md
+++ b/src/app/zeko/circuits/design/rollup-centralized-explanation.md
@@ -30,6 +30,10 @@ To that end, here is a summary of what we want from the core protocol:
   - Commit (sequencer committed)
 - There is a backup special committee that can pause the rollup.
   Being paused is indicated by a field on the outer account.
+- There is an emergency DA rule that allows committing without the DA multisig.
+  It proves, inside the circuit, that a sequence of account updates was applied
+  to transform a source ledger into a target ledger and that those updates were
+  posted as actions on a dedicated emergency DA account.
 
 How can we implement transfers of tokens on top of this?
 Consider the coremost MINA case:
@@ -138,6 +142,22 @@ the sequencer must maintain rolling commits over at least five slots
 within the max_sequencer_inactivity window. With a sufficiently
 large window (e.g., on the order of a month), this obligation is
 trivial for a healthy sequencer.
+
+### Emergency DA rule (actions-based DA)
+
+In emergency mode we replace the DA multisig check with an emergency DA proof.
+The rule applies a single account update to a sparse ledger opening and emits
+an action that contains:
+  - source ledger hash
+  - target ledger hash
+  - account index (derived from the ledger path)
+  - the updated account
+
+Because zkApp actions are limited in size, the emergency DA rule only supports
+one account update per transaction. We then fold a list of such actions with a
+folder proof to produce an action-state transition, and the emergency commit
+requires that the DA proof's source/target ledgers match the transaction SNARK.
+The emergency DA account's action state is used as an on-chain precondition.
 
 ## ZEKO token
 

--- a/src/app/zeko/circuits/design/rollup-centralized-explanation.md
+++ b/src/app/zeko/circuits/design/rollup-centralized-explanation.md
@@ -119,6 +119,30 @@ can profit from those deposits being processed.
 
 To prevent this from happening, we also specify a maximum size for the slot range.
 
+## Emergency commit
+
+When the sequencer goes offline, we need a way to unblock the system
+without decentralization of sequencing already in place.
+
+An emergency commit may be issued by anyone once enough time has
+passed since the upper bound of the last commit slot range.
+That upper bound witnesses the latest possible time a commit could
+have occurred; if the current slot is past it by a fixed margin,
+then no commit has happened since.
+
+Malicious sequencer can not pick a very large upper bound, since the slot range is capped by max_valid_size.
+
+However, we can only certify “no commit happened” relative to one of
+the last five outer action states. To make this check viable,
+the sequencer must maintain rolling commits over at least five slots
+within the max_sequencer_inactivity window. With a sufficiently
+large window (e.g., on the order of a month), this obligation is
+trivial for a healthy sequencer.
+
+In effect, the emergency commit seals the gap with a bounded slot
+range, restores liveness, and lets subsequent sequencers resume
+committing under the usual rules.
+
 ## ZEKO token
 
 The ZEKO token will use the

--- a/src/app/zeko/circuits/design/rollup-centralized-explanation.md
+++ b/src/app/zeko/circuits/design/rollup-centralized-explanation.md
@@ -139,10 +139,6 @@ within the max_sequencer_inactivity window. With a sufficiently
 large window (e.g., on the order of a month), this obligation is
 trivial for a healthy sequencer.
 
-In effect, the emergency commit seals the gap with a bounded slot
-range, restores liveness, and lets subsequent sequencers resume
-committing under the usual rules.
-
 ## ZEKO token
 
 The ZEKO token will use the

--- a/src/app/zeko/circuits/design/rollup-centralized-explanation.md
+++ b/src/app/zeko/circuits/design/rollup-centralized-explanation.md
@@ -10,6 +10,7 @@ It should be possible to have a stake in the rollup.
 And above all, it should be secure.
 
 To that end, here is a summary of what we want from the core protocol:
+
 - The core rollup protocol does not handle transfer of value/MINA.
 - There is an associated token called ZEKO, using the fungible
   token standard, minted on the L1.
@@ -25,8 +26,8 @@ To that end, here is a summary of what we want from the core protocol:
   to ensure that sequencer does not waste work synchronizing something that
   might be rolled back immediately.
 - Actions on the outside:
-  + Witness (witness arbitrary account update)
-  + Commit (sequencer committed)
+  - Witness (witness arbitrary account update)
+  - Commit (sequencer committed)
 - There is a backup special committee that can pause the rollup.
   Being paused is indicated by a field on the outer account.
 
@@ -42,6 +43,7 @@ of actions.
 Withdrawals happen correspondingly, the other way around.
 We also wish to support timeouts on deposits.
 We do this by regarding a deposit as having three states:
+
 - Unknown
 - Accepted
 - Rejected

--- a/src/app/zeko/circuits/design/rollup-centralized-spec.md
+++ b/src/app/zeko/circuits/design/rollup-centralized-spec.md
@@ -166,78 +166,37 @@ let do_emergency_commit
   ~last_commit
   ~actions_since_last_commit
   =
-  (* doesn't need to be at the same time as macroslot,
-     can be early or late depending on other factors *)
-  assert valid_while.upper - valid_while.lower < max_valid_while_size ;
-
-  (* The vk for the inner account ensures that the outer action state as recorded only goes forward. *)
-  let old_inner = get_account inner_pk txn_snark.source in
-  let new_inner = get_account inner_pk txn_snark.target in
-
-  let synchronized_outer_action_state = new_inner.app_state.outer_action_state in
-
-  (* The new actions must be the difference between old synchronized outer action state and new synchronized outer action state. *)
-  assert
-    List.append new_actions old_inner.app_state.outer_action_state
-    = synchronized_outer_action_state ;
-
-  let synchronized_outer_action_state_length =
-    List.length new_actions + old_inner.app_state.outer_action_state_length in
-
-  let action_state =
-    (* We don't force sequencer to match on latest action state,
-       since it's unreliable and might roll back. *)
-    List.append unsynchronized_actions synchronized_outer_action_state in
-
-  (* Emergency checks *)
-  let () =
-    let (target_action_state, n_commits) = count_commits
-      (List.append last_commit outer_action_state_before_last_commit)
-      actions_since_last_commit
-    in
-    (* Check that there has not been any commit after last commit *)
-    assert n_commits = 0 ;
-    assert target_action_state = action_state ;
-    assert valid_while.lower - last_commit.valid_while.upper >= max_sequencer_inactivity
+  let [ commit ] =
+    do_commit
+      ~txn_snark
+      ~valid_while
+      ~new_actions
+      ~new_inner_actions
+      ~old_inner_action_state_length
+      ~unsynchronized_actions
+      ~pause_key
+      ~da_key
   in
 
-  let ledger = txn_snark.target in
-  let inner_action_state = new_inner.action_state in
-  let inner_action_state_length = List.length new_inner_actions + old_inner_action_state_length in
+  (* Count commits since last commit *)
+  let (target_action_state, n_commits) = count_commits
+    (List.append last_commit outer_action_state_before_last_commit)
+    actions_since_last_commit
+  in
 
-  [ { public_key = zeko_pk
-    ; actions = Commit
-      { ledger
-      ; inner_action_state
-      ; inner_action_state_length
-      ; synchronized_outer_action_state
-      ; synchronized_outer_action_state_length
-      ; valid_while
-      }
-    ; app_state =
-      { ledger
-      ; inner_action_state
-      ; inner_action_state_length
-      ; sequencer
-      ; paused = false
-      ; pause_key
-      ; da_key
-      ; acc_set = txn_snark.target_acc_set
-      }
-    ; preconditions =
-      { app_state =
-        { ledger = txn_snark.source
-        ; inner_action_state = old_inner.action_state
-        ; inner_action_state_length = old_inner_action_state_length
-        (* ; sequencer *)
-        ; paused = false
-        ; pause_key
-        ; da_key
-        ; acc_set = txn_snark.source_acc_set
-        }
-      ; valid_while
-      ; action_state
-      }
+  (* Check that there has not been any commit after last commit *)
+  assert n_commits = 0 ;
+
+  (* Check that count_commits is matching the precondition *)
+  assert target_action_state = commit.preconditions.action_state ;
+
+  (* Check that enought time elapsed since last commit *)
+  assert commit.preconditions.valid_while.lower - last_commit.valid_while.upper >= max_sequencer_inactivity;
+
+  (* Remove sequencer preconditions *)
+  [ { commit with
+      children = []
+    ; preconditions.app_state.sequencer = Ignore
     }
   ]
 

--- a/src/app/zeko/circuits/design/rollup-centralized-spec.md
+++ b/src/app/zeko/circuits/design/rollup-centralized-spec.md
@@ -141,6 +141,106 @@ let do_commit
     }
   ]
 
+let count_commits original_action_state actions =
+  let f (acc_action_state, n) = function
+    | (Commit _) as action ->
+      List.append action acc_action_state, n + 1
+    | (Witness _) as action ->
+      List.append action acc_action_state, n
+  in
+  List.fold_left ~init:(original_action_state, 0) ~f actions
+
+val max_sequencer_inactivity : nat
+
+(* Emergency commit in case of sequencer's inactivity *)
+let do_emergency_commit
+  ~txn_snark
+  ~valid_while
+  ~new_actions
+  ~new_inner_actions
+  ~old_inner_action_state_length
+  ~unsynchronized_actions
+  ~pause_key
+  ~da_key
+  ~outer_action_state_before_last_commit
+  ~last_commit
+  ~actions_since_last_commit
+  =
+  (* doesn't need to be at the same time as macroslot,
+     can be early or late depending on other factors *)
+  assert valid_while.upper - valid_while.lower < max_valid_while_size ;
+
+  (* The vk for the inner account ensures that the outer action state as recorded only goes forward. *)
+  let old_inner = get_account inner_pk txn_snark.source in
+  let new_inner = get_account inner_pk txn_snark.target in
+
+  let synchronized_outer_action_state = new_inner.app_state.outer_action_state in
+
+  (* The new actions must be the difference between old synchronized outer action state and new synchronized outer action state. *)
+  assert
+    List.append new_actions old_inner.app_state.outer_action_state
+    = synchronized_outer_action_state ;
+
+  let synchronized_outer_action_state_length =
+    List.length new_actions + old_inner.app_state.outer_action_state_length in
+
+  let action_state =
+    (* We don't force sequencer to match on latest action state,
+       since it's unreliable and might roll back. *)
+    List.append unsynchronized_actions synchronized_outer_action_state in
+
+  (* Emergency checks *)
+  let () =
+    let (target_action_state, n_commits) = count_commits
+      (List.append last_commit outer_action_state_before_last_commit)
+      actions_since_last_commit
+    in
+    (* Check that there has not been any commit after last commit *)
+    assert n_commits = 0 ;
+    assert target_action_state = action_state ;
+    assert valid_while.lower - last_commit.valid_while.upper >= max_sequencer_inactivity
+  in
+
+  let ledger = txn_snark.target in
+  let inner_action_state = new_inner.action_state in
+  let inner_action_state_length = List.length new_inner_actions + old_inner_action_state_length in
+
+  [ { public_key = zeko_pk
+    ; actions = Commit
+      { ledger
+      ; inner_action_state
+      ; inner_action_state_length
+      ; synchronized_outer_action_state
+      ; synchronized_outer_action_state_length
+      ; valid_while
+      }
+    ; app_state =
+      { ledger
+      ; inner_action_state
+      ; inner_action_state_length
+      ; sequencer
+      ; paused = false
+      ; pause_key
+      ; da_key
+      ; acc_set = txn_snark.target_acc_set
+      }
+    ; preconditions =
+      { app_state =
+        { ledger = txn_snark.source
+        ; inner_action_state = old_inner.action_state
+        ; inner_action_state_length = old_inner_action_state_length
+        (* ; sequencer *)
+        ; paused = false
+        ; pause_key
+        ; da_key
+        ; acc_set = txn_snark.source_acc_set
+        }
+      ; valid_while
+      ; action_state
+      }
+    }
+  ]
+
 let do_witness_outer ~aux ~children ~valid_while =
   [ { public_key = zeko_pk
     ; actions = [ Witness { aux ; children ; valid_while } ]

--- a/src/app/zeko/circuits/design/rollup-centralized-spec.md
+++ b/src/app/zeko/circuits/design/rollup-centralized-spec.md
@@ -62,6 +62,16 @@ val max_valid_while_size : nat
 
 val zeko_token_owner : account_id
 
+(* Emergency DA account for action-based DA proofs. *)
+val emergency_da_pk : public_key
+
+type emergency_da_action =
+  { source_ledger : ledger_hash
+  ; target_ledger : ledger_hash
+  ; account_index : nat
+  ; account : account
+  }
+
 (* Commit work to L1. *)
 let do_commit
   ~txn_snark
@@ -141,6 +151,23 @@ let do_commit
     }
   ]
 
+(* Emergency DA rule: apply a single account update to a sparse ledger opening
+   and emit an action containing source/target ledger hashes, account index, and account. *)
+let do_emergency_da_step ~ledger_opening ~account_update =
+  let source_ledger = ledger_opening.root in
+  let target_ledger = apply_account ledger_opening account_update in
+  let account_index = index_from_path ledger_opening.path in
+  [ { public_key = emergency_da_pk
+    ; actions = [ emergency_da_action
+        { source_ledger
+        ; target_ledger
+        ; account_index
+        ; account = account_update
+        }
+      ]
+    }
+  ]
+
 let count_commits original_action_state actions =
   let f (acc_action_state, n) = function
     | (Commit _) as action ->
@@ -165,6 +192,7 @@ let do_emergency_commit
   ~outer_action_state_before_last_commit
   ~last_commit
   ~actions_since_last_commit
+  ~emergency_da_action_state
   =
   let [ commit ] =
     do_commit
@@ -193,10 +221,18 @@ let do_emergency_commit
   (* Check that enought time elapsed since last commit *)
   assert commit.preconditions.valid_while.lower - last_commit.valid_while.upper >= max_sequencer_inactivity;
 
+  (* Replace DA multisig with emergency DA action-state precondition. *)
+  assert emergency_da_action_state matches commit.preconditions.target_ledger ;
+
   (* Remove sequencer preconditions *)
   [ { commit with
       children = []
     ; preconditions.app_state.sequencer = Ignore
+    ; children =
+        [ { public_key = emergency_da_pk
+          ; preconditions.action_state = emergency_da_action_state
+          }
+        ]
     }
   ]
 

--- a/src/app/zeko/circuits/design/sequencer.md
+++ b/src/app/zeko/circuits/design/sequencer.md
@@ -1,0 +1,113 @@
+# Sequencer design
+
+This document describes the sequencer's offchain responsibilities and how it
+coordinates transaction application, proving, DA posting, and L1 commits.
+
+## Overview
+
+The sequencer is the single offchain orchestrator that:
+
+- Exposes a GraphQL API for transaction submission.
+- Applies user commands to the local ledger and indexed merkle tree (IMT) account set.
+- Posts account diffs to the DA layer and collects signatures.
+- Proves transaction SNARKs and merges them via the parallel merger.
+- Periodically produces L1 commit transactions.
+- Can recover from restarts by syncing from DA history.
+
+## Lifecycle of a transaction
+
+### 1. Intake and validation
+
+- Command arrives via GraphQL API.
+- The sequencer validates:
+  - pool capacity and minimum fee (dynamic)
+  - signatures / proofs (via verifier)
+  - valid-while slot range constraints
+- Invalid or failed commands are rejected (Zeko does not process failed
+  transactions).
+
+## Slot-range handling
+
+Each user command can include a valid-while slot range. The sequencer accepts
+transactions whose slot ranges are sufficiently far in the future, as measured
+by the `slot_acceptance` threshold. This ensures that there is enough time to
+batch, prove, and commit the transaction before its slot precondition expires.
+
+When a batch is committed, the commit uses the merged slot precondition across
+all transactions in that batch. As a result, the acceptance window is a safety
+buffer: transactions with tighter ranges would make the commit likely to fail
+or waste proving work. If the sequencer fails to commit within that window,
+the proving work for those transactions is wasted and the batch must be
+reconstructed with valid preconditions.
+
+### 2. Apply to local state
+
+`Zeko_transaction_logic.apply_user_command_unchecked` updates:
+
+- the local ledger database
+- the indexed merkle tree (account set)
+
+It returns:
+
+- a `Txn_snark_witness`, the witness for proving the transaction SNARK
+
+### 3. Post to DA layer
+
+From the applied command, the sequencer constructs a DA `diff`:
+
+- `(index, account)` changes
+- optional command with action-step flags for archive
+- source/target ledger hashes
+
+The diff is enqueued to DA nodes in strict order using
+`Da_layer.Client.Sequencer`. The sequencer later requests signatures for the
+current target ledger hash to satisfy the DA multisig requirement on commit.
+
+### 4. Queue proving job
+
+The transaction witness is added to the parallel merger as a `Base` job. The
+merger immediately starts proving and merging in the background. This produces
+merged proofs ready for commit.
+
+### 5. Periodic commit
+
+At each commitment period:
+
+- The sequencer may run `update_inner_account` to synchronize the inner account
+  with L1 actions (if there are new actions).
+- It requests the latest merged proof from the parallel merger.
+- It constructs the commit witness, including:
+  - transaction SNARK proof and statement
+  - action-state extension proofs (outer/inner)
+  - DA multisig signatures
+  - slot-range constraints
+- It proves the outer commit circuit and sends the resulting zkapp command to L1.
+
+If there is nothing to commit (e.g., only an inner sync happened), the commit
+step is skipped.
+
+## Recoverability and syncing from DA
+
+On startup, the sequencer attempts to reconstruct local state:
+
+1. It checks for existing ledger/IMT databases.
+2. If missing, it fetches current onchain
+   rollup state to determine the last committed ledger hash.
+   - it accounts also for transaction pool to prevent conflicts
+3. It calls `sync`, which:
+   - fetches the committed ledger hash from L1 (or commit in transaction pool)
+   - replays diffs from DA nodes in order
+   - applies each diff to the local ledger and IMT
+   - re-enqueues diffs locally (so the DA client has history to sync new da nodes)
+   - applies events/actions for zkapp commands
+4. It verifies that the reconstructed ledger hash matches the onchain committed
+   hash.
+
+This allows a new sequencer (or a restarted one) to resynchronize from DA
+history without requiring access to the previous sequencer's local state.
+
+## Commit recovery
+
+The sequencer persists commit witnesses so that failed L1 submissions can be
+retried manually via `cli.exe committer`. This avoids a stuck state if an L1
+transaction fails to be sent or accepted.

--- a/src/app/zeko/circuits/dune
+++ b/src/app/zeko/circuits/dune
@@ -28,6 +28,7 @@
    h_list.ppx))
  (modules
   bridge_rules
+  emergency_da_folder
   emergency_da_rules
   rule_emergency_da
   rule_bridge_enable

--- a/src/app/zeko/circuits/dune
+++ b/src/app/zeko/circuits/dune
@@ -37,6 +37,7 @@
   rule_bridge_outer_token_owner
   rule_change_permissions
   check_accepted_make
+  count_commits
   comparison_gadget
   bridge_state
   outer_rules

--- a/src/app/zeko/circuits/dune
+++ b/src/app/zeko/circuits/dune
@@ -28,6 +28,8 @@
    h_list.ppx))
  (modules
   bridge_rules
+  emergency_da_rules
+  rule_emergency_da
   rule_bridge_enable
   rule_bridge_disable
   rule_bridge_finalize_withdrawal

--- a/src/app/zeko/circuits/emergency_da_folder.ml
+++ b/src/app/zeko/circuits/emergency_da_folder.ml
@@ -69,7 +69,7 @@ module M = struct
 
   let name = "emergency da action fold"
 
-  let wrap_domain = Some `N14
+  let wrap_domain = Some `N15
 end
 
 include Folder.Make (M) ()

--- a/src/app/zeko/circuits/emergency_da_folder.ml
+++ b/src/app/zeko/circuits/emergency_da_folder.ml
@@ -1,0 +1,75 @@
+open Snark_params.Tick
+open Mina_base
+open Zeko_util
+
+module Stmt = struct
+  type t =
+    { source_ledger : Ledger_hash.t
+    ; target_ledger : Ledger_hash.t
+    ; target_action_state : F.t
+    }
+  [@@deriving snarky]
+end
+
+module Elem = struct
+  type t = { advance : Boolean.t; action : Rule_emergency_da.Action.t }
+  [@@deriving snarky]
+end
+
+module M = struct
+  module Elem = Elem
+
+  let dummy_elem : Elem.t =
+    { advance = false
+    ; action =
+        { source_ledger_hash = Ledger_hash.empty_hash
+        ; target_ledger_hash = Ledger_hash.empty_hash
+        ; ledger_index = Checked32.zero
+        ; account = Account.empty
+        }
+    }
+
+  module Stmt = Stmt
+  module Init = Stmt
+
+  let init ~check:_ (x : Init.var) = Checked.return x
+
+  let step (elem : Elem.var) (stmt : Stmt.var) =
+    let* eq =
+      Ledger_hash.equal_var stmt.target_ledger elem.action.source_ledger_hash
+    in
+    let* ok =
+      if_ elem.advance ~typ:Boolean.typ ~then_:eq ~else_:Boolean.true_
+    in
+    let@ () = with_label __LOC__ in
+    let* () = Boolean.Assert.is_true ok in
+    let* target_ledger =
+      if_ elem.advance ~typ:Ledger_hash.typ
+        ~then_:elem.action.target_ledger_hash ~else_:stmt.target_ledger
+    in
+    let* actions = var_to_actions Rule_emergency_da.Action.typ elem.action in
+    let* target_action_state =
+      make_checked (fun () ->
+          Zkapp_account.Actions.push_events_checked stmt.target_action_state
+            actions )
+    in
+    Checked.return { stmt with target_ledger; target_action_state }
+
+  let leaf_iterations =
+    Zeko_constants.Folder_iterations.Emergency_da.leaf_iterations
+
+  let leaf_option_iterations =
+    Zeko_constants.Folder_iterations.Emergency_da.leaf_option_iterations
+
+  let extend_iterations =
+    Zeko_constants.Folder_iterations.Emergency_da.extend_iterations
+
+  let extend_option_iterations =
+    Zeko_constants.Folder_iterations.Emergency_da.extend_option_iterations
+
+  let name = "emergency da action fold"
+
+  let wrap_domain = Some `N14
+end
+
+include Folder.Make (M) ()

--- a/src/app/zeko/circuits/emergency_da_folder.ml
+++ b/src/app/zeko/circuits/emergency_da_folder.ml
@@ -69,7 +69,7 @@ module M = struct
 
   let name = "emergency da action fold"
 
-  let wrap_domain = Some `N15
+  let wrap_domain = Some `N14
 end
 
 include Folder.Make (M) ()

--- a/src/app/zeko/circuits/emergency_da_rules.ml
+++ b/src/app/zeko/circuits/emergency_da_rules.ml
@@ -1,0 +1,14 @@
+module Make (Inputs : sig
+  val chain_l1 : Mina_signature_kind.t
+end)
+() =
+struct
+  module Rule_emergency_da_inst = Rule_emergency_da.Make (Inputs)
+
+  include
+    ( val Compile_simple.compile ()
+            ~out_typ:
+              Snark_params.Tick.Typ.(Mina_base.Zkapp_statement.typ * V.typ)
+            ~branches:[ Rule_emergency_da_inst.rule ]
+            ~name:"Emergency_da_rules" )
+end

--- a/src/app/zeko/circuits/outer_rules.ml
+++ b/src/app/zeko/circuits/outer_rules.ml
@@ -6,6 +6,8 @@ module Make (Inputs : sig
   val chain_l1 : Mina_signature_kind.t
 
   val max_sequencer_inactivity : int
+
+  val emergency_da_public_key : Signature_lib.Public_key.Compressed.t
 end)
 () =
 struct

--- a/src/app/zeko/circuits/outer_rules.ml
+++ b/src/app/zeko/circuits/outer_rules.ml
@@ -4,6 +4,8 @@ module Make (Inputs : sig
   val inner_public_key : Signature_lib.Public_key.Compressed.t
 
   val chain_l1 : Mina_signature_kind.t
+
+  val max_sequencer_inactivity : int
 end)
 () =
 struct
@@ -17,6 +19,7 @@ struct
               Snark_params.Tick.Typ.(Mina_base.Zkapp_statement.typ * V.typ)
             ~branches:
               [ Rule_commit_inst.rule
+              ; Rule_commit_inst.Emergency_commit.rule
               ; Rule_action_witness_inst.rule
               ; Rule_pause_inst.rule
               ]

--- a/src/app/zeko/circuits/rollup_state.ml
+++ b/src/app/zeko/circuits/rollup_state.ml
@@ -190,9 +190,42 @@ end
 
 module Outer_state = struct
   (* NB: change precondition code too if you change this *)
+  module Status_flags = struct
+    type t = { paused : bool; emergency : bool }
+
+    type var = F.var
+
+    let to_field { paused; emergency } =
+      let p = if paused then Field.one else Field.zero in
+      let e = if emergency then Field.of_int 2 else Field.zero in
+      Field.add p e
+
+    let typ =
+      let open Snark_params.Tick in
+      Typ.transport F.typ ~there:to_field ~back:(fun flags ->
+          let flag_int = Field.to_string flags |> Int.of_string in
+          let paused = Int.(flag_int land 1 = 1) in
+          let emergency = Int.(flag_int land 2 = 2) in
+          { paused; emergency } )
+
+    let of_bools ~paused ~emergency = { paused; emergency }
+
+    let of_bools_var ~paused ~emergency =
+      let one = Field.Var.constant Field.one in
+      let two = Field.Var.constant (Field.of_int 2) in
+      let zero = Field.Var.constant Field.zero in
+      let* p = Field.Checked.if_ paused ~then_:one ~else_:zero in
+      let* e = Field.Checked.if_ emergency ~then_:two ~else_:zero in
+      Checked.return Field.Checked.(p + e)
+
+    let paused (flags : t) = flags.paused
+
+    let emergency (flags : t) = flags.emergency
+  end
+
   type t =
     { pause_key : Even_PC.t
-    ; paused : Boolean.t
+    ; status_flags : Status_flags.t
     ; ledger_hash : Ledger_hash.t  (** The ledger hash of the rollup *)
     ; inner_action_state : Inner_action_state.With_length.t
     ; sequencer : Even_PC.t
@@ -203,7 +236,7 @@ module Outer_state = struct
 
   type fine =
     { pause_key : Even_PC.var option
-    ; paused : Boolean.var option
+    ; status_flags : Status_flags.var option
     ; ledger_hash : Ledger_hash.var option
     ; inner_action_state : Inner_action_state.With_length.fine
     ; sequencer : Even_PC.var option
@@ -216,7 +249,7 @@ module Outer_state = struct
   *)
   let _ = function
     | ({ pause_key = _
-       ; paused = _
+       ; status_flags = _
        ; ledger_hash = _
        ; inner_action_state = _
        ; sequencer = _
@@ -229,7 +262,7 @@ module Outer_state = struct
 
   let fine
       ({ pause_key
-       ; paused
+       ; status_flags
        ; ledger_hash
        ; inner_action_state
        ; sequencer
@@ -238,7 +271,7 @@ module Outer_state = struct
        } :
         fine ) : Fine.t =
     [ Whole (Even_PC.typ, pause_key)
-    ; Whole (Boolean.typ, paused)
+    ; Whole (Status_flags.typ, status_flags)
     ; Whole (Ledger_hash.typ, ledger_hash)
     ; Recursive (Inner_action_state.With_length.fine inner_action_state)
     ; Whole (Even_PC.typ, sequencer)

--- a/src/app/zeko/circuits/rule_action_witness.ml
+++ b/src/app/zeko/circuits/rule_action_witness.ml
@@ -21,6 +21,10 @@ struct
     in
     let* actions = Outer_action.witness_to_actions_var witness in
     let valid_while = Slot_range.Checked.to_valid_while witness.slot_range in
+    let* status_flags_precondition =
+      Outer_state.Status_flags.of_bools_var ~paused:Boolean.false_
+        ~emergency:Boolean.false_
+    in
     let account_update =
       { default_account_update with
         public_key
@@ -34,8 +38,8 @@ struct
                 state =
                   Outer_state.fine
                     { pause_key = None
-                    ; paused =
-                        Some Boolean.false_
+                    ; status_flags =
+                        Some status_flags_precondition
                         (* We don't allow adding actions if the rollup is paused since it signals something is wrong. *)
                     ; ledger_hash = None
                     ; inner_action_state = { length = None; state = None }

--- a/src/app/zeko/circuits/rule_bridge_finalize_cancelled_deposit.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_cancelled_deposit.ml
@@ -307,6 +307,10 @@ struct
               }
           }
         in
+        let* status_flags_precondition =
+          Rollup_state.Outer_state.Status_flags.of_bools_var
+            ~paused:Boolean.false_ ~emergency:Boolean.false_
+        in
         let witness_outer =
           { default_account_update with
             public_key = constant PC.typ zeko_l1
@@ -318,7 +322,7 @@ struct
                     state =
                       Rollup_state.Outer_state.fine
                         { pause_key = None
-                        ; paused = Some Boolean.false_ (* must not be paused *)
+                        ; status_flags = Some status_flags_precondition
                         ; ledger_hash = None
                         ; inner_action_state = { state = None; length = None }
                         ; sequencer = None

--- a/src/app/zeko/circuits/rule_bridge_finalize_withdrawal.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_withdrawal.ml
@@ -200,6 +200,10 @@ struct
             (constant Mina_numbers.Global_slot_span.typ withdrawal_delay)
         in
         let@ () = with_label __LOC__ in
+        let* status_flags_precondition =
+          Rollup_state.Outer_state.Status_flags.of_bools_var
+            ~paused:Boolean.false_ ~emergency:Boolean.false_
+        in
         let witness_outer =
           { default_account_update with
             public_key = constant PC.typ zeko_l1
@@ -211,7 +215,7 @@ struct
                     state =
                       Rollup_state.Outer_state.fine
                         { pause_key = None
-                        ; paused = Some Boolean.false_ (* must not be paused *)
+                        ; status_flags = Some status_flags_precondition
                         ; ledger_hash = None
                         ; inner_action_state = { state = None; length = None }
                         ; sequencer = None

--- a/src/app/zeko/circuits/rule_commit.ml
+++ b/src/app/zeko/circuits/rule_commit.ml
@@ -51,20 +51,27 @@ module Count_commits_inst = Count_commits.Make (struct
   let get_iterations = Zeko_constants.Max_excess_actions.Commit.count_commits
 end)
 
-(** Proves Ase_outer_inst, Ase_inner_inst, and Count_commits to circumvent limitation of two recursive proof verifications per proof. *)
+(** Used to verify emergency DA folder proof. *)
+module Emergency_da_inst = Emergency_da_folder.Make (struct
+  let get_iterations = Zeko_constants.Max_excess_actions.Commit.emergency_da
+end)
+
+(** Proves emergency folders (count commits + emergency DA). *)
 module Verify_emergency_folders = struct
-  let main (w : (Verify_both_ases.t * Count_commits_inst.t) V.t) =
-    let* verify_both_ases, count_commits =
+  let main (w : (Count_commits_inst.t * Emergency_da_inst.t) V.t) =
+    let* count_commits, emergency_da =
       exists ~compute:(V.get w)
-        Typ.(Verify_both_ases.typ * Count_commits_inst.typ)
+        Typ.(Count_commits_inst.typ * Emergency_da_inst.typ)
     in
-    let* both_ases, verify_both_ases = Verify_both_ases.get verify_both_ases in
-    let*| count_commits, verify_count_commits =
+    let* count_commits, verify_count_commits =
       Count_commits_inst.get count_commits
     in
+    let*| emergency_da, verify_emergency_da =
+      Emergency_da_inst.get emergency_da
+    in
     Compile_simple.
-      { prevs = Two_prevs (verify_both_ases, verify_count_commits)
-      ; out = (both_ases, count_commits)
+      { prevs = Two_prevs (verify_count_commits, verify_emergency_da)
+      ; out = (count_commits, emergency_da)
       }
 
   let rule : _ Compile_simple.branch lazy_t =
@@ -72,7 +79,7 @@ module Verify_emergency_folders = struct
       { branch_name = "Verify_emergency_folders"
       ; tags =
           Two_tags
-            (Lazy.force Verify_both_ases.tag, Lazy.force Count_commits.tag)
+            (Lazy.force Count_commits.tag, Lazy.force Emergency_da_folder.tag)
       ; main
       }
 
@@ -81,8 +88,37 @@ module Verify_emergency_folders = struct
             ~branches:[ rule ]
             ~out_typ:
               Typ.(
-                Ase_outer_inst.Stmt.typ * Ase_inner_inst.Stmt.typ
-                * Count_commits.Definition.Stmt.typ)
+                Count_commits.Definition.Stmt.typ * Emergency_da_folder.Stmt.typ)
+            () )
+end
+
+module Verify_base = struct
+  let main (w : (Txn_rules.t * Verify_both_ases.t) V.t) =
+    let* txn, verify_both_ases =
+      exists ~compute:(V.get w) Typ.(Txn_rules.typ * Verify_both_ases.typ)
+    in
+    let* txn_stmt, verify_txn = Txn_rules.get txn in
+    let*| both_ases, verify_both_ases = Verify_both_ases.get verify_both_ases in
+    let ase_outer, ase_inner = both_ases in
+    Compile_simple.
+      { prevs = Two_prevs (verify_txn, verify_both_ases)
+      ; out = (txn_stmt, (ase_outer, ase_inner))
+      }
+
+  let rule : _ Compile_simple.branch lazy_t =
+    lazy
+      { branch_name = "Verify_base"
+      ; tags =
+          Two_tags (Lazy.force Txn_rules.tag, Lazy.force Verify_both_ases.tag)
+      ; main
+      }
+
+  include
+    ( val Compile_simple.compile ~name:"Verify_base_wrappers" ~branches:[ rule ]
+            ~out_typ:
+              Typ.(
+                Txn_state.Zeko_stmt.typ
+                * (Ase_outer_inst.Stmt.typ * Ase_inner_inst.Stmt.typ))
             () )
 end
 
@@ -96,6 +132,8 @@ module Make (Inputs : sig
   val chain_l1 : Mina_signature_kind.t
 
   val max_sequencer_inactivity : int
+
+  val emergency_da_public_key : PC.t
 end) =
 struct
   open Inputs
@@ -114,8 +152,7 @@ struct
 
   module Base_witness = struct
     type t =
-      { txn_snark : Txn_rules.t  (** The ledger transition we are performing. *)
-      ; public_key : PC.t  (** Our public key on the L2 *)
+      { public_key : PC.t  (** Our public key on the L2 *)
       ; vk_hash : F.t  (** Our vk hash *)
       ; old_inner_acc : Account.t
       ; old_inner_acc_path : Path.t
@@ -129,7 +166,10 @@ struct
 
   module Witness = struct
     type t =
-      { base_witness : Base_witness.t; verify_both_ases : Verify_both_ases.t }
+      { txn_snark : Txn_rules.t
+      ; base_witness : Base_witness.t
+      ; verify_both_ases : Verify_both_ases.t
+      }
     [@@deriving snarky]
   end
 
@@ -154,13 +194,15 @@ struct
     in
     content
 
-  let main ?(check_sequencer_precondition = true) (w : Base_witness.var)
+  type da_mode = Multisig | Emergency of Emergency_da_folder.Stmt.var
+
+  let main ?(check_sequencer_precondition = true) ~da_mode
+      (w : Base_witness.var) (txn_stmt : Txn_state.Zeko_stmt.var)
       ((ase_outer, ase_inner) :
         Ase_outer_inst.Stmt.var * Ase_inner_inst.Stmt.var ) =
     with_label __LOC__
     @@ fun () ->
-    let ({ txn_snark
-         ; public_key
+    let ({ public_key
          ; vk_hash
          ; old_inner_acc
          ; old_inner_acc_path
@@ -178,19 +220,19 @@ struct
     let* implied_root_old = implied_root old_inner_acc old_inner_acc_path in
     let* implied_root_new = implied_root new_inner_acc new_inner_acc_path in
 
-    let* ( { source_ledger
-           ; target_ledger
-           ; source_local_state
-           ; target_local_state
-           ; sequencer
-           ; accumulated_fees
-           ; slot_range = txn_snark_slot_range
-           ; global_slot_range
-           ; source_acc_set
-           ; target_acc_set
-           }
-         , verify_txn_snark ) =
-      Txn_rules.get txn_snark
+    let ({ source_ledger
+         ; target_ledger
+         ; source_local_state
+         ; target_local_state
+         ; sequencer
+         ; accumulated_fees
+         ; slot_range = txn_snark_slot_range
+         ; global_slot_range
+         ; source_acc_set
+         ; target_acc_set
+         }
+          : Txn_state.Zeko_stmt.var ) =
+      txn_stmt
     in
     with_label __LOC__
     @@ fun () ->
@@ -204,25 +246,42 @@ struct
         assert_equal ~label:__LOC__ typ target_local_state dummy)
     in
 
-    (* DA check, simply see if public key in question has signed our ledger. *)
-    let* () =
-      with_label __LOC__
-      @@ fun () ->
-      let input =
-        let open Random_oracle.Input.Chunked in
-        append
-          (Ledger_hash.var_to_field target_ledger |> field)
-          (Account_set.to_input_var target_acc_set)
-      in
-      let* payload =
-        make_checked (fun () ->
-            Random_oracle.Checked.hash
-              ~init:(Hash_prefix_create.salt Zeko_constants.da_layer_check_salt)
-              (Random_oracle.Checked.pack_input input) )
-      in
-      Multisig.check ~signature_kind:chain_l1 da_multisig payload
+    let* da_key_opt =
+      match da_mode with
+      | Multisig ->
+          (* DA check, simply see if public key in question has signed our ledger. *)
+          let* () =
+            with_label __LOC__
+            @@ fun () ->
+            let input =
+              let open Random_oracle.Input.Chunked in
+              append
+                (Ledger_hash.var_to_field target_ledger |> field)
+                (Account_set.to_input_var target_acc_set)
+            in
+            let* payload =
+              make_checked (fun () ->
+                  Random_oracle.Checked.hash
+                    ~init:
+                      (Hash_prefix_create.salt
+                         Zeko_constants.da_layer_check_salt )
+                    (Random_oracle.Checked.pack_input input) )
+            in
+            Multisig.check ~signature_kind:chain_l1 da_multisig payload
+          in
+          let*| da_key = Multisig.of_witness_var da_multisig in
+          Some da_key
+      | Emergency emergency_da_stmt ->
+          let* () =
+            assert_equal ~label:__LOC__ Ledger_hash.typ
+              emergency_da_stmt.source_ledger source_ledger
+          in
+          let* () =
+            assert_equal ~label:__LOC__ Ledger_hash.typ
+              emergency_da_stmt.target_ledger target_ledger
+          in
+          Checked.return None
     in
-    let* da_key = Multisig.of_witness_var da_multisig in
 
     (* Sequencer must take fees. A non-zero magnitude would
        either mean printing or burning L2 MINA. *)
@@ -406,7 +465,7 @@ struct
                 ; paused = Some Boolean.false_ (* We must not be paused. *)
                 ; pause_key =
                     None (* We don't care about who can pause the rollup. *)
-                ; da_key = Some da_key
+                ; da_key = da_key_opt
                 ; acc_set = Some source_acc_set
                 }
               |> var_to_precondition_fine
@@ -451,13 +510,40 @@ struct
       ; use_full_commitment = Boolean.true_
       }
     in
+    let emergency_da_account_update_opt =
+      match da_mode with
+      | Emergency emergency_da_stmt ->
+          let preconditions =
+            { default_account_update.preconditions with
+              account =
+                { default_account_update.preconditions.account with
+                  action_state =
+                    Zkapp_basic.Or_ignore.Checked.make_unsafe Boolean.true_
+                      emergency_da_stmt.target_action_state
+                }
+            }
+          in
+          Some
+            { default_account_update with
+              public_key = constant PC.typ emergency_da_public_key
+            ; preconditions
+            }
+      | Multisig ->
+          None
+    in
 
     (* Assemble some stuff to help the prover and calculate public output *)
     let*| out =
       make_outputs ~chain:chain_l1 account_update
-        [ (sequencer_account_update, []) ]
+        ( (sequencer_account_update, [])
+        ::
+        ( match emergency_da_account_update_opt with
+        | None ->
+            []
+        | Some emergency_da_au ->
+            [ (emergency_da_au, []) ] ) )
     in
-    (out, verify_txn_snark)
+    out
 
   let rule : _ Compile_simple.branch lazy_t =
     lazy
@@ -466,14 +552,15 @@ struct
           Two_tags (Lazy.force Txn_rules.tag, Lazy.force Verify_both_ases.tag)
       ; main =
           (fun (w : Witness.t V.t) ->
-            let* Witness.{ base_witness; verify_both_ases } =
+            let* Witness.{ txn_snark; base_witness; verify_both_ases } =
               exists ~compute:(V.get w) Witness.typ
             in
+            let* txn_stmt, verify_txn_snark = Txn_rules.get txn_snark in
             let* (ase_outer, ase_inner), verify_both_ases =
               Verify_both_ases.get verify_both_ases
             in
-            let*| out, verify_txn_snark =
-              main base_witness (ase_outer, ase_inner)
+            let*| out =
+              main ~da_mode:Multisig base_witness txn_stmt (ase_outer, ase_inner)
             in
             Compile_simple.
               { prevs = Two_prevs (verify_txn_snark, verify_both_ases); out } )
@@ -488,6 +575,7 @@ struct
         ; before_last_commit : Rollup_state.Outer_action_state.t
         ; last_commit : Rollup_state.Outer_action.Commit.t
         ; verify_emergency_folders : Verify_emergency_folders.t
+        ; verify_base : Verify_base.t
         }
       [@@deriving snarky]
     end
@@ -497,7 +585,8 @@ struct
         { branch_name = "Emergency step"
         ; tags =
             Two_tags
-              (Lazy.force Txn_rules.tag, Lazy.force Verify_emergency_folders.tag)
+              ( Lazy.force Verify_base.tag
+              , Lazy.force Verify_emergency_folders.tag )
         ; main =
             (fun (w : Witness.t V.t) ->
               let* Witness.
@@ -505,11 +594,15 @@ struct
                      ; before_last_commit
                      ; last_commit
                      ; verify_emergency_folders
+                     ; verify_base
                      } =
                 exists ~compute:(V.get w) Witness.typ
               in
-              let* ( ((ase_outer, ase_inner), count_commits)
-                   , verify_emergency_folders ) =
+              let* (txn_stmt, (ase_outer, ase_inner)), verify_base =
+                Verify_base.get verify_base
+              in
+              let* (count_commits, emergency_da_stmt), verify_emergency_folders
+                  =
                 Verify_emergency_folders.get verify_emergency_folders
               in
 
@@ -552,12 +645,13 @@ struct
                   Checked32.Checked.zero
               in
 
-              let*| out, verify_txn_snark =
-                main ~check_sequencer_precondition:false base_witness
+              let*| out =
+                main ~check_sequencer_precondition:false
+                  ~da_mode:(Emergency emergency_da_stmt) base_witness txn_stmt
                   (ase_outer, ase_inner)
               in
               Compile_simple.
-                { prevs = Two_prevs (verify_txn_snark, verify_emergency_folders)
+                { prevs = Two_prevs (verify_base, verify_emergency_folders)
                 ; out
                 } )
         }

--- a/src/app/zeko/circuits/rule_commit.ml
+++ b/src/app/zeko/circuits/rule_commit.ml
@@ -160,6 +160,7 @@ struct
       ; new_inner_acc_path : Path.t
       ; da_multisig : Multisig.Witness.t
       ; slot_range : Slot_range.t
+      ; emergency_mode : Zeko_util.Boolean.t
       }
     [@@deriving snarky]
   end
@@ -210,9 +211,14 @@ struct
          ; new_inner_acc_path
          ; da_multisig
          ; slot_range
+         ; emergency_mode
          }
           : Base_witness.var ) =
       w
+    in
+    let* status_flags_precondition =
+      Outer_state.Status_flags.of_bools_var ~paused:Boolean.false_
+        ~emergency:emergency_mode
     in
     with_label __LOC__
     @@ fun () ->
@@ -404,6 +410,16 @@ struct
       new_inner_action_state
     in
 
+    let* status_flags_update =
+      match da_mode with
+      | Multisig ->
+          Outer_state.Status_flags.of_bools_var ~paused:Boolean.false_
+            ~emergency:Boolean.false_
+      | Emergency _ ->
+          Outer_state.Status_flags.of_bools_var ~paused:Boolean.false_
+            ~emergency:Boolean.true_
+    in
+
     (* Finalize update  *)
     let update =
       { default_account_update.update with
@@ -428,7 +444,7 @@ struct
                    to many other zkapps.
                 *)
             ; sequencer = None (* We don't update the sequencer. *)
-            ; paused = None (* We don't pause the rollup. *)
+            ; status_flags = Some status_flags_update
             ; pause_key = None (* We don't update the pause key. *)
             ; da_key = None
             ; acc_set = Some target_acc_set
@@ -462,7 +478,8 @@ struct
                     (* We must be the sequencer. *)
                     ( if check_sequencer_precondition then Some sequencer
                     else None )
-                ; paused = Some Boolean.false_ (* We must not be paused. *)
+                ; status_flags =
+                    Some status_flags_precondition (* We must not be paused. *)
                 ; pause_key =
                     None (* We don't care about who can pause the rollup. *)
                 ; da_key = da_key_opt
@@ -613,12 +630,19 @@ struct
                       Slot.Checked.diff base_witness.slot_range.lower
                         last_commit.slot_range.upper
                     in
-                    Mina_numbers.Global_slot_span.Checked.(
-                      diff
-                      >= constant
-                           (Global_slot_span
-                              (Unsigned.UInt32.of_int max_sequencer_inactivity)
-                           )) )
+                    let* inactivity_ok =
+                      Mina_numbers.Global_slot_span.Checked.(
+                        diff
+                        >= constant
+                             (Global_slot_span
+                                (Unsigned.UInt32.of_int max_sequencer_inactivity)
+                             ))
+                    in
+                    let* ok =
+                      if_ base_witness.emergency_mode ~typ:Boolean.typ
+                        ~then_:Boolean.true_ ~else_:inactivity_ok
+                    in
+                    Checked.return ok )
               in
 
               let Count_commits.Definition.Stmt.

--- a/src/app/zeko/circuits/rule_commit.ml
+++ b/src/app/zeko/circuits/rule_commit.ml
@@ -46,6 +46,46 @@ module Verify_both_ases = struct
             () )
 end
 
+(** Used to prove the number of commits in the emergency case. *)
+module Count_commits_inst = Count_commits.Make (struct
+  let get_iterations = Zeko_constants.Max_excess_actions.Commit.count_commits
+end)
+
+(** Proves Ase_outer_inst, Ase_inner_inst, and Count_commits to circumvent limitation of two recursive proof verifications per proof. *)
+module Verify_emergency_folders = struct
+  let main (w : (Verify_both_ases.t * Count_commits_inst.t) V.t) =
+    let* verify_both_ases, count_commits =
+      exists ~compute:(V.get w)
+        Typ.(Verify_both_ases.typ * Count_commits_inst.typ)
+    in
+    let* both_ases, verify_both_ases = Verify_both_ases.get verify_both_ases in
+    let*| count_commits, verify_count_commits =
+      Count_commits_inst.get count_commits
+    in
+    Compile_simple.
+      { prevs = Two_prevs (verify_both_ases, verify_count_commits)
+      ; out = (both_ases, count_commits)
+      }
+
+  let rule : _ Compile_simple.branch lazy_t =
+    lazy
+      { branch_name = "Verify_emergency_folders"
+      ; tags =
+          Two_tags
+            (Lazy.force Verify_both_ases.tag, Lazy.force Count_commits.tag)
+      ; main
+      }
+
+  include
+    ( val Compile_simple.compile ~name:"Verify_emergency_folders"
+            ~branches:[ rule ]
+            ~out_typ:
+              Typ.(
+                Ase_outer_inst.Stmt.typ * Ase_inner_inst.Stmt.typ
+                * Count_commits.Definition.Stmt.typ)
+            () )
+end
+
 module Make (Inputs : sig
   (** max_valid_while_size signifies how big the valid_while can be for commits. *)
   val max_valid_while_size : int
@@ -54,6 +94,8 @@ module Make (Inputs : sig
   val inner_public_key : PC.t
 
   val chain_l1 : Mina_signature_kind.t
+
+  val max_sequencer_inactivity : int
 end) =
 struct
   open Inputs
@@ -70,12 +112,11 @@ struct
         let length = Account_set.height
       end)
 
-  module Witness = struct
+  module Base_witness = struct
     type t =
       { txn_snark : Txn_rules.t  (** The ledger transition we are performing. *)
       ; public_key : PC.t  (** Our public key on the L2 *)
       ; vk_hash : F.t  (** Our vk hash *)
-      ; verify_both_ases : Verify_both_ases.t
       ; old_inner_acc : Account.t
       ; old_inner_acc_path : Path.t
       ; new_inner_acc : Account.t
@@ -83,6 +124,12 @@ struct
       ; da_multisig : Multisig.Witness.t
       ; slot_range : Slot_range.t
       }
+    [@@deriving snarky]
+  end
+
+  module Witness = struct
+    type t =
+      { base_witness : Base_witness.t; verify_both_ases : Verify_both_ases.t }
     [@@deriving snarky]
   end
 
@@ -107,22 +154,23 @@ struct
     in
     content
 
-  let main (w : Witness.t V.t) =
+  let main ?(check_sequencer_precondition = true) (w : Base_witness.var)
+      ((ase_outer, ase_inner) :
+        Ase_outer_inst.Stmt.var * Ase_inner_inst.Stmt.var ) =
     with_label __LOC__
     @@ fun () ->
-    let* ({ txn_snark
-          ; public_key
-          ; vk_hash
-          ; verify_both_ases
-          ; old_inner_acc
-          ; old_inner_acc_path
-          ; new_inner_acc
-          ; new_inner_acc_path
-          ; da_multisig
-          ; slot_range
-          } :
-           Witness.var ) =
-      with_label __LOC__ @@ fun () -> exists ~compute:(V.get w) Witness.typ
+    let ({ txn_snark
+         ; public_key
+         ; vk_hash
+         ; old_inner_acc
+         ; old_inner_acc_path
+         ; new_inner_acc
+         ; new_inner_acc_path
+         ; da_multisig
+         ; slot_range
+         }
+          : Base_witness.var ) =
+      w
     in
     with_label __LOC__
     @@ fun () ->
@@ -240,11 +288,6 @@ struct
         .outer_action_state
     in
 
-    (* Extract information from Verify_both_ases wrapper proof. *)
-    let* (ase_outer, ase_inner), verify_ases =
-      Verify_both_ases.get verify_both_ases
-    in
-
     let Ase_outer_inst.Stmt.
           { source = synchronized_outer_action_state'
           ; target = outer_action_state
@@ -356,7 +399,10 @@ struct
                        The state we already know from the ledger hash,
                        but the length is information we didn't have before.
                     *)
-                ; sequencer = Some sequencer (* We must be the sequencer. *)
+                ; sequencer =
+                    (* We must be the sequencer. *)
+                    ( if check_sequencer_precondition then Some sequencer
+                    else None )
                 ; paused = Some Boolean.false_ (* We must not be paused. *)
                 ; pause_key =
                     None (* We don't care about who can pause the rollup. *)
@@ -411,13 +457,109 @@ struct
       make_outputs ~chain:chain_l1 account_update
         [ (sequencer_account_update, []) ]
     in
-    Compile_simple.{ prevs = Two_prevs (verify_txn_snark, verify_ases); out }
+    (out, verify_txn_snark)
 
   let rule : _ Compile_simple.branch lazy_t =
     lazy
       { branch_name = "Rollup step"
       ; tags =
           Two_tags (Lazy.force Txn_rules.tag, Lazy.force Verify_both_ases.tag)
-      ; main
+      ; main =
+          (fun (w : Witness.t V.t) ->
+            let* Witness.{ base_witness; verify_both_ases } =
+              exists ~compute:(V.get w) Witness.typ
+            in
+            let* (ase_outer, ase_inner), verify_both_ases =
+              Verify_both_ases.get verify_both_ases
+            in
+            let*| out, verify_txn_snark =
+              main base_witness (ase_outer, ase_inner)
+            in
+            Compile_simple.
+              { prevs = Two_prevs (verify_txn_snark, verify_both_ases); out } )
       }
+
+  (** Specialized version of the main function, used for emergency commits.
+      Only usable after [max_sequencer_inactivity] slots of the sequencer not committing. *)
+  module Emergency_commit = struct
+    module Witness = struct
+      type t =
+        { base_witness : Base_witness.t
+        ; before_last_commit : Rollup_state.Outer_action_state.t
+        ; last_commit : Rollup_state.Outer_action.Commit.t
+        ; verify_emergency_folders : Verify_emergency_folders.t
+        }
+      [@@deriving snarky]
+    end
+
+    let rule : _ Compile_simple.branch lazy_t =
+      lazy
+        { branch_name = "Emergency step"
+        ; tags =
+            Two_tags
+              (Lazy.force Txn_rules.tag, Lazy.force Verify_emergency_folders.tag)
+        ; main =
+            (fun (w : Witness.t V.t) ->
+              let* Witness.
+                     { base_witness
+                     ; before_last_commit
+                     ; last_commit
+                     ; verify_emergency_folders
+                     } =
+                exists ~compute:(V.get w) Witness.typ
+              in
+              let* ( ((ase_outer, ase_inner), count_commits)
+                   , verify_emergency_folders ) =
+                Verify_emergency_folders.get verify_emergency_folders
+              in
+
+              (* Check that at least [max_sequencer_inactivity] slots have passed between last_commit and and this new commit *)
+              let* () =
+                assert_var __LOC__ (fun () ->
+                    let* diff =
+                      Slot.Checked.diff base_witness.slot_range.lower
+                        last_commit.slot_range.upper
+                    in
+                    Mina_numbers.Global_slot_span.Checked.(
+                      diff
+                      >= constant
+                           (Global_slot_span
+                              (Unsigned.UInt32.of_int max_sequencer_inactivity)
+                           )) )
+              in
+
+              let Count_commits.Definition.Stmt.
+                    { source_action_state; target_action_state; n_commits } =
+                count_commits
+              in
+              (* Apply last_commit to before_last_commit *)
+              let* after_last_commit =
+                Outer_action.push_commit_var last_commit before_last_commit
+              in
+              (* Check that counting started immediately after last_commit *)
+              let* () =
+                assert_equal ~label:__LOC__ Outer_action_state.typ
+                  after_last_commit source_action_state
+              in
+              (* Check that target_action_state is the target of ase_outer, i.e. the outer action state precondition *)
+              let* () =
+                assert_equal ~label:__LOC__ Outer_action_state.typ
+                  target_action_state ase_outer.target
+              in
+              (* Check that there has been no commits since last_commit *)
+              let* () =
+                assert_equal ~label:__LOC__ Checked32.typ n_commits
+                  Checked32.Checked.zero
+              in
+
+              let*| out, verify_txn_snark =
+                main ~check_sequencer_precondition:false base_witness
+                  (ase_outer, ase_inner)
+              in
+              Compile_simple.
+                { prevs = Two_prevs (verify_txn_snark, verify_emergency_folders)
+                ; out
+                } )
+        }
+  end
 end

--- a/src/app/zeko/circuits/rule_emergency_da.ml
+++ b/src/app/zeko/circuits/rule_emergency_da.ml
@@ -1,0 +1,92 @@
+open Snark_params.Tick
+open Mina_base
+module PC = Signature_lib.Public_key.Compressed
+open Zeko_util
+
+module Ledger_path = struct
+  module Step = struct
+    type t = { hash_other : F.t; is_right : Boolean.t } [@@deriving snarky]
+  end
+
+  module Path =
+    SnarkList
+      (Step)
+      (struct
+        let length = Zeko_constants.constraint_constants.ledger_depth
+      end)
+end
+
+module Action = struct
+  type t =
+    { source_ledger_hash : Ledger_hash.t
+    ; target_ledger_hash : Ledger_hash.t
+    ; ledger_index : Checked32.t
+    ; account : Account.t
+    }
+  [@@deriving snarky]
+end
+
+module Witness = struct
+  type t =
+    { public_key : PC.t
+    ; vk_hash : F.t
+    ; old_account : Account.t
+    ; new_account : Account.t
+    ; ledger_path : Ledger_path.Path.t
+    ; ledger_index : Checked32.t
+    }
+  [@@deriving snarky]
+end
+
+let implied_root (account : Account.var) (path : Ledger_path.Path.var) =
+  let* init = Account.Checked.digest account in
+  Checked.List.foldi path ~init
+    ~f:(fun height acc Ledger_path.Step.{ hash_other; is_right } ->
+      let* left = Field.Checked.if_ is_right ~then_:hash_other ~else_:acc in
+      let* right = Field.Checked.if_ is_right ~then_:acc ~else_:hash_other in
+      Checked.return (Ledger_hash.merge_var ~height left right) )
+
+module Make (Inputs : sig
+  val chain_l1 : Mina_signature_kind.t
+end) =
+struct
+  open Inputs
+
+  let%snarkydef_ main (w : Witness.t V.t) =
+    let* Witness.
+           { public_key
+           ; vk_hash
+           ; old_account
+           ; new_account
+           ; ledger_path
+           ; ledger_index
+           } =
+      exists Witness.typ ~compute:(V.get w)
+    in
+    let* source_root = implied_root old_account ledger_path in
+    let* target_root = implied_root new_account ledger_path in
+    let source_ledger_hash = Ledger_hash.var_of_hash_packed source_root in
+    let target_ledger_hash = Ledger_hash.var_of_hash_packed target_root in
+    (* TODO: derive ledger_index from ledger_path instead of trusting witness input. *)
+    let* actions =
+      var_to_actions Action.typ
+        Action.
+          { source_ledger_hash
+          ; target_ledger_hash
+          ; ledger_index
+          ; account = new_account
+          }
+    in
+    let account_update =
+      { default_account_update with
+        public_key
+      ; authorization_kind = authorization_vk_hash vk_hash
+      ; actions
+      }
+    in
+    let*| out = make_outputs ~chain:chain_l1 account_update [] in
+    Compile_simple.{ prevs = No_prevs; out }
+
+  let rule : _ Compile_simple.branch lazy_t =
+    lazy { branch_name = "emergency da apply"; tags = No_tags; main }
+end

--- a/src/app/zeko/circuits/rule_emergency_da.ml
+++ b/src/app/zeko/circuits/rule_emergency_da.ml
@@ -33,7 +33,6 @@ module Witness = struct
     ; old_account : Account.t
     ; new_account : Account.t
     ; ledger_path : Ledger_path.Path.t
-    ; ledger_index : Checked32.t
     }
   [@@deriving snarky]
 end
@@ -46,6 +45,16 @@ let implied_root (account : Account.var) (path : Ledger_path.Path.var) =
       let* right = Field.Checked.if_ is_right ~then_:acc ~else_:hash_other in
       make_checked @@ fun () -> Ledger_hash.merge_var ~height left right )
 
+let index_of_path (path : Ledger_path.Path.var) : Checked32.var Checked.t =
+  Checked.List.foldi path ~init:Checked32.Checked.zero
+    ~f:(fun height acc Ledger_path.Step.{ is_right; _ } ->
+      let* add =
+        if_ is_right ~typ:Checked32.typ
+          ~then_:(Checked32.Checked.constant (Checked32.of_int (1 lsl height)))
+          ~else_:Checked32.Checked.zero
+      in
+      Checked32.Checked.add acc add )
+
 module Make (Inputs : sig
   val chain_l1 : Mina_signature_kind.t
 end) =
@@ -53,21 +62,15 @@ struct
   open Inputs
 
   let%snarkydef_ main (w : Witness.t V.t) =
-    let* Witness.
-           { public_key
-           ; vk_hash
-           ; old_account
-           ; new_account
-           ; ledger_path
-           ; ledger_index
-           } =
+    let* Witness.{ public_key; vk_hash; old_account; new_account; ledger_path }
+        =
       exists Witness.typ ~compute:(V.get w)
     in
     let* source_root = implied_root old_account ledger_path in
     let* target_root = implied_root new_account ledger_path in
     let source_ledger_hash = Ledger_hash.var_of_hash_packed source_root in
     let target_ledger_hash = Ledger_hash.var_of_hash_packed target_root in
-    (* TODO: derive ledger_index from ledger_path instead of trusting witness input. *)
+    let* ledger_index = index_of_path ledger_path in
     let* actions =
       var_to_actions Action.typ
         Action.

--- a/src/app/zeko/circuits/rule_emergency_da.ml
+++ b/src/app/zeko/circuits/rule_emergency_da.ml
@@ -44,7 +44,7 @@ let implied_root (account : Account.var) (path : Ledger_path.Path.var) =
     ~f:(fun height acc Ledger_path.Step.{ hash_other; is_right } ->
       let* left = Field.Checked.if_ is_right ~then_:hash_other ~else_:acc in
       let* right = Field.Checked.if_ is_right ~then_:acc ~else_:hash_other in
-      Checked.return (Ledger_hash.merge_var ~height left right) )
+      make_checked @@ fun () -> Ledger_hash.merge_var ~height left right )
 
 module Make (Inputs : sig
   val chain_l1 : Mina_signature_kind.t

--- a/src/app/zeko/circuits/rule_pause.ml
+++ b/src/app/zeko/circuits/rule_pause.ml
@@ -25,6 +25,10 @@ struct
           Boolean.true_ (* added here too to be extra sure *)
       }
     in
+    let* status_flags_update =
+      Outer_state.Status_flags.of_bools_var ~paused:Boolean.true_
+        ~emergency:Boolean.false_
+    in
     let account_update =
       { default_account_update with
         public_key
@@ -34,7 +38,7 @@ struct
             app_state =
               Outer_state.fine
                 { pause_key = None
-                ; paused = Some Boolean.true_
+                ; status_flags = Some status_flags_update
                 ; ledger_hash = None
                 ; inner_action_state = { length = None; state = None }
                 ; sequencer = None
@@ -50,7 +54,7 @@ struct
                 state =
                   Outer_state.fine
                     { pause_key = Some pause_key
-                    ; paused = None
+                    ; status_flags = None
                     ; ledger_hash = None
                     ; inner_action_state = { length = None; state = None }
                     ; sequencer = None

--- a/src/app/zeko/da_layer/README.md
+++ b/src/app/zeko/da_layer/README.md
@@ -39,7 +39,10 @@ The api is exposed as `Async.Rpc` which is a typesafe ocaml rpc with binprot ser
 ### Running the node
 
 ```bash
-MINA_PRIVATE_KEY=<opaque> dune exec ./cli.exe -- run-node --port 8002 --da-node-to-sync http://localhost:8000 --da-node-to-sync http://localhost:8001
+MINA_PRIVATE_KEY=<base58> dune exec ./cli.exe -- run-node \
+  --db-dir <string?> \
+  --port <int?> \
+  --network-id <string?>
 ```
 
 To see all the options run:
@@ -47,6 +50,13 @@ To see all the options run:
 ```bash
 dune exec ./cli.exe -- run-node --help
 ```
+
+Options:
+- `--db-dir` (optional, default `da_db`): directory for the node DB.
+- `--port` (optional, default `8080`): RPC port.
+- `--random-sk`: generate a random signer key (testing mode; ignores `MINA_PRIVATE_KEY`).
+- `--no-migrations`: skip DB migrations on startup.
+- `--network-id` (optional, default `zeko`): network id used as salt for receipt logic.
 
 ## Client description
 

--- a/src/app/zeko/sequencer/README.md
+++ b/src/app/zeko/sequencer/README.md
@@ -12,14 +12,14 @@ Think of the sequencer as the conductor of an orchestra in Zeko. It plays a vita
 ## Build
 
 ```bash
-DUNE_PROFILE=devnet dune build
+DUNE_PROFILE=devnet dune build ./src/app/zeko/sequencer
 ```
 
 ## Tests
 
 ```bash
 dune build
-./tests/run_sequencer_test.sh {fake | real}
+./src/app/zeko/sequencer/tests/run-sequencer-test.sh {fake | real} <num_provers>
 ```
 
 ## Run
@@ -32,13 +32,21 @@ export DUNE_PROFILE=devnet
 dune exec ./run.exe -- \
     -p <int?> \
     --l1-uri <string> \
-    --zkapp-pk <string> \
-    --max-pool-size <int?> \
+    --archive-uri <string> \
     --commitment-period <float?> \
+    --max-pool-size <int?> \
     --da-node <string list> \
+    --da-keys <string> \
     --da-quorum <int> \
+    --mq-host <string> \
     --db-dir <string?> \
-    --network-id <string?>
+    --checkpoints-dir <string?> \
+    --postgres-uri <string> \
+    --deposit-delay-blocks <int?> \
+    --fee-modifier <float?> \
+    --minimum-fee <float?> \
+    --slot-acceptance <float?> \
+    --commit-validity-period <int?>
 ```
 
 Run help to see the options:
@@ -56,8 +64,14 @@ export MINA_PRIVATE_KEY="base58 signer private key"
 export DUNE_PROFILE=devnet
 dune exec ./deploy.exe -- \
     --l1-uri <string> \
-    --test-accounts-path <string?> \
-    --da-node <string list>
+    --ledger-input <string?> \
+    --faucet-account <string?> \
+    --da-node <string list> \
+    --pause-key <string> \
+    --sequencer-key <string> \
+    --da-keys <string> \
+    --da-quorum <int> \
+    --account-creation-fee <string>
 ```
 
 Run help to see the options:
@@ -83,31 +97,6 @@ dune exec ./archive_relay/run.exe -- \
 ```
 
 To run the adapter from docker see the section below.
-
-## Use with docker
-
-Build:
-
-```bash
-make docker
-```
-
-Run:
-
-```bash
-docker run -p <port>:<port> \
-           -v <local-db-path>:<container-db-path> \
-           -e DA_PROVIDER=<da-evm-provider> \
-           -e DA_PRIVATE_KEY=<da-private-key> \
-           -e MINA_PRIVATE_KEY=<mina-private-key> \
-           dcspark/zeko -p <port> \
-           --zkapp-pk <zkapp-pk> \
-           --l1-uri <mina-node-graphql> \
-           --archive-uri <mina-archive-node-graphql> \
-           --commitment-period <int> \
-           --da-contract-address <da-layer-contract> \
-           --db-dir <container-db-path>
-```
 
 ### Running archive relay adapter from docker
 

--- a/src/app/zeko/sequencer/cli.ml
+++ b/src/app/zeko/sequencer/cli.ml
@@ -32,6 +32,7 @@ let generate_circuits_config =
            let holder_accounts_l1 = [ generate_keypair () ] in
            let helper_token_owner_l1 = generate_keypair () in
            let zeko_l1 = generate_keypair () in
+           let emergency_da = generate_keypair () in
            let t : Zeko_circuits_config.t =
              { chain_l1 = Testnet
              ; chain_l2 = Testnet
@@ -39,6 +40,7 @@ let generate_circuits_config =
              ; holder_accounts_l1 = List.map holder_accounts_l1 ~f:fst
              ; helper_token_owner_l1 = fst helper_token_owner_l1
              ; zeko_l1 = fst zeko_l1
+             ; emergency_da_public_key = fst emergency_da
              ; withdrawal_delay = Mina_numbers.Global_slot_span.of_int 5
              }
            in
@@ -46,6 +48,7 @@ let generate_circuits_config =
              { holder_accounts_l1 = List.map holder_accounts_l1 ~f:snd
              ; helper_token_owner_l1 = snd helper_token_owner_l1
              ; zeko_l1 = snd zeko_l1
+             ; emergency_da = snd emergency_da
              }
            in
            Core.printf "circuits config: %s\n%!"

--- a/src/app/zeko/sequencer/cli.ml
+++ b/src/app/zeko/sequencer/cli.ml
@@ -65,10 +65,6 @@ let update_outer_verification_keys =
            ~doc:"bool Only check if the verification keys are up to date"
        in
        fun () ->
-         let sk = Sys.getenv_exn "MINA_PRIVATE_KEY" in
-         let sender =
-           Keypair.of_private_key_exn @@ Private_key.of_base58_check_exn sk
-         in
          let l1_uri = Uri.of_string l1_uri in
          let open Zeko_types in
          let logger = Logger.create () in
@@ -139,6 +135,10 @@ let update_outer_verification_keys =
 
          if only_check then return ()
          else
+           let sk = Sys.getenv_exn "MINA_PRIVATE_KEY" in
+           let sender =
+             Keypair.of_private_key_exn @@ Private_key.of_base58_check_exn sk
+           in
            let%bind nonce =
              Gql_client.infer_nonce ~logger l1_uri
                (Public_key.compress sender.public_key)

--- a/src/app/zeko/sequencer/cli.ml
+++ b/src/app/zeko/sequencer/cli.ml
@@ -387,7 +387,7 @@ let update_inner_verification_keys =
                ~precondition:
                  Outer_state.
                    { pause_key = None
-                   ; paused = None
+                   ; status_flags = None
                    ; ledger_hash =
                        Some (Ledger_hash.var_of_t source_ledger_hash)
                    ; inner_action_state = { state = None; length = None }
@@ -398,7 +398,7 @@ let update_inner_verification_keys =
                ~update:
                  Outer_state.
                    { pause_key = None
-                   ; paused = None
+                   ; status_flags = None
                    ; ledger_hash =
                        Some (Ledger_hash.var_of_t target_ledger_hash)
                    ; inner_action_state = { state = None; length = None }
@@ -485,7 +485,7 @@ let update_da_key =
                ~precondition:
                  Outer_state.
                    { pause_key = None
-                   ; paused = None
+                   ; status_flags = None
                    ; ledger_hash = None
                    ; inner_action_state = { state = None; length = None }
                    ; sequencer = None
@@ -495,7 +495,7 @@ let update_da_key =
                ~update:
                  Outer_state.
                    { pause_key = None
-                   ; paused = None
+                   ; status_flags = None
                    ; ledger_hash = None
                    ; inner_action_state = { state = None; length = None }
                    ; sequencer = None
@@ -599,7 +599,9 @@ let set_pause =
            >>| Or_error.ok_exn
            >>| Utils.value_of_zkapp_state
                  Zeko_circuits.Rollup_state.Outer_state.typ
-           >>| fun { paused; _ } -> paused
+           >>| fun { status_flags; _ } ->
+           Zeko_circuits.Rollup_state.Outer_state.Status_flags.paused
+             status_flags
          in
 
          [%log info] "Current paused: %b" current_paused ;
@@ -618,7 +620,7 @@ let set_pause =
              ~precondition:
                Rollup_state.Outer_state.
                  { pause_key = None
-                 ; paused = None
+                 ; status_flags = None
                  ; ledger_hash = None
                  ; inner_action_state = { state = None; length = None }
                  ; sequencer = None
@@ -628,9 +630,12 @@ let set_pause =
              ~update:
                Rollup_state.Outer_state.
                  { pause_key = None
-                 ; paused =
-                     ( if value then Some Zeko_util.Boolean.true_
-                     else Some Zeko_util.Boolean.false_ )
+                 ; status_flags =
+                     Some
+                       (Field.Var.constant
+                          (Rollup_state.Outer_state.Status_flags.to_field
+                             (Rollup_state.Outer_state.Status_flags.of_bools
+                                ~paused:value ~emergency:false ) ) )
                  ; ledger_hash = None
                  ; inner_action_state = { state = None; length = None }
                  ; sequencer = None

--- a/src/app/zeko/sequencer/lib/committer.ml
+++ b/src/app/zeko/sequencer/lib/committer.ml
@@ -94,19 +94,26 @@ let prove_commit ~logger ~proof_cache_db ~provers ~(executor : Executor.t)
   in
   let old_inner_acc, old_inner_acc_path = get_inner_acc old_inner_ledger in
   let new_inner_acc, new_inner_acc_path = get_inner_acc new_inner_ledger in
-  let%bind inner_ase_source =
-    let%map { inner_action_state = committed_inner_action_state; _ } =
+  let%bind inner_ase_source, emergency_mode =
+    let%map { inner_action_state = committed_inner_action_state
+            ; status_flags
+            ; _
+            } =
       Gql_client.infer_state ~logger
         Executor.(executor.l1_uri)
         ~zkapp_pk
         ~signer_pk:(Public_key.compress executor.signer.public_key)
       >>| Utils.value_of_zkapp_state Rollup_state.Outer_state.typ
     in
-    ( Rollup_state.Inner_action_state.With_length.
-        { action_state = raw committed_inner_action_state
-        ; length = length committed_inner_action_state
-        }
-      : Ase.With_length.Stmt.t )
+    let emergency_mode =
+      Rollup_state.Outer_state.Status_flags.emergency status_flags
+    in
+    ( ( Rollup_state.Inner_action_state.With_length.
+          { action_state = raw committed_inner_action_state
+          ; length = length committed_inner_action_state
+          }
+        : Ase.With_length.Stmt.t )
+    , emergency_mode )
   in
   let%bind new_inner_actions =
     let from =
@@ -176,7 +183,7 @@ let prove_commit ~logger ~proof_cache_db ~provers ~(executor : Executor.t)
       Zeko_prover.Client.outer_commit provers ~txn_snark ~public_key:zkapp_pk
         ~inner_ase_source ~new_inner_actions ~old_inner_acc ~old_inner_acc_path
         ~new_inner_acc ~new_inner_acc_path ~unprocessed_actions ~da_multisig
-        ~slot_range
+        ~slot_range ~emergency_mode
     in
     (* see #286 *)
     Utils.attach_proof_to_forest ~signature_kind:executor.signature_kind

--- a/src/app/zeko/sequencer/lib/deploy.ml
+++ b/src/app/zeko/sequencer/lib/deploy.ml
@@ -128,7 +128,9 @@ module Z = struct
                 (fun f -> Set_or_keep.Set f)
                 Set_or_keep.Keep typ
                 ( { pause_key
-                  ; paused = false
+                  ; status_flags =
+                      Rollup_state.Outer_state.Status_flags.of_bools
+                        ~paused:false ~emergency:false
                   ; ledger_hash
                   ; inner_action_state =
                       Rollup_state.Inner_action_state.With_length.empty

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -1034,6 +1034,7 @@ module Types = struct
       ; holder_accounts_l1 : Public_key.Compressed.t list
       ; holder_account_l2 : Public_key.Compressed.t
       ; helper_token_owner_l1 : Public_key.Compressed.t
+      ; emergency_da_public_key : Public_key.Compressed.t
       ; chain_l1 : Mina_signature_kind.t
       ; chain_l2 : Mina_signature_kind.t
       ; withdrawal_delay : int
@@ -1066,6 +1067,9 @@ module Types = struct
           ; field "helperTokenOwnerL1" ~typ:(non_null public_key)
               ~args:Arg.[]
               ~resolve:(fun _ t -> t.helper_token_owner_l1)
+          ; field "emergencyDaPublicKey" ~typ:(non_null public_key)
+              ~args:Arg.[]
+              ~resolve:(fun _ t -> t.emergency_da_public_key)
           ; field "chainL1" ~typ:(non_null string)
               ~args:Arg.[]
               ~resolve:(fun _ t -> signature_kind_to_string t.chain_l1)
@@ -2594,6 +2598,7 @@ module Queries = struct
         ; holder_accounts_l1 = Inputs.holder_accounts_l1
         ; holder_account_l2 = Inputs.holder_account_l2
         ; helper_token_owner_l1 = Inputs.helper_token_owner_l1
+        ; emergency_da_public_key = Inputs.emergency_da_public_key
         ; chain_l1 = Inputs.chain_l1
         ; chain_l2 = Inputs.chain_l2
         ; withdrawal_delay =

--- a/src/app/zeko/sequencer/prover/README.md
+++ b/src/app/zeko/sequencer/prover/README.md
@@ -39,6 +39,20 @@ let send ?(proving_timeout = 10.) ?(wait_for_prover_timeout = 600.)
     ?(attempts = 5) (state : State.t) (input : Prover.Input.t) : Prover.Output.t Deferred.t
 ```
 
+## CLI
+
+Run the prover worker (RabbitMQ consumer):
+
+```bash
+dune exec ./cli.exe -- run-server \
+  --mq-host <string> \
+  [--fake-proving-time <float>]
+```
+
+Options:
+- `--mq-host` (required): RabbitMQ host:port for the prover queue.
+- `--fake-proving-time` (optional): simulate proving time in seconds.
+
 Send function picks one of the available provers, sends a request to it and returns the result.
 It does by rotating provers list by `next` index and picking the first `Available` prover.
 By doing this it ensures that all the provers are used equally and if one of them is stuck, it will be skipped until next round.

--- a/src/app/zeko/sequencer/prover/lib/client.ml
+++ b/src/app/zeko/sequencer/prover/lib/client.ml
@@ -431,7 +431,8 @@ let verify_check_accepted_and_ase_cancelled_deposit t input =
 
 let outer_commit t ~txn_snark ~public_key ~inner_ase_source ~new_inner_actions
     ~unprocessed_actions ~(old_inner_acc : Account.t) ~old_inner_acc_path
-    ~(new_inner_acc : Account.t) ~new_inner_acc_path ~da_multisig ~slot_range =
+    ~(new_inner_acc : Account.t) ~new_inner_acc_path ~da_multisig ~slot_range
+    ~emergency_mode =
   (* Counting length of inner action state *)
   let%bind.Deferred.Result inner_ase =
     let%map.Deferred.Result proof, target, excess =
@@ -468,6 +469,7 @@ let outer_commit t ~txn_snark ~public_key ~inner_ase_source ~new_inner_actions
     (Prover.Input.Outer_commit
        { txn_snark
        ; public_key
+       ; emergency_mode
        ; verify_both_ases
        ; old_inner_acc
        ; old_inner_acc_path

--- a/src/app/zeko/sequencer/prover/lib/prover.ml
+++ b/src/app/zeko/sequencer/prover/lib/prover.ml
@@ -373,7 +373,7 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
       in
       Output.Verify_check_accepted_and_ase_cancelled_deposit (stmt, proof)
   | Outer_commit input ->
-      let Compile_simple.[ prove; _; _ ] =
+      let Compile_simple.[ prove; _; _; _ ] =
         Lazy.force Outer_rules_inst.provers
       in
       let%bind vk_hash =
@@ -394,7 +394,7 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
                  ~f:Account_update.read_all_proofs_from_disk )
         , proof )
   | Bridge (Outer_action_witness input) ->
-      let Compile_simple.[ _; prove; _ ] =
+      let Compile_simple.[ _; _; prove; _ ] =
         Lazy.force Outer_rules_inst.provers
       in
       let%bind vk_hash =

--- a/src/app/zeko/sequencer/tests/run-sequencer-test.sh
+++ b/src/app/zeko/sequencer/tests/run-sequencer-test.sh
@@ -100,7 +100,7 @@ else
 fi
 for ((i = 0; i < NUM_PROVERS; i++)); do
   PORT=$((9990 + i))
-  $BIN run-server --mq-host "localhost:5672" >/dev/null &
+  $BIN run-server --mq-host "localhost:5672" &
   PROVER_PID=$!
   PROVER_PIDS+=("$PROVER_PID")
   PROVERS+=("localhost:$PORT")

--- a/src/app/zeko/sequencer/tests/run-sequencer-test.sh
+++ b/src/app/zeko/sequencer/tests/run-sequencer-test.sh
@@ -15,6 +15,8 @@ NUM_PROVERS="$2"
 PROVER_PIDS=()
 PROVERS=()
 
+export MODE
+
 case "$MODE" in
 fake | real) ;;
 *)

--- a/src/app/zeko/tests/account_set_data.ml
+++ b/src/app/zeko/tests/account_set_data.ml
@@ -564,6 +564,8 @@ end) : sig
   type r =
     { path : [ `Left of field | `Right of field ] list
     ; before_path : [ `Left of field | `Right of field ] list
+    ; y_prev_hash : field
+    ; y_prev_path : [ `Left of field | `Right of field ] list
     ; before : T.t
     ; after : T.t
     ; hash : field
@@ -580,6 +582,8 @@ end = struct
   type r =
     { path : [ `Left of field | `Right of field ] list
     ; before_path : [ `Left of field | `Right of field ] list
+    ; y_prev_hash : field
+    ; y_prev_path : [ `Left of field | `Right of field ] list
     ; before : T.t
     ; after : T.t
     ; hash : field
@@ -621,7 +625,11 @@ end = struct
     let path = path_simple (get_idx entry entries') new_tree in
     let before_path = path_simple (get_idx before entries) old_tree in
     let hash = hash_simple new_tree in
-    (entries', { path; before_path; before; after; hash })
+    let y_prev_idx = Int64.(get_idx entry entries' - one) in
+    let y_prev_hash = List.nth_exn new_tree (Int64.to_int_exn y_prev_idx) in
+    let y_prev_path = path_simple y_prev_idx new_tree in
+    ( entries'
+    , { path; before_path; y_prev_hash; y_prev_path; before; after; hash } )
 
   let to_string_hum entries =
     let tree = calculate_tree (S.of_list entries) entries in

--- a/src/app/zeko/tests/compile_circuits.ml
+++ b/src/app/zeko/tests/compile_circuits.ml
@@ -26,6 +26,8 @@ module Inputs = struct
 
   let withdrawal_delay = Mina_numbers.Global_slot_span.of_string "5"
 
+  let max_sequencer_inactivity = 128
+
   let holder_account_l1_permissions_enabled : Mina_base.Permissions.t =
     { edit_state = Proof
     ; access = None
@@ -73,22 +75,80 @@ module Inner_rules_inst = Zeko_circuits.Inner_rules.Make (Inputs) ()
 
 module Outer_rules_inst = Zeko_circuits.Outer_rules.Make (Inputs) ()
 
-let _tag = Inner_rules_inst.tag
+let tag = Lazy.force Inner_rules_inst.tag
 
-let _tag = Outer_rules_inst.tag
+let () =
+  Promise.block_on_async_exn (fun () ->
+      Compile_simple.Verification_key.of_tag tag )
+  |> Compile_simple.Verification_key.hash |> Snark_params.Tick.Field.to_string
+  |> Core.printf "Inner rules vk: %s\n"
+
+let tag = Lazy.force Outer_rules_inst.tag
+
+let () =
+  Promise.block_on_async_exn (fun () ->
+      Compile_simple.Verification_key.of_tag tag )
+  |> Compile_simple.Verification_key.hash |> Snark_params.Tick.Field.to_string
+  |> Core.printf "Outer rules vk: %s\n"
+
+module Emergency_da_inst = Zeko_circuits.Emergency_da_rules.Make (Inputs) ()
+
+let tag = Lazy.force Emergency_da_inst.tag
+
+let () =
+  Promise.block_on_async_exn (fun () ->
+      Compile_simple.Verification_key.of_tag tag )
+  |> Compile_simple.Verification_key.hash |> Snark_params.Tick.Field.to_string
+  |> Core.printf "Emergency da vk: %s\n"
 
 module B_mina = Zeko_circuits.Bridge_rules.Make_mina (Inputs) ()
 
-let _tag = B_mina.System_L1_enabled.tag
+let tag = Lazy.force B_mina.System_L1_enabled.tag
 
-let _tag = B_mina.System_L1_disabled.tag
+let () =
+  Promise.block_on_async_exn (fun () ->
+      Compile_simple.Verification_key.of_tag tag )
+  |> Compile_simple.Verification_key.hash |> Snark_params.Tick.Field.to_string
+  |> Core.printf "System L1 enabled vk: %s\n"
 
-let _tag = B_mina.System_L2.tag
+let tag = Lazy.force B_mina.System_L1_disabled.tag
+
+let () =
+  Promise.block_on_async_exn (fun () ->
+      Compile_simple.Verification_key.of_tag tag )
+  |> Compile_simple.Verification_key.hash |> Snark_params.Tick.Field.to_string
+  |> Core.printf "System L1 disabled vk: %s\n"
+
+let tag = Lazy.force B_mina.System_L2.tag
+
+let () =
+  Promise.block_on_async_exn (fun () ->
+      Compile_simple.Verification_key.of_tag tag )
+  |> Compile_simple.Verification_key.hash |> Snark_params.Tick.Field.to_string
+  |> Core.printf "System L2 vk: %s\n"
 
 module B_custom = Zeko_circuits.Bridge_rules.Make_custom (Inputs) ()
 
-let _tag = B_custom.System_L1_enabled.tag
+let tag = Lazy.force B_custom.System_L1_enabled.tag
 
-let _tag = B_custom.System_L1_disabled.tag
+let () =
+  Promise.block_on_async_exn (fun () ->
+      Compile_simple.Verification_key.of_tag tag )
+  |> Compile_simple.Verification_key.hash |> Snark_params.Tick.Field.to_string
+  |> Core.printf "System L1 enabled vk: %s\n"
 
-let _tag = B_custom.System_L2.tag
+let tag = Lazy.force B_custom.System_L1_disabled.tag
+
+let () =
+  Promise.block_on_async_exn (fun () ->
+      Compile_simple.Verification_key.of_tag tag )
+  |> Compile_simple.Verification_key.hash |> Snark_params.Tick.Field.to_string
+  |> Core.printf "System L1 disabled vk: %s\n"
+
+let tag = Lazy.force B_custom.System_L2.tag
+
+let () =
+  Promise.block_on_async_exn (fun () ->
+      Compile_simple.Verification_key.of_tag tag )
+  |> Compile_simple.Verification_key.hash |> Snark_params.Tick.Field.to_string
+  |> Core.printf "System L2 vk: %s\n"

--- a/src/app/zeko/tests/compile_circuits.ml
+++ b/src/app/zeko/tests/compile_circuits.ml
@@ -22,6 +22,8 @@ module Inputs = struct
 
   let zeko_l2 = point_of_string "39921"
 
+  let emergency_da_public_key = point_of_string "43210"
+
   let withdrawal_delay = Mina_numbers.Global_slot_span.of_string "5"
 
   let holder_account_l1_permissions_enabled : Mina_base.Permissions.t =

--- a/src/app/zeko/tests/dune
+++ b/src/app/zeko/tests/dune
@@ -5,7 +5,7 @@
 
 (executable
  (name compile_circuits)
- (libraries zeko_circuits compile_simple compile_simple_fake)
+ (libraries zeko_circuits compile_simple compile_simple_real)
  (instrumentation
   (backend bisect_ppx))
  (preprocess

--- a/src/app/zeko/tests/test_all_real.ml
+++ b/src/app/zeko/tests/test_all_real.ml
@@ -846,6 +846,7 @@ open struct
         ; old_inner_acc_path = convert_path old_inner_acc_path
         ; new_inner_acc_path
         ; da_multisig
+        ; emergency_mode = false
         }
 
       let witness : Outer_rules_inst.Rule_commit_inst.Witness.t =

--- a/src/app/zeko/tests/test_all_real.ml
+++ b/src/app/zeko/tests/test_all_real.ml
@@ -902,6 +902,8 @@ open struct
 
     let zeko_l2 = inner_public_key
 
+    let emergency_da_public_key = point_of_string "44444"
+
     let withdrawal_delay = Mina_numbers.Global_slot_span.of_string "5"
 
     let holder_account_l1_permissions_enabled : Mina_base.Permissions.t =

--- a/src/app/zeko/tests/test_all_real.ml
+++ b/src/app/zeko/tests/test_all_real.ml
@@ -468,10 +468,10 @@ open struct
         let (Typ typ) = Account_set.typ in
         typ.value_of_fields ([| x |], typ.constraint_system_auxiliary ())
 
-      (* let of_account_set x =
-         let (Typ typ) = Account_set.typ in
-         let fields, _aux = typ.value_to_fields x in
-         match fields with [| f |] -> f | _ -> failwith __LOC__ *)
+      let account_set_to_field x =
+        let (Typ typ) = Account_set.typ in
+        let fields, _aux = typ.value_to_fields x in
+        match fields with [| f |] -> f | _ -> failwith __LOC__
 
       let derive pk =
         Mina_base.Account_id.create pk Mina_base.Token_id.default
@@ -527,6 +527,11 @@ open struct
         { Txn_state.get_account_set_x =
             list_to_fun [ first.S.before; second.S.before ]
         ; get_account_set_z = list_to_fun [ first.after; second.after ]
+        ; get_account_set_y_prev_hash =
+            list_to_fun [ first.S.y_prev_hash; second.S.y_prev_hash ]
+        ; get_account_set_y_prev_path =
+            List.map ~f:convert_path [ first.y_prev_path; second.y_prev_path ]
+            |> list_to_fun
         ; get_account_set_x_path =
             List.map ~f:convert_path [ first.before_path; second.before_path ]
             |> list_to_fun
@@ -806,10 +811,9 @@ open struct
 
       let da_signature =
         let input =
-          let open Random_oracle.Input.Chunked in
-          (* append *)
-          stmt.target_ledger |> field
-          (* (stmt.target_acc_set |> of_account_set |> field) *)
+          Random_oracle.Input.Chunked.(
+            append (field stmt.target_ledger)
+              (field (account_set_to_field stmt.target_acc_set)))
         in
         let payload =
           Random_oracle.hash

--- a/src/app/zeko/tests/test_all_real.ml
+++ b/src/app/zeko/tests/test_all_real.ml
@@ -29,7 +29,7 @@ open struct
       let trans0, proof0 =
         Promise.block_on_async_exn
         @@ fun () ->
-        Ase.With_length.leaf
+        (Lazy.force Ase.With_length.leaf)
           ( [ Field.one ]
           , { action_state = Field.of_string "6"
             ; length = Unsigned.UInt32.of_string "42"
@@ -38,12 +38,13 @@ open struct
       let trans1, proof1 =
         Promise.block_on_async_exn
         @@ fun () ->
-        Ase.With_length.leaf_option ([ Field.of_string "2" ], trans0.target)
+        (Lazy.force Ase.With_length.leaf_option)
+          ([ Field.of_string "2" ], trans0.target)
 
       let trans2, proof2 =
         Promise.block_on_async_exn
         @@ fun () ->
-        Ase.With_length.merge
+        (Lazy.force Ase.With_length.merge)
           { left = trans0
           ; left_proof = proof0
           ; right = trans1
@@ -53,12 +54,13 @@ open struct
       let trans3, proof3 =
         Promise.block_on_async_exn
         @@ fun () ->
-        Ase.With_length.extend ([ Field.of_string "99" ], (trans2, proof2))
+        (Lazy.force Ase.With_length.extend)
+          ([ Field.of_string "99" ], (trans2, proof2))
 
       let trans4, proof4 =
         Promise.block_on_async_exn
         @@ fun () ->
-        Ase.With_length.extend_option
+        (Lazy.force Ase.With_length.extend_option)
           ([ Field.of_string "99" ], (trans3, proof3))
     end in
     (trans4, proof4)
@@ -67,17 +69,19 @@ open struct
     let open struct
       let trans0, proof0 =
         Promise.block_on_async_exn
-        @@ fun () -> Ase.Without_length.leaf ([ Field.one ], Field.of_string "6")
+        @@ fun () ->
+        (Lazy.force Ase.Without_length.leaf) ([ Field.one ], Field.of_string "6")
 
       let trans1, proof1 =
         Promise.block_on_async_exn
         @@ fun () ->
-        Ase.Without_length.leaf_option ([ Field.of_string "2" ], trans0.target)
+        (Lazy.force Ase.Without_length.leaf_option)
+          ([ Field.of_string "2" ], trans0.target)
 
       let trans2, proof2 =
         Promise.block_on_async_exn
         @@ fun () ->
-        Ase.Without_length.merge
+        (Lazy.force Ase.Without_length.merge)
           { left = trans0
           ; left_proof = proof0
           ; right = trans1
@@ -87,12 +91,13 @@ open struct
       let trans3, proof3 =
         Promise.block_on_async_exn
         @@ fun () ->
-        Ase.Without_length.extend ([ Field.of_string "99" ], (trans2, proof2))
+        (Lazy.force Ase.Without_length.extend)
+          ([ Field.of_string "99" ], (trans2, proof2))
 
       let trans4, proof4 =
         Promise.block_on_async_exn
         @@ fun () ->
-        Ase.Without_length.extend_option
+        (Lazy.force Ase.Without_length.extend_option)
           ([ Field.of_string "99" ], (trans3, proof3))
     end in
     (trans4, proof4)
@@ -118,7 +123,7 @@ open struct
 
   let _inner_stmt, _inner_proof =
     let open struct
-      let Compile_simple.[ sync; action ] = Inner_rules_inst.provers
+      let Compile_simple.[ sync; action ] = Lazy.force Inner_rules_inst.provers
 
       let ase_with_length : Rule_inner_sync.Ase_inst.t =
         Rule_inner_sync.Ase_inst.make ~proof_source:ase_with_length.source
@@ -162,12 +167,17 @@ open struct
         let inner_public_key = inner_public_key
 
         let chain_l1 = Mina_signature_kind.Testnet
+
+        let max_sequencer_inactivity = 128
+
+        let emergency_da_public_key = point_of_string "223344"
       end)
       ()
 
   let _txn_stmt, _txn_proof =
     let open struct
-      let Compile_simple.[ commit; action; _pause ] = Outer_rules_inst.provers
+      let Compile_simple.[ commit; _emergency_commit; action; _pause ] =
+        Lazy.force Outer_rules_inst.provers
 
       (*
     let pause_witness : Rule_pause.Witness.t =
@@ -196,7 +206,8 @@ open struct
       let _stmt, _proof =
         Promise.block_on_async_exn @@ fun () -> action action_witness
 
-      let Compile_simple.[ prove_both ] = Rule_commit.Verify_both_ases.provers
+      let Compile_simple.[ prove_both ] =
+        Lazy.force Rule_commit.Verify_both_ases.provers
 
       let ase_outer =
         let default = Mina_base.Zkapp_account.Actions.empty_state_element in
@@ -250,7 +261,7 @@ open struct
             ; _zkapp_proved
             ; merge
             ] =
-        Txn_rules.provers
+        Lazy.force Txn_rules.provers
 
       let constraint_constants : Genesis_constants.Constraint_constants.t =
         { sub_windows_per_window = 1
@@ -789,18 +800,23 @@ open struct
         Signature_lib.Schnorr.Chunked.sign ~signature_kind da_kp.private_key
           (Random_oracle.Input.Chunked.field payload)
 
-      let da_key =
-        da_kp.public_key |> Public_key.compress
-        |> fun p : Zeko_util.Even_PC.t ->
-        { public_key = p.Public_key.Compressed.Poly.x }
-
       let () = assert (Int.(List.length old_inner_acc_path = 35))
 
       let () = assert (Int.(List.length new_inner_acc_path = 35))
 
-      let witness : Outer_rules_inst.Rule_commit_inst.Witness.t =
-        { txn_snark = Txn_rules.make_unchecked ~proof stmt
-        ; public_key = point_of_string "29421"
+      let da_multisig : Multisig.Witness.t =
+        { signatures =
+            [ { Multisig.Maybe_signature.public_key =
+                  Public_key.compress da_kp.public_key
+              ; signature = da_signature
+              ; is_some = true
+              }
+            ]
+        ; quorum = Field.of_int 1
+        }
+
+      let base_witness : Outer_rules_inst.Rule_commit_inst.Base_witness.t =
+        { public_key = point_of_string "29421"
         ; vk_hash = Snark_params.Tick.Field.zero
         ; slot_range =
             { lower = Mina_numbers.Global_slot_since_genesis.zero
@@ -810,8 +826,12 @@ open struct
         ; new_inner_acc = old_inner_acc
         ; old_inner_acc_path = convert_path old_inner_acc_path
         ; new_inner_acc_path
-        ; da_signature
-        ; da_key
+        ; da_multisig
+        }
+
+      let witness : Outer_rules_inst.Rule_commit_inst.Witness.t =
+        { txn_snark = Txn_rules.make_unchecked ~proof stmt
+        ; base_witness
         ; verify_both_ases
         }
 
@@ -906,6 +926,8 @@ open struct
 
     let withdrawal_delay = Mina_numbers.Global_slot_span.of_string "5"
 
+    let max_sequencer_inactivity = 128
+
     let holder_account_l1_permissions_enabled : Mina_base.Permissions.t =
       { edit_state = Proof
       ; access = None
@@ -948,17 +970,19 @@ open struct
   module Inner_rules = Inner_rules.Make (Inputs) ()
 
   let Compile_simple.[ cancel_deposit; finalize_withdrawal; _ ] =
-    Bridge.System_L1_enabled.provers
+    Lazy.force Bridge.System_L1_enabled.provers
 
   let Compile_simple.[ finalize_deposit; inner_receive ] =
-    Bridge.System_L2.provers
+    Lazy.force Bridge.System_L2.provers
 
   let Compile_simple.[ outer_token_owner ] =
-    Bridge.System_L1_token_owner.provers
+    Lazy.force Bridge.System_L1_token_owner.provers
 
-  let Compile_simple.[ _; outer_action_witness; _ ] = Outer_rules.provers
+  let Compile_simple.[ _; _; outer_action_witness; _ ] =
+    Lazy.force Outer_rules.provers
 
-  let Compile_simple.[ _; inner_action_witness ] = Inner_rules.provers
+  let Compile_simple.[ _; inner_action_witness ] =
+    Lazy.force Inner_rules.provers
 
   module Deposit = struct
     let recipient = Keypair.create ()
@@ -1012,7 +1036,8 @@ open struct
           ; vk_hash =
               ( Promise.block_on_async_exn
               @@ fun () ->
-              Compile_simple.Verification_key.of_tag Outer_rules.tag )
+              Compile_simple.Verification_key.of_tag
+                (Lazy.force Outer_rules.tag) )
               |> Compile_simple.Verification_key.hash
           ; witness = deposit_witness
           }
@@ -1091,7 +1116,7 @@ open struct
         let Bridge.Check_accepted.{ source; target }, proof =
           Promise.block_on_async_exn
           @@ fun () ->
-          Bridge.Check_accepted.leaf_option
+          (Lazy.force Bridge.Check_accepted.leaf_option)
             ( [ Commit commit_witness ]
             , { params = deposit_params
               ; action_state =
@@ -1128,7 +1153,8 @@ open struct
           ; vk_hash =
               ( Promise.block_on_async_exn
               @@ fun () ->
-              Compile_simple.Verification_key.of_tag Bridge.System_L2.tag )
+              Compile_simple.Verification_key.of_tag
+                (Lazy.force Bridge.System_L2.tag) )
               |> Compile_simple.Verification_key.hash
           ; may_use_token = Bridge.Rule_bridge_finalize_deposit.May_use_token.No
           ; inner_authorization_kind = Rule_bridge_finalize_deposit.A.None_given
@@ -1279,7 +1305,8 @@ open struct
           ; vk_hash =
               ( Promise.block_on_async_exn
               @@ fun () ->
-              Compile_simple.Verification_key.of_tag Outer_rules.tag )
+              Compile_simple.Verification_key.of_tag
+                (Lazy.force Outer_rules.tag) )
               |> Compile_simple.Verification_key.hash
           ; witness = deposit_witness
           }
@@ -1380,8 +1407,9 @@ open struct
             action_state [ commit_action ]
         in
         let [ prover ] =
-          Bridge.Rule_bridge_finalize_cancelled_deposit.Verify_two_outer_ases
-          .provers
+          Lazy.force
+            Bridge.Rule_bridge_finalize_cancelled_deposit.Verify_two_outer_ases
+            .provers
         in
         let stmt, proof =
           Promise.block_on_async_exn @@ fun () -> prover (commit_ase, sync_ase)
@@ -1394,7 +1422,7 @@ open struct
           let Bridge.Check_accepted.{ source; target }, proof =
             Promise.block_on_async_exn
             @@ fun () ->
-            Bridge.Check_accepted.leaf_option
+            (Lazy.force Bridge.Check_accepted.leaf_option)
               ( [ Commit commit_witness ]
               , { params = deposit_params
                 ; action_state =
@@ -1439,9 +1467,10 @@ open struct
             action_state []
         in
         let [ prover ] =
-          Bridge.Rule_bridge_finalize_cancelled_deposit
-          .Verify_check_accepted_and_ase
-          .provers
+          Lazy.force
+            Bridge.Rule_bridge_finalize_cancelled_deposit
+            .Verify_check_accepted_and_ase
+            .provers
         in
         let stmt, proof =
           Promise.block_on_async_exn
@@ -1463,7 +1492,7 @@ open struct
               ( Promise.block_on_async_exn
               @@ fun () ->
               Compile_simple.Verification_key.of_tag
-                Bridge.System_L1_enabled.tag )
+                (Lazy.force Bridge.System_L1_enabled.tag) )
               |> Compile_simple.Verification_key.hash
           ; may_use_token =
               Bridge.Rule_bridge_finalize_cancelled_deposit.May_use_token.No
@@ -1480,7 +1509,7 @@ open struct
               ( Promise.block_on_async_exn
               @@ fun () ->
               Compile_simple.Verification_key.of_tag
-                Bridge.System_L1_token_owner.tag )
+                (Lazy.force Bridge.System_L1_token_owner.tag) )
               |> Compile_simple.Verification_key.hash
           }
       in
@@ -1573,7 +1602,7 @@ open struct
               ( Promise.block_on_async_exn
               @@ fun () ->
               Compile_simple.Verification_key.of_tag
-                Bridge.System_L1_token_owner.tag )
+                (Lazy.force Bridge.System_L1_token_owner.tag) )
               |> Compile_simple.Verification_key.hash
           ; a = helper_account.body
           }
@@ -1610,7 +1639,8 @@ open struct
           ; vk_hash =
               ( Promise.block_on_async_exn
               @@ fun () ->
-              Compile_simple.Verification_key.of_tag Inner_rules.tag )
+              Compile_simple.Verification_key.of_tag
+                (Lazy.force Inner_rules.tag) )
               |> Compile_simple.Verification_key.hash
           ; amount
           }
@@ -1644,7 +1674,8 @@ open struct
           ; vk_hash =
               ( Promise.block_on_async_exn
               @@ fun () ->
-              Compile_simple.Verification_key.of_tag Inner_rules.tag )
+              Compile_simple.Verification_key.of_tag
+                (Lazy.force Inner_rules.tag) )
               |> Compile_simple.Verification_key.hash
           ; witness = withdrawal_witness
           }
@@ -1725,7 +1756,7 @@ open struct
               ( Promise.block_on_async_exn
               @@ fun () ->
               Compile_simple.Verification_key.of_tag
-                Bridge.System_L1_enabled.tag )
+                (Lazy.force Bridge.System_L1_enabled.tag) )
               |> Compile_simple.Verification_key.hash
           ; may_use_token = Bridge.Rule_bridge_finalize_deposit.May_use_token.No
           ; outer_authorization_kind =
@@ -1741,12 +1772,13 @@ open struct
               ( Promise.block_on_async_exn
               @@ fun () ->
               Compile_simple.Verification_key.of_tag
-                Bridge.System_L1_token_owner.tag )
+                (Lazy.force Bridge.System_L1_token_owner.tag) )
               |> Compile_simple.Verification_key.hash
           ; l2_holder_vk_hash =
               ( Promise.block_on_async_exn
               @@ fun () ->
-              Compile_simple.Verification_key.of_tag Inner_rules.tag )
+              Compile_simple.Verification_key.of_tag
+                (Lazy.force Inner_rules.tag) )
               |> Compile_simple.Verification_key.hash
           }
       in
@@ -1843,7 +1875,7 @@ open struct
               ( Promise.block_on_async_exn
               @@ fun () ->
               Compile_simple.Verification_key.of_tag
-                Bridge.System_L1_token_owner.tag )
+                (Lazy.force Bridge.System_L1_token_owner.tag) )
               |> Compile_simple.Verification_key.hash
           ; a = helper_account.body
           }

--- a/src/app/zeko/tests/test_all_real.ml
+++ b/src/app/zeko/tests/test_all_real.ml
@@ -174,9 +174,16 @@ open struct
       end)
       ()
 
+  module Emergency_da_rules_inst =
+    Emergency_da_rules.Make
+      (struct
+        let chain_l1 = Mina_signature_kind.Testnet
+      end)
+      ()
+
   let _txn_stmt, _txn_proof =
     let open struct
-      let Compile_simple.[ commit; _emergency_commit; action; _pause ] =
+      let Compile_simple.[ commit; emergency_commit; action; _pause ] =
         Lazy.force Outer_rules_inst.provers
 
       (*
@@ -313,6 +320,8 @@ open struct
         ; balance = Currency.Balance.of_mina_string_exn "100000"
         }
 
+      let fee_payer_acc_source = fee_payer_acc
+
       let path_inner =
         `Left (Mina_base.Account.digest fee_payer_acc)
         :: ( List.map ~f:(fun (_, h) -> `Left h)
@@ -334,6 +343,12 @@ open struct
         :: List.map
              ~f:(fun (_, h) -> `Left h)
              (List.drop intermediate_ledger_hashes 2)
+
+      let path_inner_source = path_inner
+
+      let path_fee_payer_source = path_fee_payer
+
+      let path_new_source = path_new
 
       let source_ledger = implied_root old_inner_acc path_inner
 
@@ -611,6 +626,8 @@ open struct
           cons_zkapp_command_commitment Unsigned.UInt32.zero
             (Zkapp_command_commitment full_transaction_commitment) empty)
 
+      let receipt_chain_hash_0 = receipt_chain_hash
+
       let fee_payer_acc =
         { fee_payer_acc with nonce = Unsigned.UInt32.one; receipt_chain_hash }
 
@@ -727,6 +744,8 @@ open struct
             (Zkapp_command_commitment full_transaction_commitment)
             receipt_chain_hash)
 
+      let receipt_chain_hash_1 = receipt_chain_hash
+
       let fee_payer_acc =
         { fee_payer_acc with nonce = Unsigned.UInt32.one; receipt_chain_hash }
 
@@ -835,9 +854,487 @@ open struct
         ; verify_both_ases
         }
 
-      let stmt, proof = Promise.block_on_async_exn @@ fun () -> commit witness
+      let commit_stmt, commit_proof =
+        Promise.block_on_async_exn @@ fun () -> commit witness
+
+      let Compile_simple.[ emergency_da_apply ] =
+        Lazy.force Emergency_da_rules_inst.provers
+
+      let to_emergency_path path =
+        List.map
+          ~f:(function
+            | `Left hash_other ->
+                ( { Rule_emergency_da.Ledger_path.Step.hash_other
+                  ; is_right = false
+                  }
+                  : Rule_emergency_da.Ledger_path.Step.t )
+            | `Right hash_other ->
+                ( { Rule_emergency_da.Ledger_path.Step.hash_other
+                  ; is_right = true
+                  }
+                  : Rule_emergency_da.Ledger_path.Step.t ) )
+          path
+
+      let action_fields_of_emergency_output
+          ((_, (account_update, _digest, _calls)) :
+            Mina_base.Zkapp_statement.t
+            * ( Mina_base.Account_update.Body.t
+              * Mina_base.Zkapp_command.Digest.Account_update.t
+              * ( Mina_base.Account_update.t
+                , Mina_base.Zkapp_command.Digest.Account_update.t
+                , Rollup_state.Zkapp_call_forest.Digest.t )
+                Mina_base.Zkapp_command.Call_forest.t ) ) : Field.t array =
+        let Mina_base.Account_update.Body.{ actions; _ } = account_update in
+        match actions with
+        | [ action_fields ] ->
+            action_fields
+        | _ ->
+            failwith __LOC__
+
+      let emergency_da_action ~source_ledger_hash ~target_ledger_hash
+          ~ledger_index ~account : Rule_emergency_da.Action.t =
+        { source_ledger_hash; target_ledger_hash; ledger_index; account }
+
+      let assert_action_fields_equal expected actual =
+        assert (Int.(Array.length expected = Array.length actual)) ;
+        assert (Array.for_all2_exn expected actual ~f:Field.equal)
+
+      let action_to_fields action =
+        let (Snark_params.Tick.Typ.Typ action_typ) =
+          Rule_emergency_da.Action.typ
+        in
+        let fields, _aux = action_typ.value_to_fields action in
+        fields
+
+      let fee_payer_acc_after_first =
+        { fee_payer_acc_source with
+          nonce = Unsigned.UInt32.one
+        ; receipt_chain_hash = receipt_chain_hash_0
+        }
+
+      let fee_payer_balance_after_third =
+        let b, _ =
+          Currency.Balance.add_signed_amount_flagged
+            fee_payer_acc_after_first.balance
+            third_account_update.balance_change
+        in
+        b
+
+      let fee_payer_acc_after_third =
+        { fee_payer_acc_after_first with
+          receipt_chain_hash = receipt_chain_hash_1
+        ; balance = fee_payer_balance_after_third
+        }
+
+      let new_account_created =
+        { Mina_base.Account.empty with
+          public_key = Public_key.compress new_kp.public_key
+        ; balance = Currency.Balance.of_mina_string_exn "1"
+        ; delegate = Some (Public_key.compress new_kp.public_key)
+        }
+
+      let emergency_sparse_ledger : Mina_ledger.Sparse_ledger.t =
+        Mina_ledger.Sparse_ledger.of_root
+          ~depth:constraint_constants.ledger_depth stmt.source_ledger
+        |> fun x ->
+        Mina_ledger.Sparse_ledger.add_path x path_inner_source
+          (id_of old_inner_acc) old_inner_acc
+        |> fun x ->
+        Mina_ledger.Sparse_ledger.add_path x path_fee_payer_source
+          (id_of fee_payer_acc_source)
+          fee_payer_acc_source
+        |> fun x ->
+        Mina_ledger.Sparse_ledger.add_path x path_new_source account_id_new
+          Mina_base.Account.empty
+
+      let update_sparse ledger account_id account =
+        let idx = Mina_ledger.Sparse_ledger.find_index_exn ledger account_id in
+        Mina_ledger.Sparse_ledger.set_exn ledger idx account
+
+      let emergency_ledger_1 =
+        update_sparse emergency_sparse_ledger
+          (id_of fee_payer_acc_source)
+          fee_payer_acc_after_first
+
+      let emergency_ledger_2 =
+        update_sparse emergency_ledger_1 (id_of old_inner_acc) old_inner_acc
+
+      let emergency_ledger_3 =
+        update_sparse emergency_ledger_2
+          (id_of fee_payer_acc_source)
+          fee_payer_acc_after_third
+
+      let emergency_ledger_4 =
+        update_sparse emergency_ledger_3 account_id_new new_account_created
+
+      let ledger0 =
+        Mina_ledger.Sparse_ledger.merkle_root emergency_sparse_ledger
+
+      let ledger1 = Mina_ledger.Sparse_ledger.merkle_root emergency_ledger_1
+
+      let ledger2 = Mina_ledger.Sparse_ledger.merkle_root emergency_ledger_2
+
+      let ledger3 = Mina_ledger.Sparse_ledger.merkle_root emergency_ledger_3
+
+      let ledger4 = Mina_ledger.Sparse_ledger.merkle_root emergency_ledger_4
+
+      let () = assert (Mina_base.Ledger_hash.equal ledger0 stmt.source_ledger)
+
+      let () = assert (Mina_base.Ledger_hash.equal ledger4 stmt.target_ledger)
+
+      let fee_payer_index =
+        Mina_ledger.Sparse_ledger.find_index_exn emergency_sparse_ledger
+          (id_of fee_payer_acc_source)
+
+      let inner_index =
+        Mina_ledger.Sparse_ledger.find_index_exn emergency_sparse_ledger
+          (id_of old_inner_acc)
+
+      let new_index =
+        Mina_ledger.Sparse_ledger.find_index_exn emergency_sparse_ledger
+          account_id_new
+
+      let fee_payer_path_0 =
+        Mina_ledger.Sparse_ledger.path_exn emergency_sparse_ledger
+          fee_payer_index
+
+      let inner_path_1 =
+        Mina_ledger.Sparse_ledger.path_exn emergency_ledger_1 inner_index
+
+      let fee_payer_path_2 =
+        Mina_ledger.Sparse_ledger.path_exn emergency_ledger_2 fee_payer_index
+
+      let new_path_3 =
+        Mina_ledger.Sparse_ledger.path_exn emergency_ledger_3 new_index
+
+      let emergency_da_witness_1 : Rule_emergency_da.Witness.t =
+        { public_key = point_of_string "281"
+        ; vk_hash = Field.zero
+        ; old_account = fee_payer_acc_source
+        ; new_account = fee_payer_acc_after_first
+        ; ledger_path = to_emergency_path fee_payer_path_0
+        ; ledger_index = Zeko_util.Checked32.of_int fee_payer_index
+        }
+
+      let emergency_da_witness_2 : Rule_emergency_da.Witness.t =
+        { public_key = point_of_string "281"
+        ; vk_hash = Field.zero
+        ; old_account = old_inner_acc
+        ; new_account = old_inner_acc
+        ; ledger_path = to_emergency_path inner_path_1
+        ; ledger_index = Zeko_util.Checked32.of_int inner_index
+        }
+
+      let emergency_da_witness_3 : Rule_emergency_da.Witness.t =
+        { public_key = point_of_string "281"
+        ; vk_hash = Field.zero
+        ; old_account = fee_payer_acc_after_first
+        ; new_account = fee_payer_acc_after_third
+        ; ledger_path = to_emergency_path fee_payer_path_2
+        ; ledger_index = Zeko_util.Checked32.of_int fee_payer_index
+        }
+
+      let emergency_da_witness_4 : Rule_emergency_da.Witness.t =
+        { public_key = point_of_string "281"
+        ; vk_hash = Field.zero
+        ; old_account = Mina_base.Account.empty
+        ; new_account = new_account_created
+        ; ledger_path = to_emergency_path new_path_3
+        ; ledger_index = Zeko_util.Checked32.of_int new_index
+        }
+
+      let emergency_da_out_1, _emergency_da_proof_1 =
+        Promise.block_on_async_exn
+        @@ fun () -> emergency_da_apply emergency_da_witness_1
+
+      let emergency_da_out_2, _emergency_da_proof_2 =
+        Promise.block_on_async_exn
+        @@ fun () -> emergency_da_apply emergency_da_witness_2
+
+      let emergency_da_out_3, _emergency_da_proof_3 =
+        Promise.block_on_async_exn
+        @@ fun () -> emergency_da_apply emergency_da_witness_3
+
+      let emergency_da_out_4, _emergency_da_proof_4 =
+        Promise.block_on_async_exn
+        @@ fun () -> emergency_da_apply emergency_da_witness_4
+
+      let emergency_da_action_fields_1 =
+        action_fields_of_emergency_output emergency_da_out_1
+
+      let emergency_da_action_fields_2 =
+        action_fields_of_emergency_output emergency_da_out_2
+
+      let emergency_da_action_fields_3 =
+        action_fields_of_emergency_output emergency_da_out_3
+
+      let emergency_da_action_fields_4 =
+        action_fields_of_emergency_output emergency_da_out_4
+
+      let emergency_da_action_1 =
+        emergency_da_action ~source_ledger_hash:ledger0
+          ~target_ledger_hash:ledger1
+          ~ledger_index:(Zeko_util.Checked32.of_int fee_payer_index)
+          ~account:fee_payer_acc_after_first
+
+      let emergency_da_action_2 =
+        emergency_da_action ~source_ledger_hash:ledger1
+          ~target_ledger_hash:ledger2
+          ~ledger_index:(Zeko_util.Checked32.of_int inner_index)
+          ~account:old_inner_acc
+
+      let emergency_da_action_3 =
+        emergency_da_action ~source_ledger_hash:ledger2
+          ~target_ledger_hash:ledger3
+          ~ledger_index:(Zeko_util.Checked32.of_int fee_payer_index)
+          ~account:fee_payer_acc_after_third
+
+      let emergency_da_action_4 =
+        emergency_da_action ~source_ledger_hash:ledger3
+          ~target_ledger_hash:ledger4
+          ~ledger_index:(Zeko_util.Checked32.of_int new_index)
+          ~account:new_account_created
+
+      let expected_action_fields_1 = action_to_fields emergency_da_action_1
+
+      let expected_action_fields_2 = action_to_fields emergency_da_action_2
+
+      let expected_action_fields_3 = action_to_fields emergency_da_action_3
+
+      let expected_action_fields_4 = action_to_fields emergency_da_action_4
+
+      let () =
+        assert_action_fields_equal expected_action_fields_1
+          emergency_da_action_fields_1
+
+      let () =
+        assert_action_fields_equal expected_action_fields_2
+          emergency_da_action_fields_2
+
+      let () =
+        assert_action_fields_equal expected_action_fields_3
+          emergency_da_action_fields_3
+
+      let () =
+        assert_action_fields_equal expected_action_fields_4
+          emergency_da_action_fields_4
+
+      let () =
+        assert (
+          Mina_base.Ledger_hash.equal emergency_da_action_1.source_ledger_hash
+            ledger0 )
+
+      let () =
+        assert (
+          Mina_base.Ledger_hash.equal emergency_da_action_1.target_ledger_hash
+            ledger1 )
+
+      let () =
+        assert (
+          Mina_base.Ledger_hash.equal emergency_da_action_2.source_ledger_hash
+            ledger1 )
+
+      let () =
+        assert (
+          Mina_base.Ledger_hash.equal emergency_da_action_2.target_ledger_hash
+            ledger2 )
+
+      let () =
+        assert (
+          Mina_base.Ledger_hash.equal emergency_da_action_3.source_ledger_hash
+            ledger2 )
+
+      let () =
+        assert (
+          Mina_base.Ledger_hash.equal emergency_da_action_3.target_ledger_hash
+            ledger3 )
+
+      let () =
+        assert (
+          Mina_base.Ledger_hash.equal emergency_da_action_4.source_ledger_hash
+            ledger3 )
+
+      let () =
+        assert (
+          Mina_base.Ledger_hash.equal emergency_da_action_4.target_ledger_hash
+            ledger4 )
+
+      let emergency_da_actions =
+        [ emergency_da_action_1
+        ; emergency_da_action_2
+        ; emergency_da_action_3
+        ; emergency_da_action_4
+        ]
+
+      let action_state_from_actions =
+        let (Typ typ) = Rule_emergency_da.Action.typ in
+        List.fold emergency_da_actions
+          ~init:Mina_base.Zkapp_account.Actions.empty_state_element
+          ~f:(fun acc action ->
+            let action_fields, _aux = typ.value_to_fields action in
+            let actions =
+              Mina_base.Zkapp_account.Actions.of_event_list [ action_fields ]
+            in
+            Mina_base.Zkapp_account.Actions.push_events acc actions )
+
+      let emergency_da_source_stmt : Emergency_da_folder.Stmt.t =
+        { source_ledger = stmt.source_ledger
+        ; target_ledger = stmt.source_ledger
+        ; target_action_state =
+            Mina_base.Zkapp_account.Actions.empty_state_element
+        }
+
+      let ( ({ source = emergency_da_proof_source
+             ; target = emergency_da_proof_target
+             } :
+              Emergency_da_folder.trans )
+          , emergency_da_proof ) =
+        Promise.block_on_async_exn
+        @@ fun () ->
+        (Lazy.force Emergency_da_folder.leaf_option)
+          ( List.map emergency_da_actions
+              ~f:(fun action : Emergency_da_folder.Elem.t ->
+                { Emergency_da_folder.Elem.advance = true; action } )
+          , emergency_da_source_stmt )
+
+      let () =
+        assert (
+          Mina_base.Ledger_hash.equal emergency_da_proof_target.target_ledger
+            stmt.target_ledger )
+
+      let () =
+        assert (
+          Field.equal emergency_da_proof_target.target_action_state
+            action_state_from_actions )
+
+      let emergency_da_inst : Rule_commit.Emergency_da_inst.t =
+        Rule_commit.Emergency_da_inst.make
+          ~proof_source:emergency_da_proof_source
+          ~proof_target:emergency_da_proof_target ~proof:emergency_da_proof
+          emergency_da_source_stmt []
+
+      let last_commit : Rollup_state.Outer_action.Commit.t =
+        { ledger = stmt.source_ledger
+        ; inner_action_state = Rollup_state.Inner_action_state.With_length.empty
+        ; synchronized_outer_action_state =
+            Rollup_state.Outer_action_state.With_length.empty
+        ; slot_range =
+            { lower = Zeko_util.Slot.zero; upper = Zeko_util.Slot.zero }
+        }
+
+      let before_last_commit = Rollup_state.Outer_action_state.empty
+
+      let last_commit_actions_hash, after_last_commit =
+        let (Typ typ) =
+          Typ.(Field.typ * Rollup_state.Outer_action.Commit.typ)
+        in
+        let action_fields, _aux =
+          typ.value_to_fields (Field.of_int 0, last_commit)
+        in
+        let actions =
+          Mina_base.Zkapp_account.Actions.of_event_list [ action_fields ]
+        in
+        let after_last_commit_field =
+          Mina_base.Zkapp_account.Actions.push_events
+            (Rollup_state.Outer_action_state.raw before_last_commit)
+            actions
+        in
+        ( actions.hash
+        , Rollup_state.Outer_action_state.unsafe_value_of_field
+            after_last_commit_field )
+
+      let count_commits_stmt : Count_commits.Definition.Stmt.t =
+        { source_action_state = after_last_commit
+        ; target_action_state = after_last_commit
+        ; n_commits = Zeko_util.Checked32.zero
+        }
+
+      let ( ({ source = count_commits_proof_source
+             ; target = count_commits_proof_target
+             } :
+              Count_commits.trans )
+          , count_commits_proof ) =
+        Promise.block_on_async_exn
+        @@ fun () ->
+        (Lazy.force Count_commits.leaf_option) ([], count_commits_stmt)
+
+      let count_commits_init : Count_commits.Definition.Init.t =
+        { original_action_state = after_last_commit }
+
+      let count_commits_inst : Rule_commit.Count_commits_inst.t =
+        Rule_commit.Count_commits_inst.make
+          ~proof_source:count_commits_proof_source
+          ~proof_target:count_commits_proof_target ~proof:count_commits_proof
+          count_commits_init []
+
+      let Compile_simple.[ verify_emergency_folders ] =
+        Lazy.force Rule_commit.Verify_emergency_folders.provers
+
+      let verify_emergency_folders_stmt, verify_emergency_folders_proof =
+        Promise.block_on_async_exn
+        @@ fun () ->
+        verify_emergency_folders (count_commits_inst, emergency_da_inst)
+
+      let verify_emergency_folders =
+        Rule_commit.Verify_emergency_folders.make_unchecked
+          ~proof:verify_emergency_folders_proof verify_emergency_folders_stmt
+
+      let Compile_simple.[ verify_base ] =
+        Lazy.force Rule_commit.Verify_base.provers
+
+      let ase_outer_source =
+        Rollup_state.Outer_action_state.raw
+          Rollup_state.Outer_action_state.empty
+
+      let ase_outer_target =
+        Rollup_state.Outer_action_state.raw after_last_commit
+
+      let ase_outer_emergency : Rule_commit.Ase_outer_inst.t =
+        Rule_commit.Ase_outer_inst.make ~proof_source:ase_outer_source
+          ~proof_target:ase_outer_target ase_outer_source
+          [ last_commit_actions_hash ]
+
+      let verify_both_ases_emergency_stmt, verify_both_ases_emergency_proof =
+        Promise.block_on_async_exn
+        @@ fun () -> prove_both (ase_outer_emergency, ase_inner)
+
+      let verify_both_ases_emergency =
+        Rule_commit.Verify_both_ases.make_unchecked
+          ~proof:verify_both_ases_emergency_proof
+          verify_both_ases_emergency_stmt
+
+      let verify_base_stmt, verify_base_proof =
+        Promise.block_on_async_exn
+        @@ fun () ->
+        verify_base
+          (Txn_rules.make_unchecked ~proof stmt, verify_both_ases_emergency)
+
+      let verify_base =
+        Rule_commit.Verify_base.make_unchecked ~proof:verify_base_proof
+          verify_base_stmt
+
+      let base_witness_emergency =
+        { base_witness with
+          slot_range =
+            { lower = Zeko_util.Slot.of_int 128
+            ; upper = Zeko_util.Slot.of_int 128
+            }
+        }
+
+      let emergency_witness :
+          Outer_rules_inst.Rule_commit_inst.Emergency_commit.Witness.t =
+        { base_witness = base_witness_emergency
+        ; before_last_commit
+        ; last_commit
+        ; verify_emergency_folders
+        ; verify_base
+        }
+
+      let _stmt, _proof =
+        Promise.block_on_async_exn
+        @@ fun () -> emergency_commit emergency_witness
     end in
-    (stmt, proof)
+    (commit_stmt, commit_proof)
 end
 
 open struct

--- a/src/app/zeko/tests/test_all_real.ml
+++ b/src/app/zeko/tests/test_all_real.ml
@@ -1013,7 +1013,6 @@ open struct
         ; old_account = fee_payer_acc_source
         ; new_account = fee_payer_acc_after_first
         ; ledger_path = to_emergency_path fee_payer_path_0
-        ; ledger_index = Zeko_util.Checked32.of_int fee_payer_index
         }
 
       let emergency_da_witness_2 : Rule_emergency_da.Witness.t =
@@ -1022,7 +1021,6 @@ open struct
         ; old_account = old_inner_acc
         ; new_account = old_inner_acc
         ; ledger_path = to_emergency_path inner_path_1
-        ; ledger_index = Zeko_util.Checked32.of_int inner_index
         }
 
       let emergency_da_witness_3 : Rule_emergency_da.Witness.t =
@@ -1031,7 +1029,6 @@ open struct
         ; old_account = fee_payer_acc_after_first
         ; new_account = fee_payer_acc_after_third
         ; ledger_path = to_emergency_path fee_payer_path_2
-        ; ledger_index = Zeko_util.Checked32.of_int fee_payer_index
         }
 
       let emergency_da_witness_4 : Rule_emergency_da.Witness.t =
@@ -1040,7 +1037,6 @@ open struct
         ; old_account = Mina_base.Account.empty
         ; new_account = new_account_created
         ; ledger_path = to_emergency_path new_path_3
-        ; ledger_index = Zeko_util.Checked32.of_int new_index
         }
 
       let emergency_da_out_1, _emergency_da_proof_1 =

--- a/src/app/zeko/tests/test_pause_real.ml
+++ b/src/app/zeko/tests/test_pause_real.ml
@@ -17,10 +17,21 @@ module Outer_rules_inst =
         Signature_lib.Public_key.compress pk
 
       let chain_l1 = Mina_signature_kind.Testnet
+
+      let max_sequencer_inactivity = 128
+
+      let emergency_da_public_key =
+        let pk =
+          Snark_params.Tick.Inner_curve.(
+            to_affine_exn @@ point_near_x
+            @@ Snark_params.Tick.Field.of_int 223344)
+        in
+        Signature_lib.Public_key.compress pk
     end)
     ()
 
-let Compile_simple.[ _commit; _action; pause ] = Outer_rules_inst.provers
+let Compile_simple.[ _commit; _emergency_commit; _action; pause ] =
+  Lazy.force Outer_rules_inst.provers
 
 let point_of_string_even s : Zeko_util.Even_PC.t =
   let x, _ =
@@ -41,4 +52,3 @@ let pause_witness : Rule_pause.Witness.t =
   }
 
 let _stmt, _proof = Promise.block_on_async_exn @@ fun () -> pause pause_witness
-

--- a/src/app/zeko/tests/test_zkapp_real.ml
+++ b/src/app/zeko/tests/test_zkapp_real.ml
@@ -307,6 +307,11 @@ let make_update_acc_set_witness first second =
   { Txn_state.get_account_set_x =
       list_to_fun [ first.S.before; second.S.before ]
   ; get_account_set_z = list_to_fun [ first.after; second.after ]
+  ; get_account_set_y_prev_hash =
+      list_to_fun [ first.S.y_prev_hash; second.S.y_prev_hash ]
+  ; get_account_set_y_prev_path =
+      List.map ~f:convert_path [ first.y_prev_path; second.y_prev_path ]
+      |> list_to_fun
   ; get_account_set_x_path =
       List.map ~f:convert_path [ first.before_path; second.before_path ]
       |> list_to_fun

--- a/src/app/zeko/tests/test_zkapp_real.ml
+++ b/src/app/zeko/tests/test_zkapp_real.ml
@@ -39,7 +39,7 @@ let old_inner_acc =
 
 let Compile_simple.
       [ _signed_command; _zkapp_single; zkapp_double; _zkapp_proved; _merge ] =
-  Txn_rules.provers
+  Lazy.force Txn_rules.provers
 
 let constraint_constants : Genesis_constants.Constraint_constants.t =
   { sub_windows_per_window = 1

--- a/src/app/zeko/tests/transfers.ml
+++ b/src/app/zeko/tests/transfers.ml
@@ -833,7 +833,9 @@ let create_deploy_inner ~(zeko_kp : Keypair.t) () =
         ; sequencer
         ; da_key
         ; acc_set = failwith "FIXME"
-        ; paused = false
+        ; status_flags =
+            Zeko_circuits.Rollup_state.Outer_state.Status_flags.of_bools
+              ~paused:false ~emergency:false
         }
         : Zeko_circuits.Rollup_state.Outer_state.t )
     in

--- a/src/app/zeko/tests/transfers.ml
+++ b/src/app/zeko/tests/transfers.ml
@@ -531,6 +531,8 @@ let prove_zkapp ~source_acc_set
       Zeko_circuits.Zeko_transaction_snark.update_acc_set_witness =
     { get_account_set_x = list_to_unit_function xs
     ; get_account_set_z = list_to_unit_function zs
+    ; get_account_set_y_prev_hash = list_to_unit_function xs
+    ; get_account_set_y_prev_path = list_to_unit_function xs_paths
     ; get_account_set_x_path = list_to_unit_function xs_paths
     ; get_account_set_y_path = list_to_unit_function ys_paths
     }

--- a/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
+++ b/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
@@ -90,6 +90,8 @@ module Inputs = struct
   let max_valid_while_size =
     Zeko_circuits.Zeko_util.Slot.to_int t.max_valid_while_size
 
+  let max_sequencer_inactivity = 24 * 60 * 30 / 3 (* A month in slots *)
+
   let holder_accounts_l1 = t.holder_accounts_l1
 
   let holder_account_l2 = Zeko_constants.inner_holder_key

--- a/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
+++ b/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
@@ -90,7 +90,7 @@ module Inputs = struct
   let max_valid_while_size =
     Zeko_circuits.Zeko_util.Slot.to_int t.max_valid_while_size
 
-  let max_sequencer_inactivity = 24 * 60 * 30 / 3 (* A month in slots *)
+  let max_sequencer_inactivity = (24 * 60 * 30 / 3) + 5 (* A month in slots *)
 
   let holder_accounts_l1 = t.holder_accounts_l1
 

--- a/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
+++ b/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
@@ -15,6 +15,7 @@ type t =
   ; holder_accounts_l1 : Public_key.Compressed.t list
   ; helper_token_owner_l1 : Public_key.Compressed.t
   ; zeko_l1 : Public_key.Compressed.t
+  ; emergency_da_public_key : Public_key.Compressed.t
   ; withdrawal_delay : Global_slot_span.t
   }
 [@@deriving yojson]
@@ -24,6 +25,7 @@ module Deploy = struct
     { holder_accounts_l1 : Private_key.t list
     ; helper_token_owner_l1 : Private_key.t
     ; zeko_l1 : Private_key.t
+    ; emergency_da : Private_key.t
     }
   [@@deriving yojson]
 end
@@ -52,18 +54,23 @@ let (t, deploy_config) : t * Deploy.t option =
       let zeko_l1 =
         keypair_of_b58_sk "EKEFFD7uJayycrse8A2ixBR2Wu7cA5GnGS5ydcYNyzhvr1EPPvj8"
       in
+      let emergency_da =
+        keypair_of_b58_sk "EKE9VtD6g4AgoscJdxBbFak6yfBgnQDHTpyj23CfNFT5BxL51Zin"
+      in
       ( { chain_l1 = Testnet
         ; chain_l2 = Testnet
         ; max_valid_while_size = Zeko_circuits.Zeko_util.Slot.max_value
         ; holder_accounts_l1 = List.map holder_accounts_l1 ~f:fst
         ; helper_token_owner_l1 = fst helper_token_owner_l1
         ; zeko_l1 = fst zeko_l1
+        ; emergency_da_public_key = fst emergency_da
         ; withdrawal_delay = Global_slot_span.of_int 5
         }
       , Some
           { holder_accounts_l1 = List.map holder_accounts_l1 ~f:snd
           ; helper_token_owner_l1 = snd helper_token_owner_l1
           ; zeko_l1 = snd zeko_l1
+          ; emergency_da = snd emergency_da
           } )
   | Some path -> (
       match Yojson.Safe.from_file path |> of_yojson with
@@ -101,6 +108,8 @@ module Inputs = struct
   let zeko_l1 = t.zeko_l1
 
   let zeko_l2 = Zeko_constants.inner_public_key
+
+  let emergency_da_public_key = t.emergency_da_public_key
 
   let withdrawal_delay = t.withdrawal_delay
 

--- a/src/app/zeko/zeko_constants.ml
+++ b/src/app/zeko/zeko_constants.ml
@@ -128,7 +128,15 @@ module Folder_iterations = struct
 
   module Count_commits : FOLDER_ITERATIONS = Check_accepted
 
-  module Emergency_da : FOLDER_ITERATIONS = Check_accepted
+  module Emergency_da : FOLDER_ITERATIONS = struct
+    let leaf_iterations = 8
+
+    let leaf_option_iterations = 4
+
+    let extend_iterations = 4
+
+    let extend_option_iterations = 2
+  end
 end
 
 let multisig_salt = "multisig"

--- a/src/app/zeko/zeko_constants.ml
+++ b/src/app/zeko/zeko_constants.ml
@@ -58,6 +58,8 @@ module Max_excess_actions = struct
     let outer = Int.pow 2 9
 
     let count_commits = Int.pow 2 9
+
+    let emergency_da = Int.pow 2 9
   end
 
   module Finalize_cancelled_deposit = struct

--- a/src/app/zeko/zeko_constants.ml
+++ b/src/app/zeko/zeko_constants.ml
@@ -57,9 +57,9 @@ module Max_excess_actions = struct
 
     let outer = Int.pow 2 9
 
-    let count_commits = Int.pow 2 9
+    let count_commits = 0
 
-    let emergency_da = Int.pow 2 9
+    let emergency_da = 0
   end
 
   module Finalize_cancelled_deposit = struct

--- a/src/app/zeko/zeko_constants.ml
+++ b/src/app/zeko/zeko_constants.ml
@@ -56,6 +56,8 @@ module Max_excess_actions = struct
     let inner = Int.pow 2 9
 
     let outer = Int.pow 2 9
+
+    let count_commits = Int.pow 2 9
   end
 
   module Finalize_cancelled_deposit = struct
@@ -121,6 +123,8 @@ module Folder_iterations = struct
 
     let extend_option_iterations = Int.pow 2 3
   end
+
+  module Count_commits : FOLDER_ITERATIONS = Check_accepted
 end
 
 let multisig_salt = "multisig"

--- a/src/app/zeko/zeko_constants.ml
+++ b/src/app/zeko/zeko_constants.ml
@@ -125,6 +125,8 @@ module Folder_iterations = struct
   end
 
   module Count_commits : FOLDER_ITERATIONS = Check_accepted
+
+  module Emergency_da : FOLDER_ITERATIONS = Check_accepted
 end
 
 let multisig_salt = "multisig"

--- a/src/app/zeko/zeko_types/zeko_types.ml
+++ b/src/app/zeko/zeko_types/zeko_types.ml
@@ -751,6 +751,7 @@ module Outer_commit = struct
     type serializable =
       { txn_snark : Txn_snark.serializable
       ; public_key : Public_key.Compressed.t
+      ; emergency_mode : bool
       ; old_inner_acc : Account.t
       ; old_inner_acc_path : Path.t
       ; new_inner_acc : Account.t
@@ -764,6 +765,7 @@ module Outer_commit = struct
     let of_serializable
         ({ txn_snark
          ; public_key
+         ; emergency_mode
          ; verify_both_ases
          ; old_inner_acc
          ; old_inner_acc_path
@@ -776,6 +778,7 @@ module Outer_commit = struct
       { base_witness =
           { public_key
           ; vk_hash
+          ; emergency_mode
           ; old_inner_acc
           ; old_inner_acc_path
           ; new_inner_acc

--- a/src/app/zeko/zeko_types/zeko_types.ml
+++ b/src/app/zeko/zeko_types/zeko_types.ml
@@ -751,13 +751,13 @@ module Outer_commit = struct
     type serializable =
       { txn_snark : Txn_snark.serializable
       ; public_key : Public_key.Compressed.t
-      ; verify_both_ases : Verify_both_ases.serializable
       ; old_inner_acc : Account.t
       ; old_inner_acc_path : Path.t
       ; new_inner_acc : Account.t
       ; new_inner_acc_path : Path.t
       ; da_multisig : Multisig.Witness.t
       ; slot_range : Slot_range.t
+      ; verify_both_ases : Verify_both_ases.serializable
       }
     [@@deriving yojson]
 
@@ -773,16 +773,18 @@ module Outer_commit = struct
          ; slot_range
          } :
           serializable ) ~vk_hash : t =
-      { txn_snark = Txn_snark.of_serializable txn_snark
-      ; public_key
-      ; vk_hash
+      { base_witness =
+          { txn_snark = Txn_snark.of_serializable txn_snark
+          ; public_key
+          ; vk_hash
+          ; old_inner_acc
+          ; old_inner_acc_path
+          ; new_inner_acc
+          ; new_inner_acc_path
+          ; da_multisig
+          ; slot_range
+          }
       ; verify_both_ases = Verify_both_ases.of_serializable verify_both_ases
-      ; old_inner_acc
-      ; old_inner_acc_path
-      ; new_inner_acc
-      ; new_inner_acc_path
-      ; da_multisig
-      ; slot_range
       }
   end
 end

--- a/src/app/zeko/zeko_types/zeko_types.ml
+++ b/src/app/zeko/zeko_types/zeko_types.ml
@@ -774,8 +774,7 @@ module Outer_commit = struct
          } :
           serializable ) ~vk_hash : t =
       { base_witness =
-          { txn_snark = Txn_snark.of_serializable txn_snark
-          ; public_key
+          { public_key
           ; vk_hash
           ; old_inner_acc
           ; old_inner_acc_path
@@ -784,6 +783,7 @@ module Outer_commit = struct
           ; da_multisig
           ; slot_range
           }
+      ; txn_snark = Txn_snark.of_serializable txn_snark
       ; verify_both_ases = Verify_both_ases.of_serializable verify_both_ases
       }
   end


### PR DESCRIPTION
Until we have decentralized sequencing, we need some kind of mechanism to do emergency commit in case the sequencer goes offline. This PR implements the simple commit in case there has been no commits for some period of time.

The original commit rule stays the same.

The new emergency commit rule reuses the original rule, and checks that there has been no commit for max_sequencer_inactivity slots.

The main drawback of this approach is that the outer action state precondition can be set to the last 5 values, therefore the sequencer has to maintain commits in 5 distinct slots in the max_sequencer_inactivity window.

More detailed explanation is in the spec and rollup explanation doc.

Follwing is left to do:
- [x] tests
- [ ] tooling to execute the emergency commit

fix ZK-115