### PR TITLE
Add events for transfer finalizations

### DIFF
--- a/src/app/zeko/circuits/rule_bridge_finalize_deposit.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_deposit.ml
@@ -206,6 +206,11 @@ struct
       }
     in
     let@ () = with_label __LOC__ in
+    let* events =
+      var_to_events
+        Typ.(Checked32.typ * Deposit_params.typ)
+        (deposit_index, params)
+    in
     let account_update =
       { default_account_update with
         public_key
@@ -215,6 +220,7 @@ struct
       ; balance_change =
           Currency.Amount.Signed.Checked.(
             of_unsigned base_params.amount |> negate)
+      ; events
       }
     in
     let@ () = with_label __LOC__ in

--- a/src/app/zeko/circuits/rule_bridge_finalize_withdrawal.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_withdrawal.ml
@@ -231,6 +231,15 @@ struct
           }
         in
         let@ () = with_label __LOC__ in
+        let* events =
+          let* withdrawal_index =
+            Checked32.Checked.sub next_withdrawal
+              Checked32.(Checked.constant one)
+          in
+          var_to_events
+            Typ.(Checked32.typ * Withdrawal_params.typ)
+            (withdrawal_index, withdrawal_params)
+        in
         let account_update =
           { default_account_update with
             public_key
@@ -240,6 +249,7 @@ struct
           ; balance_change =
               Currency.Amount.Signed.Checked.(
                 of_unsigned base_params.amount |> negate)
+          ; events
           }
         in
         let@ () = with_label __LOC__ in

--- a/src/app/zeko/circuits/zeko_util.ml
+++ b/src/app/zeko/circuits/zeko_util.ml
@@ -281,7 +281,14 @@ let var_to_actions (typ : ('var, 'value) Typ.t) (x : 'var) :
   in
   actions
 
-let var_to_events = var_to_actions
+let var_to_events (typ : ('var, 'value) Typ.t) (x : 'var) :
+    Zkapp_account.Events.var Checked.t =
+  let@ () = make_checked in
+  let empty_events = Zkapp_account.Events.(constant typ []) in
+  let events =
+    Zkapp_account.Events.push_to_data_as_hash empty_events (var_to_fields typ x)
+  in
+  events
 
 let var_to_hash ~(init : string) (typ : ('var, 'value) Typ.t) (x : 'var) :
     F.var Checked.t =

--- a/src/app/zeko/circuits/zeko_util.ml
+++ b/src/app/zeko/circuits/zeko_util.ml
@@ -281,6 +281,8 @@ let var_to_actions (typ : ('var, 'value) Typ.t) (x : 'var) :
   in
   actions
 
+let var_to_events = var_to_actions
+
 let var_to_hash ~(init : string) (typ : ('var, 'value) Typ.t) (x : 'var) :
     F.var Checked.t =
   let@ () = make_checked in

--- a/src/app/zeko/circuits/zeko_util.mli
+++ b/src/app/zeko/circuits/zeko_util.mli
@@ -39,6 +39,9 @@ val var_to_optional_fine :
 val var_to_actions :
   ('var, 'value) Typ.t -> 'var -> Mina_base.Zkapp_account.Actions.var Checked.t
 
+val var_to_events :
+  ('var, 'value) Typ.t -> 'var -> Mina_base.Zkapp_account.Actions.var Checked.t
+
 val var_to_hash :
   init:string -> ('var, 'value) Typ.t -> 'var -> Field.Var.t Checked.t
 

--- a/src/app/zeko/circuits/zeko_util.mli
+++ b/src/app/zeko/circuits/zeko_util.mli
@@ -40,7 +40,7 @@ val var_to_actions :
   ('var, 'value) Typ.t -> 'var -> Mina_base.Zkapp_account.Actions.var Checked.t
 
 val var_to_events :
-  ('var, 'value) Typ.t -> 'var -> Mina_base.Zkapp_account.Actions.var Checked.t
+  ('var, 'value) Typ.t -> 'var -> Mina_base.Zkapp_account.Events.var Checked.t
 
 val var_to_hash :
   init:string -> ('var, 'value) Typ.t -> 'var -> Field.Var.t Checked.t


### PR DESCRIPTION
the typ of the deposit event is `Checked32.typ * Deposit_params.typ` and of the withdrawal event is `Checked32.typ * Withdrawal.typ`
- Checked32.var is field
- Deposit_params: https://github.com/zeko-labs/zeko/blob/compatible/src/app/zeko/circuits/bridge_state.ml#L160-L166
- Withdrawal_params: https://github.com/zeko-labs/zeko/blob/compatible/src/app/zeko/circuits/bridge_state.ml#L191

fix ZK-361, ZK-362