### PR TITLE
Fix race condition on Pickles global state

### DIFF
--- a/src/app/zeko/circuits/ase.mli
+++ b/src/app/zeko/circuits/ase.mli
@@ -10,33 +10,34 @@ module With_length : sig
 
   type trans = { source : Stmt.t; target : Stmt.t }
 
-  val leaf : field list * Stmt.t -> (trans * Proof.t) Promise.t
+  val leaf : (field list * Stmt.t -> (trans * Proof.t) Promise.t) lazy_t
 
   val leaf_iterations : int
 
-  val leaf_option : field list * Stmt.t -> (trans * Proof.t) Promise.t
+  val leaf_option : (field list * Stmt.t -> (trans * Proof.t) Promise.t) lazy_t
 
   val leaf_option_iterations : int
 
-  val extend : field list * (trans * Proof.t) -> (trans * Proof.t) Promise.t
+  val extend :
+    (field list * (trans * Proof.t) -> (trans * Proof.t) Promise.t) lazy_t
 
   val extend_iterations : int
 
   val extend_option :
-    field list * (trans * Proof.t) -> (trans * Proof.t) Promise.t
+    (field list * (trans * Proof.t) -> (trans * Proof.t) Promise.t) lazy_t
 
   val extend_option_iterations : int
 
   type merge_input =
     { left : trans; left_proof : Proof.t; right : trans; right_proof : Proof.t }
 
-  val merge : merge_input -> (trans * Proof.t) Promise.t
+  val merge : (merge_input -> (trans * Proof.t) Promise.t) lazy_t
 
   type tag_t
 
   type tag_var
 
-  val tag : tag_var Compile_simple.tag
+  val tag : tag_var Compile_simple.tag lazy_t
 
   module Make : functor
     (Inputs : sig
@@ -81,33 +82,34 @@ module Without_length : sig
 
   type trans = { source : field; target : field }
 
-  val leaf : field list * field -> (trans * Proof.t) Promise.t
+  val leaf : (field list * field -> (trans * Proof.t) Promise.t) lazy_t
 
   val leaf_iterations : int
 
-  val leaf_option : field list * field -> (trans * Proof.t) Promise.t
+  val leaf_option : (field list * field -> (trans * Proof.t) Promise.t) lazy_t
 
   val leaf_option_iterations : int
 
-  val extend : field list * (trans * Proof.t) -> (trans * Proof.t) Promise.t
+  val extend :
+    (field list * (trans * Proof.t) -> (trans * Proof.t) Promise.t) lazy_t
 
   val extend_iterations : int
 
   val extend_option :
-    field list * (trans * Proof.t) -> (trans * Proof.t) Promise.t
+    (field list * (trans * Proof.t) -> (trans * Proof.t) Promise.t) lazy_t
 
   val extend_option_iterations : int
 
   type merge_input =
     { left : trans; left_proof : Proof.t; right : trans; right_proof : Proof.t }
 
-  val merge : merge_input -> (trans * Proof.t) Promise.t
+  val merge : (merge_input -> (trans * Proof.t) Promise.t) lazy_t
 
   type tag_t
 
   type tag_var
 
-  val tag : tag_var Compile_simple.tag
+  val tag : tag_var Compile_simple.tag lazy_t
 
   module Make : functor
     (Inputs : sig

--- a/src/app/zeko/circuits/folder.ml
+++ b/src/app/zeko/circuits/folder.ml
@@ -119,7 +119,7 @@ struct
       Compile_simple.
         { out = ({ source = stmt_source; target } : Trans.var); prevs }
 
-    let rule : _ Compile_simple.branch = { branch_name; tags; main }
+    let rule : _ Compile_simple.branch lazy_t = lazy { branch_name; tags; main }
   end
 
   module Rule_leaf = Make_rule (struct
@@ -254,8 +254,8 @@ struct
           ; out = new_stmt
           }
 
-    let rule : _ Compile_simple.branch =
-      { branch_name = "Rule_merge"; tags = Two_tags_own; main }
+    let rule : _ Compile_simple.branch lazy_t =
+      lazy { branch_name = "Rule_merge"; tags = Two_tags_own; main }
   end
 
   type merge_input = Rule_merge.Witness.t =
@@ -279,8 +279,8 @@ struct
 
   let tag = System.tag
 
-  let Compile_simple.[ leaf; leaf_option; extend; extend_option; merge ] =
-    System.provers
+  let leaf, leaf_option, extend, extend_option, merge =
+    Compile_simple.Lazy_helper.split5 System.provers
 
   module Make (Inputs : sig
     val get_iterations : int

--- a/src/app/zeko/circuits/folder.mli
+++ b/src/app/zeko/circuits/folder.mli
@@ -55,33 +55,33 @@ end)
 
   type t := trans * Proof.t
 
-  val leaf : Elem.t list * Stmt.t -> t Promise.t
+  val leaf : (Elem.t list * Stmt.t -> t Promise.t) lazy_t
 
   val leaf_iterations : int
 
-  val leaf_option : Elem.t list * Stmt.t -> t Promise.t
+  val leaf_option : (Elem.t list * Stmt.t -> t Promise.t) lazy_t
 
   val leaf_option_iterations : int
 
-  val extend : Elem.t list * t -> t Promise.t
+  val extend : (Elem.t list * t -> t Promise.t) lazy_t
 
   val extend_iterations : int
 
-  val extend_option : Elem.t list * t -> t Promise.t
+  val extend_option : (Elem.t list * t -> t Promise.t) lazy_t
 
   val extend_option_iterations : int
 
   type merge_input =
     { left : trans; left_proof : Proof.t; right : trans; right_proof : Proof.t }
 
-  val merge : merge_input -> t Promise.t
+  val merge : (merge_input -> t Promise.t) lazy_t
 
   type tag_t
 
   type tag_var
 
   (** The tag for the Pickles rule. You need to specify this in your rule. *)
-  val tag : tag_var Compile_simple.tag
+  val tag : tag_var Compile_simple.tag lazy_t
 
   module Make : functor
     (Inputs : sig

--- a/src/app/zeko/circuits/rule_action_witness.ml
+++ b/src/app/zeko/circuits/rule_action_witness.ml
@@ -53,6 +53,6 @@ struct
     in
     Compile_simple.{ prevs = No_prevs; out }
 
-  let rule : _ Compile_simple.branch =
-    { branch_name = "zeko action witness"; tags = No_tags; main }
+  let rule : _ Compile_simple.branch lazy_t =
+    lazy { branch_name = "zeko action witness"; tags = No_tags; main }
 end

--- a/src/app/zeko/circuits/rule_bridge_disable.ml
+++ b/src/app/zeko/circuits/rule_bridge_disable.ml
@@ -107,6 +107,6 @@ struct
     let*| out = make_outputs ~chain:chain_l1 account_update [] in
     Compile_simple.{ prevs = No_prevs; out }
 
-  let rule : _ Compile_simple.branch =
-    { branch_name = "disable holder account"; tags = No_tags; main }
+  let rule : _ Compile_simple.branch lazy_t =
+    lazy { branch_name = "disable holder account"; tags = No_tags; main }
 end

--- a/src/app/zeko/circuits/rule_bridge_enable.ml
+++ b/src/app/zeko/circuits/rule_bridge_enable.ml
@@ -107,6 +107,6 @@ struct
     let*| out = make_outputs ~chain:chain_l1 account_update [] in
     Compile_simple.{ prevs = No_prevs; out }
 
-  let rule : _ Compile_simple.branch =
-    { branch_name = "enable holder account"; tags = No_tags; main }
+  let rule : _ Compile_simple.branch lazy_t =
+    lazy { branch_name = "enable holder account"; tags = No_tags; main }
 end

--- a/src/app/zeko/circuits/rule_bridge_finalize_cancelled_deposit.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_cancelled_deposit.ml
@@ -89,11 +89,14 @@ struct
         ; out = (outer, outer_with_length)
         }
 
-    let rule : _ Compile_simple.branch =
-      { branch_name = "Verify_two_outer_ases"
-      ; tags = Two_tags (Ase.Without_length.tag, Ase.With_length.tag)
-      ; main
-      }
+    let rule : _ Compile_simple.branch lazy_t =
+      lazy
+        { branch_name = "Verify_two_outer_ases"
+        ; tags =
+            Two_tags
+              (Lazy.force Ase.Without_length.tag, Lazy.force Ase.With_length.tag)
+        ; main
+        }
 
     include
       ( val Compile_simple.compile ~name:"Verify_both_ases" ~branches:[ rule ]
@@ -131,11 +134,14 @@ struct
         ; out = (check_accepted, ase)
         }
 
-    let rule : _ Compile_simple.branch =
-      { branch_name = "Verify_two_outer_ases"
-      ; tags = Two_tags (Check_accepted.tag, Ase.With_length.tag)
-      ; main
-      }
+    let rule : _ Compile_simple.branch lazy_t =
+      lazy
+        { branch_name = "Verify_two_outer_ases"
+        ; tags =
+            Two_tags
+              (Lazy.force Check_accepted.tag, Lazy.force Ase.With_length.tag)
+        ; main
+        }
 
     include
       ( val Compile_simple.compile ~name:"Verify_check_accepted_and_ase"
@@ -352,10 +358,13 @@ struct
           ; out
           } )
 
-  let rule : _ Compile_simple.branch =
-    { branch_name = "finalize cancelled deposit"
-    ; tags =
-        Two_tags (Verify_two_outer_ases.tag, Verify_check_accepted_and_ase.tag)
-    ; main
-    }
+  let rule : _ Compile_simple.branch lazy_t =
+    lazy
+      { branch_name = "finalize cancelled deposit"
+      ; tags =
+          Two_tags
+            ( Lazy.force Verify_two_outer_ases.tag
+            , Lazy.force Verify_check_accepted_and_ase.tag )
+      ; main
+      }
 end

--- a/src/app/zeko/circuits/rule_bridge_finalize_deposit.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_deposit.ml
@@ -231,9 +231,12 @@ struct
     Compile_simple.
       { prevs = Two_prevs (verify_check_accepted, verify_ase); out }
 
-  let rule : _ Compile_simple.branch =
-    { branch_name = "finalize deposit"
-    ; tags = Two_tags (Check_accepted.tag, Ase.With_length.tag)
-    ; main
-    }
+  let rule : _ Compile_simple.branch lazy_t =
+    lazy
+      { branch_name = "finalize deposit"
+      ; tags =
+          Two_tags
+            (Lazy.force Check_accepted.tag, Lazy.force Ase.With_length.tag)
+      ; main
+      }
 end

--- a/src/app/zeko/circuits/rule_bridge_finalize_withdrawal.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_withdrawal.ml
@@ -262,9 +262,12 @@ struct
         Compile_simple.
           { prevs = Two_prevs (verify_commit_ase, verify_withdrawal_ase); out } )
 
