### PR TITLE
docs: specify URS loading output type

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -13,7 +13,7 @@
 * `offset` of binary URS within file
 
 **Outputs**
-* `TODO`
+* `CamlPastaFpUrs` loaded
 
 **Spec**
 


### PR DESCRIPTION
Replace TODO with `CamlPastaFpUrs` loaded output type specification.