-  let rule : _ Compile_simple.branch =
-    { branch_name = "finalize withdrawal"
-    ; tags = Two_tags (Ase.Without_length.tag, Ase.With_length.tag)
-    ; main
-    }
+  let rule : _ Compile_simple.branch lazy_t =
+    lazy
+      { branch_name = "finalize withdrawal"
+      ; tags =
+          Two_tags
+            (Lazy.force Ase.Without_length.tag, Lazy.force Ase.With_length.tag)
+      ; main
+      }
 end

--- a/src/app/zeko/circuits/rule_bridge_inner_receive.ml
+++ b/src/app/zeko/circuits/rule_bridge_inner_receive.ml
@@ -30,7 +30,8 @@ struct
           { default_account_update with
             public_key
           ; token_id = constant Token_id.typ token_id_l2
-          ; may_use_token = constant Account_update.May_use_token.typ Parents_own_token
+          ; may_use_token =
+              constant Account_update.May_use_token.typ Parents_own_token
           ; authorization_kind = authorization_vk_hash vk_hash
           ; balance_change = Currency.Amount.Signed.Checked.(of_unsigned amount)
           }
@@ -38,6 +39,6 @@ struct
         let*| out = make_outputs ~chain:chain_l2 account_update [] in
         Compile_simple.{ prevs = No_prevs; out } )
 
-  let rule : _ Compile_simple.branch =
-    { branch_name = "inner receive"; tags = No_tags; main }
+  let rule : _ Compile_simple.branch lazy_t =
+    lazy { branch_name = "inner receive"; tags = No_tags; main }
 end

--- a/src/app/zeko/circuits/rule_bridge_outer_token_owner.ml
+++ b/src/app/zeko/circuits/rule_bridge_outer_token_owner.ml
@@ -101,6 +101,6 @@ struct
     let*| out = make_outputs ~chain:chain_l1 account_update [ (a, []) ] in
     Compile_simple.{ prevs = No_prevs; out }
 
-  let rule : _ Compile_simple.branch =
-    { branch_name = "outer token owner"; tags = No_tags; main }
+  let rule : _ Compile_simple.branch lazy_t =
+    lazy { branch_name = "outer token owner"; tags = No_tags; main }
 end

--- a/src/app/zeko/circuits/rule_change_permissions.ml
+++ b/src/app/zeko/circuits/rule_change_permissions.ml
@@ -40,8 +40,8 @@ struct
     let*| out = make_outputs ~chain:chain_l1 account_update [] in
     Compile_simple.{ prevs = No_prevs; out }
 
-  let rule : _ Compile_simple.branch =
-    { branch_name = "zeko change permissions"; tags = No_tags; main }
+  let rule : _ Compile_simple.branch lazy_t =
+    lazy { branch_name = "zeko change permissions"; tags = No_tags; main }
 
   include
     ( val Compile_simple.compile ()

--- a/src/app/zeko/circuits/rule_commit.ml
+++ b/src/app/zeko/circuits/rule_commit.ml
@@ -31,11 +31,14 @@ module Verify_both_ases = struct
     Compile_simple.
       { prevs = Two_prevs (verify_outer, verify_inner); out = (outer, inner) }
 
-  let rule : _ Compile_simple.branch =
-    { branch_name = "Verify_both_ases"
-    ; tags = Two_tags (Ase.Without_length.tag, Ase.With_length.tag)
-    ; main
-    }
+  let rule : _ Compile_simple.branch lazy_t =
+    lazy
+      { branch_name = "Verify_both_ases"
+      ; tags =
+          Two_tags
+            (Lazy.force Ase.Without_length.tag, Lazy.force Ase.With_length.tag)
+      ; main
+      }
 
   include
     ( val Compile_simple.compile ~name:"Verify_both_ases" ~branches:[ rule ]
@@ -408,9 +411,11 @@ struct
     in
     Compile_simple.{ prevs = Two_prevs (verify_txn_snark, verify_ases); out }
 
-  let rule : _ Compile_simple.branch =
-    { branch_name = "Rollup step"
-    ; tags = Two_tags (Txn_rules.tag, Verify_both_ases.tag)
-    ; main
-    }
+  let rule : _ Compile_simple.branch lazy_t =
+    lazy
+      { branch_name = "Rollup step"
+      ; tags =
+          Two_tags (Lazy.force Txn_rules.tag, Lazy.force Verify_both_ases.tag)
+      ; main
+      }
 end

--- a/src/app/zeko/circuits/rule_inner_action_witness.ml
+++ b/src/app/zeko/circuits/rule_inner_action_witness.ml
@@ -31,6 +31,6 @@ struct
     in
     Compile_simple.{ prevs = No_prevs; out }
 
-  let rule : _ Compile_simple.branch =
-    { branch_name = "zeko action witness"; tags = No_tags; main }
+  let rule : _ Compile_simple.branch lazy_t =
+    lazy { branch_name = "zeko action witness"; tags = No_tags; main }
 end

--- a/src/app/zeko/circuits/rule_inner_sync.ml
+++ b/src/app/zeko/circuits/rule_inner_sync.ml
@@ -71,9 +71,10 @@ struct
     let*| out = make_outputs ~chain:chain_l2 account_update [] in
     Compile_simple.{ prevs = One_prev verify_ase; out }
 
-  let rule : _ Compile_simple.branch =
-    { branch_name = "Rollup inner account step"
-    ; tags = One_tag Ase.With_length.tag
-    ; main
-    }
+  let rule : _ Compile_simple.branch lazy_t =
+    lazy
+      { branch_name = "Rollup inner account step"
+      ; tags = One_tag (Lazy.force Ase.With_length.tag)
+      ; main
+      }
 end

--- a/src/app/zeko/circuits/rule_pause.ml
+++ b/src/app/zeko/circuits/rule_pause.ml
@@ -67,6 +67,6 @@ struct
     in
     Compile_simple.{ prevs = No_prevs; out }
 
-  let rule : _ Compile_simple.branch =
-    { branch_name = "zeko pause"; tags = No_tags; main }
+  let rule : _ Compile_simple.branch lazy_t =
+    lazy { branch_name = "zeko pause"; tags = No_tags; main }
 end

--- a/src/app/zeko/circuits/txn_rules.ml
+++ b/src/app/zeko/circuits/txn_rules.ml
@@ -2,34 +2,40 @@ include
   ( val Compile_simple.compile ~name:"zeko-transaction-snark"
           ~out_typ:Txn_state.Zeko_stmt.typ
           ~branches:
-            [ { branch_name = "single-signed-command"
-              ; tags = No_tags
-              ; main = Rule_signed_command.main
-              }
-            ; { branch_name = "single-unproved-zkapp-command"
-              ; tags = No_tags
-              ; main = Rule_zkapp_command.single_unproved
-              }
-            ; { branch_name = "double-unproved-zkapp-command"
-              ; tags = No_tags
-              ; main = Rule_zkapp_command.double_unproved
-              }
-            ; { branch_name = "single-proved-zkapp-command"
-              ; tags =
-                  One_tag_sideloaded
-                    { sideloaded_tag_name =
-                        "single-proved-zkapp-command-sideloaded-vk"
-                    ; typ = Mina_base.Zkapp_statement.typ
-                    ; extract_vk =
-                        (fun ({ vk; _ } :
-                               Rule_zkapp_command.Zkapp_single_proved_input.t ) ->
-                          vk )
-                    }
-              ; main = Rule_zkapp_command.single_proved
-              }
-            ; { branch_name = "merge"
-              ; tags = Two_tags_own
-              ; main = Rule_txn_merge.main
-              }
+            [ lazy
+                { branch_name = "single-signed-command"
+                ; tags = No_tags
+                ; main = Rule_signed_command.main
+                }
+            ; lazy
+                { branch_name = "single-unproved-zkapp-command"
+                ; tags = No_tags
+                ; main = Rule_zkapp_command.single_unproved
+                }
+            ; lazy
+                { branch_name = "double-unproved-zkapp-command"
+                ; tags = No_tags
+                ; main = Rule_zkapp_command.double_unproved
+                }
+            ; lazy
+                { branch_name = "single-proved-zkapp-command"
+                ; tags =
+                    One_tag_sideloaded
+                      { sideloaded_tag_name =
+                          "single-proved-zkapp-command-sideloaded-vk"
+                      ; typ = Mina_base.Zkapp_statement.typ
+                      ; extract_vk =
+                          (fun ({ vk; _ } :
+                                 Rule_zkapp_command.Zkapp_single_proved_input.t
+                                 ) ->
+                            vk )
+                      }
+                ; main = Rule_zkapp_command.single_proved
+                }
+            ; lazy
+                { branch_name = "merge"
+                ; tags = Two_tags_own
+                ; main = Rule_txn_merge.main
+                }
             ]
           () )

--- a/src/app/zeko/compile_simple/compile_simple_intf.ml
+++ b/src/app/zeko/compile_simple/compile_simple_intf.ml
@@ -132,7 +132,7 @@ struct
     type ('out_var, 'branches, 'n_available_branches) t =
       | [] : ('out_var, nil_branch, all_branches_available) t
       | ( :: ) :
-          ('input, 'out_var, 'prevs) branch
+          ('input, 'out_var, 'prevs) branch lazy_t
           * ('out_var, 'branches, 'n_available_branches available_branch) t
           -> ( 'out_var
              , ('input, 'branches) cons_branch
@@ -155,9 +155,9 @@ struct
 
     type tag_t
 
-    val tag : tag_var tag
+    val tag : tag_var tag lazy_t
 
-    val provers : (out_t, branches) provers
+    val provers : (out_t, branches) provers lazy_t
 
     type t
 
@@ -171,5 +171,33 @@ struct
     val get : ?check:Boolean.var -> var -> (out_var * tag_var prev) Checked.t
 
     val make_unchecked : ?proof:proof -> out_t -> t
+  end
+
+  module Lazy_helper = struct
+    let split2 (provers : ('out_t, 'branches) provers lazy_t) =
+      let p1 = Lazy.map (fun [ p; _ ] -> p) provers in
+      let p2 = Lazy.map (fun [ _; p ] -> p) provers in
+      (p1, p2)
+
+    let split3 (provers : ('out_t, 'branches) provers lazy_t) =
+      let p1 = Lazy.map (fun [ p; _; _ ] -> p) provers in
+      let p2 = Lazy.map (fun [ _; p; _ ] -> p) provers in
+      let p3 = Lazy.map (fun [ _; _; p ] -> p) provers in
+      (p1, p2, p3)
+
+    let split4 (provers : ('out_t, 'branches) provers lazy_t) =
+      let p1 = Lazy.map (fun [ p; _; _; _ ] -> p) provers in
+      let p2 = Lazy.map (fun [ _; p; _; _ ] -> p) provers in
+      let p3 = Lazy.map (fun [ _; _; p; _ ] -> p) provers in
+      let p4 = Lazy.map (fun [ _; _; _; p ] -> p) provers in
+      (p1, p2, p3, p4)
+
+    let split5 (provers : ('out_t, 'branches) provers lazy_t) =
+      let p1 = Lazy.map (fun [ p; _; _; _; _ ] -> p) provers in
+      let p2 = Lazy.map (fun [ _; p; _; _; _ ] -> p) provers in
+      let p3 = Lazy.map (fun [ _; _; p; _; _ ] -> p) provers in
+      let p4 = Lazy.map (fun [ _; _; _; p; _ ] -> p) provers in
+      let p5 = Lazy.map (fun [ _; _; _; _; p ] -> p) provers in
+      (p1, p2, p3, p4, p5)
   end
 end

--- a/src/app/zeko/compile_simple/dune
+++ b/src/app/zeko/compile_simple/dune
@@ -1,6 +1,7 @@
 (env
  (_
-  (flags (:standard -w @a-42-40-44-70-45-41))))
+  (flags
+   (:standard -w @a-42-40-44-70-45-41))))
 
 (library
  (name compile_simple)
@@ -10,8 +11,7 @@
   pickles
   snark_params
   v)
- (preprocess (pps ppx_mina))
- (modules
-  compile_simple
-  compile_simple_intf)
+ (preprocess
+  (pps ppx_mina))
+ (modules compile_simple compile_simple_intf)
  (virtual_modules compile_simple))

--- a/src/app/zeko/compile_simple/fake/compile_simple.ml
+++ b/src/app/zeko/compile_simple/fake/compile_simple.ml
@@ -253,9 +253,10 @@ let match_tags_prevs :
 let branches_to_provers name tag out_typ =
   let rec go :
       type branches available_branches.
-      (_, branches, available_branches) Branches.t -> (_, branches) provers =
-    function
-    | Branches.({ branch_name; tags; main } :: rest) ->
+         (_, branches, available_branches) Branches.t
+      -> (_, branches) provers lazy_t = function
+    | branch :: rest ->
+        let%map.Lazy { branch_name; tags; main } = branch in
         let prover input =
           printf "compile_simple.fake: proving %s.%s\n" name branch_name ;
           let recursion_valid, out =
@@ -279,17 +280,18 @@ let branches_to_provers name tag out_typ =
           let fake_proof = make_fake_proof tag out_typ out in
           (out, fake_proof)
         in
-        prover :: go rest
+        prover :: Lazy.force (go rest)
     | [] ->
-        []
+        lazy []
   in
   go
 
 let rec hash_branches :
     type branches available_branches.
-    (_, branches, available_branches) Branches.t -> field = function
-  | Branches.({ branch_name = _; tags = _; main } :: rest) ->
-      let rest_hash = hash_branches rest in
+    (_, branches, available_branches) Branches.t -> field lazy_t = function
+  | branch :: rest ->
+      let%bind.Lazy { branch_name = _; tags = _; main } = branch in
+      let%map.Lazy rest_hash = hash_branches rest in
       let main_wrapper input () =
         Run.run_checked Checked.(main input >>| fun _ -> ())
       in
@@ -309,7 +311,7 @@ let rec hash_branches :
         ~init:(Hash_prefix_create.salt "fake circuit hash")
         [| tags_hash; cs_hash; rest_hash |]
   | [] ->
-      Field.zero
+      lazy Field.zero
 
 let compile (type out_t out_var first_input branches n_available_branches)
     ?(wrap_domain : [ `N13 | `N14 | `N15 ] option) ~(name : string)
@@ -328,7 +330,7 @@ let compile (type out_t out_var first_input branches n_available_branches)
   (* ZEKO NOTE: ZEKO FIXME: Add back! didn't work very likely because of snarky bug that should be fixed *)
   (* assert (Run.in_checked_computation () |> not) ; *)
   (* assert (Run.in_prover () |> not) ; *)
-  let circuit_hash = hash_branches branches in
+  let circuit_hash = Lazy.force (hash_branches branches) in
   printf "compile_simple.fake: hashed %s\n" name ;
   let tag = Tag { circuit_hash; typ = out_typ } in
   let r :
@@ -346,8 +348,6 @@ let compile (type out_t out_var first_input branches n_available_branches)
       type tag_var = out_var
 
       type tag_t = out_t
-
-      let tag = tag
 
       let provers = branches_to_provers name tag out_typ branches
 
@@ -373,6 +373,8 @@ let compile (type out_t out_var first_input branches n_available_branches)
         Checked.return (out, prev)
 
       let make_unchecked ?proof out : t = ignore proof ; out
+
+      let tag = lazy tag
     end )
   in
   r

--- a/src/app/zeko/compile_simple/real/compile_simple.ml
+++ b/src/app/zeko/compile_simple/real/compile_simple.ml
@@ -1,4 +1,3 @@
-module P = Printexc
 open Core_kernel
 open Snark_params.Tick
 open Checked.Let_syntax
@@ -676,18 +675,6 @@ let rec branches_to_choices :
                       rule :: f ~self )
                 } ) )
 
-let get_first_backtrace_entry b =
-  let open P in
-  match backtrace_slots b with
-  | None ->
-      "<invalid>"
-  | Some slots -> (
-      match Slot.location slots.(1) with
-      | None ->
-          "<invalid>"
-      | Some { filename; line_number; _ } ->
-          filename ^ ":" ^ Int.to_string line_number )
-
 let compile (type out_t out_var first_input branches n_available_branches)
     ?(wrap_domain : [ `N13 | `N14 | `N15 ] option) ~(name : string)
     ~(branches :
@@ -699,8 +686,6 @@ let compile (type out_t out_var first_input branches n_available_branches)
        with type out_t = out_t
         and type out_var = out_var
         and type branches = (first_input, branches) cons_branch ) =
-  printf "compile_simple.real: %s at %s\n%!" name
-    (P.get_callstack 9999 |> get_first_backtrace_entry) ;
   assert (Run.in_checked_computation () |> not) ;
   assert (Run.in_prover () |> not) ;
   let override_wrap_domain : Pickles_base.Proofs_verified.t option =
@@ -768,11 +753,6 @@ let compile (type out_t out_var first_input branches n_available_branches)
           ~max_proofs_verified:(module Pickles_types.Nat.N2)
           ~name:("compile_simple of " ^ name)
       in
-      (* FIXME: Don't do this. Make lazy compilation work. Fix Pickles bug. *)
-      Promise.block_on_async_exn (fun () ->
-          time_promise ("(compile_simple) compiled " ^ name) (fun () ->
-              Verification_key.of_compiled_promise tag )
-          |> Promise.map ~f:(fun _ -> ()) ) ;
       let provers = transform_provers provers in
       let r :
           (module Result

--- a/src/app/zeko/compile_simple/real/compile_simple.ml
+++ b/src/app/zeko/compile_simple/real/compile_simple.ml
@@ -288,18 +288,21 @@ let rec branches_to_choices :
     type out_var out_t branches available_branches tag_branches.
        name:string
     -> (out_var, branches, available_branches) Branches.t
-    -> (out_var, out_t, branches, tag_branches) branches_to_choices_return =
+    -> (out_var, out_t, branches, tag_branches) branches_to_choices_return
+       lazy_t =
  fun ~name -> function
   | [] ->
       let open
         Pickles_types.Hlist.H4_6_with_length.T (Pickles.Inductive_rule.Promise) in
-      Choices
-        { branches_length = Z
-        ; rules = (fun ~self:_ -> [])
-        ; transform_provers = (fun [] -> [])
-        }
-  | { branch_name; tags; main } :: xs -> (
-      match branches_to_choices ~name xs with
+      lazy
+        (Choices
+           { branches_length = Z
+           ; rules = (fun ~self:_ -> [])
+           ; transform_provers = (fun [] -> [])
+           } )
+  | branch :: xs -> (
+      let%map.Lazy { branch_name; tags; main } = branch in
+      match branches_to_choices ~name xs |> Lazy.force with
       | Choices
           { branches_length
           ; rules = f
@@ -702,120 +705,124 @@ let compile (type out_t out_var first_input branches n_available_branches)
   in
   let (Count_branches_result tag_branches) = count_branches branches in
   let (module N_branches) = branches_length_to_module tag_branches in
-  match branches_to_choices ~name branches with
-  | Choices { branches_length; rules; transform_provers } ->
-      (* pretty sure this shouldn't be needed, but dumb ocaml type checker *)
-      let T = branches_length_functional (tag_branches, branches_length) in
-      let choices :
-             self:(out_var, out_t, self_width, N_branches.n) Pickles.Tag.t
-          -> ( _
-             , _
-             , _
-             , _
-             , _
-             , unit
-             , unit
-             , out_var
-             , out_t
-             , unit
-             , unit )
-             Pickles_types.Hlist.H4_6_with_length.T
-               (Pickles.Inductive_rule.Promise)
-             .t =
-        rules
-      in
-      let dummy_proof =
-        lazy
-          Pickles_types.Nat.(
-            Pickles.Proof.dummy N2.n N2.n
-              ~domain_log2:
-                ( match override_wrap_domain with
-                | None ->
-                    14
-                    (* TODO: probably ok, maybe not?
-                       If not ok, need dependency on compilation to
-                       figure out override wrap domain. *)
-                | Some N0 ->
-                    13
-                | Some N1 ->
-                    14
-                | Some N2 ->
-                    15 ))
-      in
-      assert (Run.in_checked_computation () |> not) ;
-      assert (Run.in_prover () |> not) ;
-      let ( (tag : (_, _, _, N_branches.n) Pickles.Tag.t)
-          , _cache
-          , _proof_module
-          , provers ) =
-        Pickles.compile_promise () ?override_wrap_domain ~cache:Cache_dir.cache
-          ~public_input:(Output out_typ) ~auxiliary_typ:Typ.unit ~choices
-          ~max_proofs_verified:(module Pickles_types.Nat.N2)
-          ~name:("compile_simple of " ^ name)
-      in
-      let provers = transform_provers provers in
-      let r :
-          (module Result
-             with type out_t = out_t
-              and type out_var = out_var
-              and type branches = (first_input, branches) cons_branch ) =
-        ( module struct
-          type nonrec out_t = out_t
+  let dummy_proof =
+    lazy
+      Pickles_types.Nat.(
+        Pickles.Proof.dummy N2.n N2.n
+          ~domain_log2:
+            ( match override_wrap_domain with
+            | None ->
+                14
+                (* TODO: probably ok, maybe not?
+                   If not ok, need dependency on compilation to
+                   figure out override wrap domain. *)
+            | Some N0 ->
+                13
+            | Some N1 ->
+                14
+            | Some N2 ->
+                15 ))
+  in
+  let tag, provers =
+    let lazy_result =
+      match%map.Lazy branches_to_choices ~name branches with
+      | Choices { branches_length; rules; transform_provers } ->
+          let T = branches_length_functional (tag_branches, branches_length) in
+          (* pretty sure this shouldn't be needed, but dumb ocaml type checker *)
+          let choices :
+                 self:(out_var, out_t, self_width, N_branches.n) Pickles.Tag.t
+              -> ( _
+                 , _
+                 , _
+                 , _
+                 , _
+                 , unit
+                 , unit
+                 , out_var
+                 , out_t
+                 , unit
+                 , unit )
+                 Pickles_types.Hlist.H4_6_with_length.T
+                   (Pickles.Inductive_rule.Promise)
+                 .t =
+            rules
+          in
+          assert (Run.in_checked_computation () |> not) ;
+          assert (Run.in_prover () |> not) ;
+          let ( (tag : (_, _, _, N_branches.n) Pickles.Tag.t)
+              , _cache
+              , _proof_module
+              , provers ) =
+            Pickles.compile_promise () ?override_wrap_domain
+              ~cache:Cache_dir.cache ~public_input:(Output out_typ)
+              ~auxiliary_typ:Typ.unit ~choices
+              ~max_proofs_verified:(module Pickles_types.Nat.N2)
+              ~name:("compile_simple of " ^ name)
+          in
+          let provers = transform_provers provers in
+          (Tag tag, provers)
+    in
+    (Lazy.map lazy_result ~f:fst, Lazy.map lazy_result ~f:snd)
+  in
 
-          type nonrec out_var = out_var
+  let r :
+      (module Result
+         with type out_t = out_t
+          and type out_var = out_var
+          and type branches = (first_input, branches) cons_branch ) =
+    ( module struct
+      type nonrec out_t = out_t
 
-          type nonrec branches = (first_input, branches) cons_branch
+      type nonrec out_var = out_var
 
-          type tag_var = out_var
+      type nonrec branches = (first_input, branches) cons_branch
 
-          type tag_t = out_t
+      type tag_var = out_var
 
-          let tag = Tag tag
+      type tag_t = out_t
 
-          let provers = provers
+      let tag = tag
 
-          open struct
-            module Out = struct
-              type t = out_t
+      let provers = provers
 
-              type var = out_var
+      open struct
+        module Out = struct
+          type t = out_t
 
-              let typ = out_typ
-            end
+          type var = out_var
 
-            module Proof_V = struct
-              type t = self_width Pickles.Proof.t
+          let typ = out_typ
+        end
 
-              type var = t V.t
+        module Proof_V = struct
+          type t = self_width Pickles.Proof.t
 
-              let typ = V.typ
-            end
-          end
+          type var = t V.t
 
-          type t = { out : Out.t; proof : Proof_V.t } [@@deriving snarky]
+          let typ = V.typ
+        end
+      end
 
-          let get ?check { out; proof } =
-            let prev : _ prev =
-              { public_input = out
-              ; proof
-              ; proof_must_verify =
-                  (match check with Some b -> b | None -> Boolean.true_)
-              }
-            in
-            Checked.return (out, prev)
+      type t = { out : Out.t; proof : Proof_V.t } [@@deriving snarky]
 
-          let make_unchecked ?proof out : t =
-            { out
-            ; proof =
-                ( match proof with
-                | Some proof ->
-                    proof
-                | None ->
-                    force dummy_proof )
-            }
-        end )
-      in
-      r
+      let get ?check { out; proof } =
+        let prev : _ prev =
+          { public_input = out
+          ; proof
+          ; proof_must_verify =
+              (match check with Some b -> b | None -> Boolean.true_)
+          }
+        in
+        Checked.return (out, prev)
+
+      let make_unchecked ?proof out : t =
+        { out
+        ; proof =
+            (match proof with Some proof -> proof | None -> force dummy_proof)
+        }
+    end )
+  in
+  r
 
 let add_plonk_constraint ~label c =
   ( match !bad_fixme_feature_flags with

--- a/src/app/zeko/sequencer/cli.ml
+++ b/src/app/zeko/sequencer/cli.ml
@@ -107,13 +107,13 @@ let update_outer_verification_keys =
            >>| Compile_simple.Verification_key.hash
          in
          let%bind outer_vk =
-           Outer_rules_inst.tag |> Compile_simple.Verification_key.of_tag
-           |> Promise.to_deferred
+           Lazy.force Outer_rules_inst.tag
+           |> Compile_simple.Verification_key.of_tag |> Promise.to_deferred
          and bridge_holder_vk =
-           Bridge_inst_mina.System_L1_enabled.tag
+           Lazy.force Bridge_inst_mina.System_L1_enabled.tag
            |> Compile_simple.Verification_key.of_tag |> Promise.to_deferred
          and helper_token_owner_vk =
-           Bridge_inst_mina.System_L1_token_owner.tag
+           Lazy.force Bridge_inst_mina.System_L1_token_owner.tag
            |> Compile_simple.Verification_key.of_tag |> Promise.to_deferred
          in
          let deploy_config =
@@ -268,10 +268,10 @@ let update_inner_verification_keys =
 
          (* Get compiled vks *)
          let%bind inner_vk =
-           Inner_rules_inst.tag |> Compile_simple.Verification_key.of_tag
-           |> Promise.to_deferred
+           Lazy.force Inner_rules_inst.tag
+           |> Compile_simple.Verification_key.of_tag |> Promise.to_deferred
          and bridge_holder_vk =
-           Bridge_inst_mina.System_L2.tag
+           Lazy.force Bridge_inst_mina.System_L2.tag
            |> Compile_simple.Verification_key.of_tag |> Promise.to_deferred
          in
          (* let deploy_config =

--- a/src/app/zeko/sequencer/lib/deploy.ml
+++ b/src/app/zeko/sequencer/lib/deploy.ml
@@ -46,11 +46,12 @@ module Z = struct
   module Inner = struct
     let initial_accounts () =
       let%bind inner_vk =
-        Compile_simple.Verification_key.of_tag Inner_rules_inst.tag
+        Compile_simple.Verification_key.of_tag (Lazy.force Inner_rules_inst.tag)
         |> Promise.to_deferred
       in
       let%map holder_vk =
-        Compile_simple.Verification_key.of_tag Bridge_inst_mina.System_L2.tag
+        Compile_simple.Verification_key.of_tag
+          (Lazy.force Bridge_inst_mina.System_L2.tag)
         |> Promise.to_deferred
       in
       let inner_account =
@@ -116,7 +117,7 @@ module Z = struct
     let unsafe_deploy ~pause_key ~ledger_hash ~sequencer ~da_key ~acc_set () =
       let open Zkapp_basic in
       let%bind outer_vk =
-        Compile_simple.Verification_key.of_tag Outer_rules_inst.tag
+        Compile_simple.Verification_key.of_tag (Lazy.force Outer_rules_inst.tag)
         |> Promise.to_deferred
       in
       let outer_update =
@@ -159,7 +160,7 @@ module Z = struct
       in
       let%bind holder_vk =
         Compile_simple.Verification_key.of_tag
-          Bridge_inst_mina.System_L1_enabled.tag
+          (Lazy.force Bridge_inst_mina.System_L1_enabled.tag)
         |> Promise.to_deferred
       in
       let holder_update =
@@ -187,7 +188,7 @@ module Z = struct
       in
       let%map token_owner_vk =
         Compile_simple.Verification_key.of_tag
-          Bridge_inst_mina.System_L1_token_owner.tag
+          (Lazy.force Bridge_inst_mina.System_L1_token_owner.tag)
         |> Promise.to_deferred
       in
       let token_owner_update =
@@ -451,7 +452,7 @@ let update_permissions ~signature_kind ~(signer : Keypair.t)
   in
   let%bind temp_vk =
     let%map vk =
-      Compile_simple.Verification_key.of_tag Change_permissions.tag
+      Compile_simple.Verification_key.of_tag (Lazy.force Change_permissions.tag)
       |> Promise.to_deferred
     in
     Verification_key_wire.Stable.Latest.M.of_binable
@@ -483,7 +484,7 @@ let update_permissions ~signature_kind ~(signer : Keypair.t)
               ~signature_kind )
   in
   let%map f2 =
-    let [ prover ] = Change_permissions.provers in
+    let [ prover ] = Lazy.force Change_permissions.provers in
     let%map (_stmt, (body, _, calls)), proof =
       prover
         { public_key = Zeko_circuits_config.t.zeko_l1

--- a/src/app/zeko/sequencer/prover/cli.ml
+++ b/src/app/zeko/sequencer/prover/cli.ml
@@ -15,7 +15,6 @@ let run_server =
        in
        let logger = Logger.create () in
        Stdout_log.setup log_json log_level ;
-       [%log info] "Compiling circuits" ;
        Zeko_prover.Prover.run
          ?fake_proving_time:(Option.map ~f:Time.Span.of_sec fake_proving_time)
          ~logger

--- a/src/app/zeko/sequencer/prover/lib/compile_circuits.ml
+++ b/src/app/zeko/sequencer/prover/lib/compile_circuits.ml
@@ -10,29 +10,37 @@ let compile_tag tag =
 let compile_all ~logger () =
   [%log info] "Compiling circuits" ;
   let start = Time.now () in
-  let%bind () = compile_tag Txn_rules.tag in
-  let%bind () = compile_tag Ase.Without_length.tag in
-  let%bind () = compile_tag Ase.With_length.tag in
-  let%bind () = compile_tag Rule_commit.Verify_both_ases.tag in
-  let%bind () = compile_tag Inner_rules_inst.tag in
-  let%bind () = compile_tag Outer_rules_inst.tag in
-  let%bind () = compile_tag Bridge_inst_mina.Check_accepted.tag in
+  let%bind () = compile_tag (Lazy.force Txn_rules.tag) in
+  let%bind () = compile_tag (Lazy.force Ase.Without_length.tag) in
+  let%bind () = compile_tag (Lazy.force Ase.With_length.tag) in
+  let%bind () = compile_tag (Lazy.force Rule_commit.Verify_both_ases.tag) in
+  let%bind () = compile_tag (Lazy.force Inner_rules_inst.tag) in
+  let%bind () = compile_tag (Lazy.force Outer_rules_inst.tag) in
+  let%bind () = compile_tag (Lazy.force Bridge_inst_mina.Check_accepted.tag) in
   let%bind () =
     compile_tag
-      Bridge_inst_mina.Rule_bridge_finalize_cancelled_deposit
-      .Verify_two_outer_ases
-      .tag
+      (Lazy.force
+         Bridge_inst_mina.Rule_bridge_finalize_cancelled_deposit
+         .Verify_two_outer_ases
+         .tag )
   in
   let%bind () =
     compile_tag
-      Bridge_inst_mina.Rule_bridge_finalize_cancelled_deposit
-      .Verify_check_accepted_and_ase
-      .tag
+      (Lazy.force
+         Bridge_inst_mina.Rule_bridge_finalize_cancelled_deposit
+         .Verify_check_accepted_and_ase
+         .tag )
   in
-  let%bind () = compile_tag Bridge_inst_mina.System_L1_enabled.tag in
-  let%bind () = compile_tag Bridge_inst_mina.System_L1_disabled.tag in
-  let%bind () = compile_tag Bridge_inst_mina.System_L2.tag in
-  let%bind () = compile_tag Bridge_inst_mina.System_L1_token_owner.tag in
+  let%bind () =
+    compile_tag (Lazy.force Bridge_inst_mina.System_L1_enabled.tag)
+  in
+  let%bind () =
+    compile_tag (Lazy.force Bridge_inst_mina.System_L1_disabled.tag)
+  in
+  let%bind () = compile_tag (Lazy.force Bridge_inst_mina.System_L2.tag) in
+  let%bind () =
+    compile_tag (Lazy.force Bridge_inst_mina.System_L1_token_owner.tag)
+  in
   [%log info] "Compiled circuits in %s"
     (Time.Span.to_string_hum (Time.diff (Time.now ()) start)) ;
   return ()

--- a/src/app/zeko/sequencer/prover/lib/compile_circuits.ml
+++ b/src/app/zeko/sequencer/prover/lib/compile_circuits.ml
@@ -1,0 +1,38 @@
+open Core_kernel
+open Async
+open Zeko_types
+open Compile_simple
+open Zeko_circuits
+
+let compile_tag tag =
+  Verification_key.of_tag tag |> Promise.to_deferred |> Deferred.ignore_m
+
+let compile_all ~logger () =
+  [%log info] "Compiling circuits" ;
+  let start = Time.now () in
+  let%bind () = compile_tag Txn_rules.tag in
+  let%bind () = compile_tag Ase.Without_length.tag in
+  let%bind () = compile_tag Ase.With_length.tag in
+  let%bind () = compile_tag Rule_commit.Verify_both_ases.tag in
+  let%bind () = compile_tag Inner_rules_inst.tag in
+  let%bind () = compile_tag Outer_rules_inst.tag in
+  let%bind () = compile_tag Bridge_inst_mina.Check_accepted.tag in
+  let%bind () =
+    compile_tag
+      Bridge_inst_mina.Rule_bridge_finalize_cancelled_deposit
+      .Verify_two_outer_ases
+      .tag
+  in
+  let%bind () =
+    compile_tag
+      Bridge_inst_mina.Rule_bridge_finalize_cancelled_deposit
+      .Verify_check_accepted_and_ase
+      .tag
+  in
+  let%bind () = compile_tag Bridge_inst_mina.System_L1_enabled.tag in
+  let%bind () = compile_tag Bridge_inst_mina.System_L1_disabled.tag in
+  let%bind () = compile_tag Bridge_inst_mina.System_L2.tag in
+  let%bind () = compile_tag Bridge_inst_mina.System_L1_token_owner.tag in
+  [%log info] "Compiled circuits in %s"
+    (Time.Span.to_string_hum (Time.diff (Time.now ()) start)) ;
+  return ()

--- a/src/app/zeko/sequencer/prover/lib/prover.ml
+++ b/src/app/zeko/sequencer/prover/lib/prover.ml
@@ -549,6 +549,7 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
 
 let run ?fake_proving_time ~logger ~mq_host () =
   let proof_cache_db = Proof_cache_tag.create_identity_db () in
+  let%bind () = Compile_circuits.compile_all ~logger () in
   let handler input =
     Yojson.Safe.from_string input
     |> Input.of_yojson
@@ -569,6 +570,5 @@ let run ?fake_proving_time ~logger ~mq_host () =
     >>| Output.to_yojson >>| Yojson.Safe.to_string
   in
   let%bind _server = Message_queue.Worker.start mq_host handler in
-  [%log info] "Listening on message queue %s\n"
-    (Host_and_port.to_string mq_host) ;
+  [%log info] "Listening on message queue %s" (Host_and_port.to_string mq_host) ;
   Deferred.never ()

--- a/src/app/zeko/sequencer/prover/lib/prover.ml
+++ b/src/app/zeko/sequencer/prover/lib/prover.ml
@@ -33,18 +33,21 @@ module Make_folder (System : sig
 
   type trans = { source : Stmt.t; target : Stmt.t }
 
-  val leaf : Elem.t list * Stmt.t -> (trans * Compile_simple.Proof.t) Promise.t
+  val leaf :
+    (Elem.t list * Stmt.t -> (trans * Compile_simple.Proof.t) Promise.t) lazy_t
 
   val leaf_option :
-    Elem.t list * Stmt.t -> (trans * Compile_simple.Proof.t) Promise.t
+    (Elem.t list * Stmt.t -> (trans * Compile_simple.Proof.t) Promise.t) lazy_t
 
   val extend :
-       Elem.t list * (trans * Compile_simple.Proof.t)
-    -> (trans * Compile_simple.Proof.t) Promise.t
+    (   Elem.t list * (trans * Compile_simple.Proof.t)
+     -> (trans * Compile_simple.Proof.t) Promise.t )
+    lazy_t
 
   val extend_option :
-       Elem.t list * (trans * Compile_simple.Proof.t)
-    -> (trans * Compile_simple.Proof.t) Promise.t
+    (   Elem.t list * (trans * Compile_simple.Proof.t)
+     -> (trans * Compile_simple.Proof.t) Promise.t )
+    lazy_t
 
   (* type merge_input =
        { left : trans
@@ -64,6 +67,18 @@ module Make_folder (System : sig
   val extend_option_iterations : int
 end) =
 struct
+  module System = struct
+    include System
+
+    let leaf = Lazy.force leaf
+
+    let leaf_option = Lazy.force leaf_option
+
+    let extend = Lazy.force extend
+
+    let extend_option = Lazy.force extend_option
+  end
+
   type out_t = Compile_simple.Proof.t option * System.Stmt.t [@@deriving yojson]
 
   let fold
@@ -226,14 +241,14 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
   | Ping ->
       return Output.Pong
   | Txn_snark (Signed_command input) ->
-      let Compile_simple.[ prove; _; _; _; _ ] = Txn_rules.provers in
+      let Compile_simple.[ prove; _; _; _; _ ] = Lazy.force Txn_rules.provers in
       let%map stmt, proof =
         time ?fake_proving_time ~logger "Txn_rules.single_signed_command"
           (prove (Base_input.of_serializable input) |> Promise.to_deferred)
       in
       Output.Txn_snark (stmt, proof)
   | Txn_snark (Zkapp_command (Single_unproved input)) ->
-      let Compile_simple.[ _; prove; _; _; _ ] = Txn_rules.provers in
+      let Compile_simple.[ _; prove; _; _; _ ] = Lazy.force Txn_rules.provers in
       let%map stmt, proof =
         time ?fake_proving_time ~logger
           "Txn_rules.single_unproved_zkapp_command"
@@ -243,7 +258,7 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
       in
       Output.Txn_snark (stmt, proof)
   | Txn_snark (Zkapp_command (Double_unproved input)) ->
-      let Compile_simple.[ _; _; prove; _; _ ] = Txn_rules.provers in
+      let Compile_simple.[ _; _; prove; _; _ ] = Lazy.force Txn_rules.provers in
       let%map stmt, proof =
         time ?fake_proving_time ~logger
           "Txn_rules.double_unproved_zkapp_command"
@@ -253,7 +268,7 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
       in
       Output.Txn_snark (stmt, proof)
   | Txn_snark (Zkapp_command (Single_proved input)) ->
-      let Compile_simple.[ _; _; _; prove; _ ] = Txn_rules.provers in
+      let Compile_simple.[ _; _; _; prove; _ ] = Lazy.force Txn_rules.provers in
       let%map stmt, proof =
         time ?fake_proving_time ~logger "Txn_rules.single_proved_zkapp_command"
           ( prove
@@ -262,16 +277,16 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
       in
       Output.Txn_snark (stmt, proof)
   | Txn_snark (Merge input) ->
-      let Compile_simple.[ _; _; _; _; prove ] = Txn_rules.provers in
+      let Compile_simple.[ _; _; _; _; prove ] = Lazy.force Txn_rules.provers in
       let%map stmt, proof =
         time ?fake_proving_time ~logger "Txn_rules.merge"
           (prove input |> Promise.to_deferred)
       in
       Output.Txn_snark (stmt, proof)
   | Inner_sync input ->
-      let Compile_simple.[ prove; _ ] = Inner_rules_inst.provers in
+      let Compile_simple.[ prove; _ ] = Lazy.force Inner_rules_inst.provers in
       let%bind vk_hash =
-        Compile_simple.Verification_key.of_tag Inner_rules_inst.tag
+        Compile_simple.Verification_key.of_tag (Lazy.force Inner_rules_inst.tag)
         |> Promise.to_deferred
         (* To make fake tests work *)
         >>| Compile_simple.Verification_key.hash
@@ -307,7 +322,9 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
       in
       Output.(Folder (Check_accepted_mina snark))
   | Verify_both_ases_commit (outer, inner) ->
-      let Compile_simple.[ prove ] = Rule_commit.Verify_both_ases.provers in
+      let Compile_simple.[ prove ] =
+        Lazy.force Rule_commit.Verify_both_ases.provers
+      in
       let%map stmt, proof =
         time ?fake_proving_time ~logger "Rule_commit.verify_both_ases"
           ( prove
@@ -319,9 +336,10 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
       Output.Verify_both_ases_commit (stmt, proof)
   | Verify_two_outer_ases_cancelled_deposit (outer, outer_with_length) ->
       let Compile_simple.[ prove ] =
-        Bridge_inst_mina.Rule_bridge_finalize_cancelled_deposit
-        .Verify_two_outer_ases
-        .provers
+        Lazy.force
+          Bridge_inst_mina.Rule_bridge_finalize_cancelled_deposit
+          .Verify_two_outer_ases
+          .provers
       in
       let%map stmt, proof =
         time ?fake_proving_time ~logger
@@ -337,9 +355,10 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
   | Verify_check_accepted_and_ase_cancelled_deposit
       (check_accepted, outer_with_length) ->
       let Compile_simple.[ prove ] =
-        Bridge_inst_mina.Rule_bridge_finalize_cancelled_deposit
-        .Verify_check_accepted_and_ase
-        .provers
+        Lazy.force
+          Bridge_inst_mina.Rule_bridge_finalize_cancelled_deposit
+          .Verify_check_accepted_and_ase
+          .provers
       in
       let%map stmt, proof =
         time ?fake_proving_time ~logger
@@ -354,9 +373,11 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
       in
       Output.Verify_check_accepted_and_ase_cancelled_deposit (stmt, proof)
   | Outer_commit input ->
-      let Compile_simple.[ prove; _; _ ] = Outer_rules_inst.provers in
+      let Compile_simple.[ prove; _; _ ] =
+        Lazy.force Outer_rules_inst.provers
+      in
       let%bind vk_hash =
-        Compile_simple.Verification_key.of_tag Outer_rules_inst.tag
+        Compile_simple.Verification_key.of_tag (Lazy.force Outer_rules_inst.tag)
         |> Promise.to_deferred
         (* To make fake tests work *)
         >>| Compile_simple.Verification_key.hash
@@ -373,9 +394,11 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
                  ~f:Account_update.read_all_proofs_from_disk )
         , proof )
   | Bridge (Outer_action_witness input) ->
-      let Compile_simple.[ _; prove; _ ] = Outer_rules_inst.provers in
+      let Compile_simple.[ _; prove; _ ] =
+        Lazy.force Outer_rules_inst.provers
+      in
       let%bind vk_hash =
-        Compile_simple.Verification_key.of_tag Outer_rules_inst.tag
+        Compile_simple.Verification_key.of_tag (Lazy.force Outer_rules_inst.tag)
         |> Promise.to_deferred
         (* To make fake tests work *)
         >>| Compile_simple.Verification_key.hash
@@ -394,9 +417,9 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
                  ~f:Account_update.read_all_proofs_from_disk )
         , proof )
   | Bridge (Inner_action_witness input) ->
-      let Compile_simple.[ _; prove ] = Inner_rules_inst.provers in
+      let Compile_simple.[ _; prove ] = Lazy.force Inner_rules_inst.provers in
       let%bind vk_hash =
-        Compile_simple.Verification_key.of_tag Inner_rules_inst.tag
+        Compile_simple.Verification_key.of_tag (Lazy.force Inner_rules_inst.tag)
         |> Promise.to_deferred
         (* To make fake tests work *)
         >>| Compile_simple.Verification_key.hash
@@ -415,9 +438,12 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
                  ~f:Account_update.read_all_proofs_from_disk )
         , proof )
   | Bridge (Finalize_deposit input) ->
-      let Compile_simple.[ prove; _ ] = Bridge_inst_mina.System_L2.provers in
+      let Compile_simple.[ prove; _ ] =
+        Lazy.force Bridge_inst_mina.System_L2.provers
+      in
       let%bind vk_hash =
-        Compile_simple.Verification_key.of_tag Bridge_inst_mina.System_L2.tag
+        Compile_simple.Verification_key.of_tag
+          (Lazy.force Bridge_inst_mina.System_L2.tag)
         |> Promise.to_deferred
         (* To make fake tests work *)
         >>| Compile_simple.Verification_key.hash
@@ -435,18 +461,18 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
         , proof )
   | Bridge (Finalize_cancelled_deposit input) ->
       let Compile_simple.[ prove; _; _ ] =
-        Bridge_inst_mina.System_L1_enabled.provers
+        Lazy.force Bridge_inst_mina.System_L1_enabled.provers
       in
       let%bind vk_hash =
         Compile_simple.Verification_key.of_tag
-          Bridge_inst_mina.System_L1_enabled.tag
+          (Lazy.force Bridge_inst_mina.System_L1_enabled.tag)
         |> Promise.to_deferred
         (* To make fake tests work *)
         >>| Compile_simple.Verification_key.hash
       in
       let%bind helper_token_owner_l1_vk_hash =
         Compile_simple.Verification_key.of_tag
-          Bridge_inst_mina.System_L1_token_owner.tag
+          (Lazy.force Bridge_inst_mina.System_L1_token_owner.tag)
         |> Promise.to_deferred
         (* To make fake tests work *)
         >>| Compile_simple.Verification_key.hash
@@ -466,9 +492,12 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
                  ~f:Account_update.read_all_proofs_from_disk )
         , proof )
   | Bridge (Inner_receive input) ->
-      let Compile_simple.[ _; prove ] = Bridge_inst_mina.System_L2.provers in
+      let Compile_simple.[ _; prove ] =
+        Lazy.force Bridge_inst_mina.System_L2.provers
+      in
       let%bind vk_hash =
-        Compile_simple.Verification_key.of_tag Bridge_inst_mina.System_L2.tag
+        Compile_simple.Verification_key.of_tag
+          (Lazy.force Bridge_inst_mina.System_L2.tag)
         |> Promise.to_deferred
         (* To make fake tests work *)
         >>| Compile_simple.Verification_key.hash
@@ -486,24 +515,25 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
         , proof )
   | Bridge (Finalize_withdrawal input) ->
       let Compile_simple.[ _; prove; _ ] =
-        Bridge_inst_mina.System_L1_enabled.provers
+        Lazy.force Bridge_inst_mina.System_L1_enabled.provers
       in
       let%bind vk_hash =
         Compile_simple.Verification_key.of_tag
-          Bridge_inst_mina.System_L1_enabled.tag
+          (Lazy.force Bridge_inst_mina.System_L1_enabled.tag)
         |> Promise.to_deferred
         (* To make fake tests work *)
         >>| Compile_simple.Verification_key.hash
       in
       let%bind helper_token_owner_l1_vk_hash =
         Compile_simple.Verification_key.of_tag
-          Bridge_inst_mina.System_L1_token_owner.tag
+          (Lazy.force Bridge_inst_mina.System_L1_token_owner.tag)
         |> Promise.to_deferred
         (* To make fake tests work *)
         >>| Compile_simple.Verification_key.hash
       in
       let%bind l2_holder_vk_hash =
-        Compile_simple.Verification_key.of_tag Bridge_inst_mina.System_L2.tag
+        Compile_simple.Verification_key.of_tag
+          (Lazy.force Bridge_inst_mina.System_L2.tag)
         |> Promise.to_deferred
         (* To make fake tests work *)
         >>| Compile_simple.Verification_key.hash
@@ -525,11 +555,11 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
         , proof )
   | Bridge (Outer_token_owner input) ->
       let Compile_simple.[ prove ] =
-        Bridge_inst_mina.System_L1_token_owner.provers
+        Lazy.force Bridge_inst_mina.System_L1_token_owner.provers
       in
       let%bind vk_hash =
         Compile_simple.Verification_key.of_tag
-          Bridge_inst_mina.System_L1_token_owner.tag
+          (Lazy.force Bridge_inst_mina.System_L1_token_owner.tag)
         |> Promise.to_deferred
         (* To make fake tests work *)
         >>| Compile_simple.Verification_key.hash

--- a/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
+++ b/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
@@ -30,9 +30,7 @@ end
 
 let (t, deploy_config) : t * Deploy.t option =
   match Sys.getenv_opt "ZEKO_CIRCUITS_CONFIG" with
-  | None ->
-      failwith "ZEKO_CIRCUITS_CONFIG is not set"
-  | Some "test" ->
+  | Some "test" | None ->
       let keypair_of_b58_sk sk =
         let kp =
           Private_key.of_base58_check_exn sk |> Keypair.of_private_key_exn

--- a/src/lib/pickles/compile.ml
+++ b/src/lib/pickles/compile.ml
@@ -577,10 +577,13 @@ struct
                          Impl.constraint_system_manual ~input_typ:Typ.unit
                            ~return_typ:typ
                        in
-                       let%map.Promise res =
-                         constraint_builder.run_circuit main
+                       let%map.Promise cs =
+                         State_lock.with_lock ~f:(fun () ->
+                             let%map.Promise res =
+                               constraint_builder.run_circuit main
+                             in
+                             constraint_builder.finish_computation res )
                        in
-                       let cs = constraint_builder.finish_computation res in
                        let cs_hash =
                          Md5.to_hex (R1CS_constraint_system.digest cs)
                        in

--- a/src/lib/pickles/fix_domains.ml
+++ b/src/lib/pickles/fix_domains.ml
@@ -86,8 +86,11 @@ struct
     let constraint_builder =
       Impl.constraint_system_manual ~input_typ:typ ~return_typ
     in
-    let%map.Promise res = constraint_builder.run_circuit main in
-    let constraint_system = constraint_builder.finish_computation res in
+    let%map.Promise constraint_system =
+      State_lock.with_lock ~f:(fun () ->
+          let%map.Promise res = constraint_builder.run_circuit main in
+          constraint_builder.finish_computation res )
+    in
     domains2 constraint_system
 end
 

--- a/src/lib/pickles/state_lock.ml
+++ b/src/lib/pickles/state_lock.ml
@@ -1,0 +1,31 @@
+open Core_kernel
+
+open struct
+  type waiter = unit -> unit
+
+  type t = { mutable locked : bool; waiters : waiter Queue.t }
+
+  let t = { locked = false; waiters = Queue.create () }
+
+  let lock () =
+    if not t.locked then (
+      t.locked <- true ;
+      Promise.return () )
+    else
+      let promise =
+        Promise.create (fun resolve -> Queue.enqueue t.waiters resolve)
+      in
+      promise
+
+  let unlock () =
+    match Queue.dequeue t.waiters with
+    | None ->
+        t.locked <- false
+    | Some resolve ->
+        resolve ()
+end
+
+let with_lock ~f =
+  let%bind.Promise () = lock () in
+  let%map.Promise result = f () in
+  unlock () ; result


### PR DESCRIPTION
This PR fixes the race condition on Pickles global state by introducing a simple lock. This unfortunately is not enough to have lazy compilation, since something forces the compilation anyways.

fix ZK-376