### PR TITLE
Fix archive relay

### DIFF
--- a/.github/workflows/build-docker-images.yaml
+++ b/.github/workflows/build-docker-images.yaml
@@ -3,7 +3,7 @@ name: Publish docker images
 on:
   push:
     tags:
-    - '*'
+      - "*"
   workflow_dispatch:
     inputs:
       docker_tag_prefix:
@@ -16,7 +16,7 @@ env:
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
-  group: '${{ github.workflow }} @ ${{ github.head_ref || github.ref }}'
+  group: "${{ github.workflow }} @ ${{ github.head_ref || github.ref }}"
   cancel-in-progress: true
 
 jobs:
@@ -25,7 +25,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-4x
     strategy:
       matrix:
-        package: [zeko, zeko-da, zeko-archive-relay]
+        package: [zeko, zeko-da, zeko-archive-relay, zeko-archive]
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v5
@@ -65,7 +65,7 @@ jobs:
 
       - name: 🛠️ Build ${{ matrix.package }} OCI image
         run: nix build .?submodules=1#${{ matrix.package }}-image
-        
+
       - name: 🚚 Load and Push ${{ matrix.package }} docker image
         run: |
           IMAGE_TAR=$(readlink -f result)

--- a/flake.nix
+++ b/flake.nix
@@ -330,7 +330,7 @@
             libp2p_helper kimchi_bindings_stubs snarky_js validation trace-tool
             zkapp-cli;
           inherit (dockerImages)
-            zeko-image zeko-da-image zeko-archive-relay-image mina-image-slim
+            zeko-image zeko-da-image zeko-archive-relay-image zeko-archive-image mina-image-slim
             mina-image-full mina-archive-image-full mina-image-instr-full;
           mina-deb = debianPackages.mina;
           impure-shell = (import ./nix/impure-shell.nix pkgs).inputDerivation;

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -148,7 +148,7 @@ in {
     };
   };
 
-  zeko-archive = dockerTools.buildLayeredImage {
+  zeko-archive-image = dockerTools.buildLayeredImage {
     name = "zeko-archive";
     tag = "latest";
     inherit created;

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -148,6 +148,28 @@ in {
     };
   };
 
+  zeko-archive = dockerTools.buildLayeredImage {
+    name = "zeko-archive";
+    tag = "latest";
+    inherit created;
+    contents = [
+      ocamlPackages_mina.devnet.zeko_archive_relay
+      coreutils
+      findutils
+      bashInteractive
+      procps
+      curl
+      jq
+    ];
+    config = {
+      Entrypoint = [ "/bin/zeko-archive" ];
+      Env = [
+        "NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+        "ZEKO_SIGNATURE_KIND=testnet"
+      ];
+    };
+  };
+
   mina-image-slim = dockerTools.streamLayeredImage {
     name = "mina";
     inherit created;

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -452,6 +452,7 @@ let
           cp src/app/zeko/sequencer/prover/cli_fake.exe $zeko/bin/zeko-prover-fake
           cp src/app/zeko/da_layer/cli.exe $zeko_da/bin/zeko-da
           cp src/app/zeko/sequencer/archive_relay/run.exe $zeko_archive_relay/bin/zeko-archive-relay
+          cp src/app/archive/archive.exe $zeko_archive_relay/bin/zeko-archive
           cp -R _doc/_html $out/share/doc/html
           # cp src/lib/mina_base/sample_keypairs.json $sample/share/mina
           popd

--- a/src/app/archive/dune
+++ b/src/app/archive/dune
@@ -4,12 +4,7 @@
  (public_name archive)
  (modules archive)
  (modes native)
- (libraries
-  archive_cli
-  async
-  async_unix
-  core_kernel
-  mina_version)
+ (libraries archive_cli async async_unix core_kernel mina_version)
  (instrumentation
   (backend bisect_ppx --bisect-sigterm))
  (preprocess

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -4308,6 +4308,206 @@ module Block = struct
          |sql} )
       (state_hash, height)
 
+  let find_common_ancestor_id_opt (module Conn : CONNECTION) ~a_id ~b_id =
+    Conn.find_opt
+      (Caqti_request.find_opt
+         Caqti_type.(tup2 int int)
+         Caqti_type.int
+         {sql| WITH RECURSIVE climb AS (
+                  -- initial state: both blocks
+                  SELECT
+                      a.id        AS a_id,
+                      a.parent_id AS a_parent,
+                      a.height    AS a_h,
+                      b.id        AS b_id,
+                      b.parent_id AS b_parent,
+                      b.height    AS b_h
+                  FROM blocks a
+                  JOIN blocks b
+                   ON a.id = $1
+                  AND b.id = $2
+
+                UNION ALL
+
+                  -- move up: deeper side climbs; if equal heights, both climb
+                  SELECT
+                      CASE
+                          WHEN c.a_h > c.b_h THEN pa.id        -- move A up
+                          WHEN c.b_h > c.a_h THEN c.a_id       -- keep A
+                          ELSE pa.id                           -- equal heights: move A up
+                      END AS a_id,
+                      CASE
+                          WHEN c.a_h > c.b_h THEN pa.parent_id
+                          WHEN c.b_h > c.a_h THEN c.a_parent
+                          ELSE pa.parent_id
+                      END AS a_parent,
+                      CASE
+                          WHEN c.a_h > c.b_h THEN pa.height
+                          WHEN c.b_h > c.a_h THEN c.a_h
+                          ELSE pa.height
+                      END AS a_h,
+
+                      CASE
+                          WHEN c.b_h > c.a_h THEN pb.id        -- move B up
+                          WHEN c.a_h > c.b_h THEN c.b_id       -- keep B
+                          ELSE pb.id                           -- equal heights: move B up
+                      END AS b_id,
+                      CASE
+                          WHEN c.b_h > c.a_h THEN pb.parent_id
+                          WHEN c.a_h > c.b_h THEN c.b_parent
+                          ELSE pb.parent_id
+                      END AS b_parent,
+                      CASE
+                          WHEN c.b_h > c.a_h THEN pb.height
+                          WHEN c.a_h > c.b_h THEN c.b_h
+                          ELSE pb.height
+                      END AS b_h
+                  FROM climb c
+                  JOIN blocks pa ON pa.id = c.a_parent
+                  JOIN blocks pb ON pb.id = c.b_parent
+                  WHERE c.a_id <> c.b_id       -- stop recursing once they're equal
+              )
+              SELECT a_id AS lca_id
+              FROM climb
+              WHERE a_id = b_id               -- the row(s) where they meet
+              LIMIT 1;
+          |sql} )
+      (a_id, b_id)
+
+  let get_chain_from_root (module Conn : CONNECTION) ~block_id =
+    (* derive query from type `t` *)
+    let concat = String.concat ~sep:"," in
+    let columns_with_id = concat ("id" :: Fields.names) in
+    let b_columns_with_id =
+      concat (List.map ("id" :: Fields.names) ~f:(fun s -> "b." ^ s))
+    in
+    let columns = concat Fields.names in
+    Conn.collect_list
+      (Caqti_request.collect Caqti_type.int typ
+         (sprintf
+            {sql| WITH RECURSIVE chain AS (
+                  -- start at the given node
+                  SELECT %s
+                  FROM blocks
+                  WHERE id = ?
+
+                  UNION ALL
+
+                  -- walk upward to the root
+                  SELECT %s
+                  FROM blocks b
+                  JOIN chain c ON b.id = c.parent_id
+              )
+              SELECT %s
+              FROM chain
+              ORDER BY height ASC; |sql}
+            columns_with_id b_columns_with_id columns ) )
+      block_id
+
+  (* ZEKO NOTE: we mark as canonical chain the latest one *)
+  let zeko_update_chain_status (module Conn : CONNECTION) ~block_id =
+    let open Deferred.Result.Let_syntax in
+    let%bind block = load (module Conn) ~id:block_id in
+    match%bind get_highest_canonical_block_opt (module Conn) () with
+    | None ->
+        (* first block, mark as canonical *)
+        (* should not even be reachable since block 0 will be canonical automatically *)
+        let%bind () =
+          mark_as_canonical (module Conn) ~state_hash:block.state_hash
+        in
+        Deferred.Result.return ()
+    | Some (highest_canonical_block_id, _)
+      when Option.value block.parent_id ~default:(-1)
+           = highest_canonical_block_id ->
+        (* added new block, mark as canonical *)
+        let%bind () =
+          mark_as_canonical (module Conn) ~state_hash:block.state_hash
+        in
+        Deferred.Result.return ()
+    | Some (highest_canonical_block_id, _) -> (
+        (* need to find common ancestor *)
+        match%bind
+          find_common_ancestor_id_opt
+            (module Conn)
+            ~a_id:highest_canonical_block_id ~b_id:block_id
+        with
+        | Some common_ancestor_id ->
+            (* blocks between common ancestor and highest canonical block mark as orphaned *)
+            let%bind orphaned_subchain =
+              get_subchain
+                (module Conn)
+                ~start_block_id:common_ancestor_id
+                ~end_block_id:highest_canonical_block_id
+            in
+            let%bind () =
+              Metrics.time
+                ~label:
+                  "mark_as_orphaned (common_ancestor_id -> \
+                   highest_canonical_block_id)" (fun () ->
+                  Mina_caqti.deferred_result_list_fold orphaned_subchain
+                    ~init:() ~f:(fun () block ->
+                      mark_as_orphaned
+                        (module Conn)
+                        ~state_hash:"never" ~height:block.height ) )
+            in
+            (* blocks between common ancestor and new block mark as canonical *)
+            let%bind canonical_subchain =
+              get_subchain
+                (module Conn)
+                ~start_block_id:common_ancestor_id ~end_block_id:block_id
+            in
+            let%bind () =
+              Metrics.time
+                ~label:"mark_as_canonical (common_ancestor_id -> block_id)"
+                (fun () ->
+                  Mina_caqti.deferred_result_list_fold canonical_subchain
+                    ~init:() ~f:(fun () block ->
+                      let%bind () =
+                        mark_as_canonical
+                          (module Conn)
+                          ~state_hash:block.state_hash
+                      in
+                      mark_as_orphaned
+                        (module Conn)
+                        ~state_hash:block.state_hash ~height:block.height ) )
+            in
+            Deferred.Result.return ()
+        | None ->
+            (* completely new chain, mark whole old chain as orphaned *)
+            let%bind orphaned_subchain =
+              get_chain_from_root
+                (module Conn)
+                ~block_id:highest_canonical_block_id
+            in
+            let%bind () =
+              Metrics.time
+                ~label:"mark_as_orphaned (root -> highest_canonical_block_id)"
+                (fun () ->
+                  Mina_caqti.deferred_result_list_fold orphaned_subchain
+                    ~init:() ~f:(fun () block ->
+                      mark_as_orphaned
+                        (module Conn)
+                        ~state_hash:"never" ~height:block.height ) )
+            in
+            let%bind canonical_subchain =
+              get_chain_from_root (module Conn) ~block_id
+            in
+            let%bind () =
+              Metrics.time ~label:"mark_as_canonical (root -> block_id)"
+                (fun () ->
+                  Mina_caqti.deferred_result_list_fold canonical_subchain
+                    ~init:() ~f:(fun () block ->
+                      let%bind () =
+                        mark_as_canonical
+                          (module Conn)
+                          ~state_hash:block.state_hash
+                      in
+                      mark_as_orphaned
+                        (module Conn)
+                        ~state_hash:block.state_hash ~height:block.height ) )
+            in
+            Deferred.Result.return () )
+
   (* update chain_status for blocks now known to be canonical or orphaned *)
   let update_chain_status (module Conn : CONNECTION)
       ~(genesis_constants : Genesis_constants.t) ~block_id =
@@ -4477,7 +4677,7 @@ let retry ~f ~logger ~error_str retries =
   in
   go retries
 
-let add_block_aux ?(retries = 3) ~logger ~genesis_constants ~pool ~add_block
+let add_block_aux ?(retries = 3) ~logger ~genesis_constants:_ ~pool ~add_block
     ~hash ~delete_older_than ~accounts_accessed ~accounts_created ~tokens_used
     block =
   let state_hash = hash block in
@@ -4523,10 +4723,8 @@ let add_block_aux ?(retries = 3) ~logger ~genesis_constants ~pool ~add_block
           in
           (* update chain status for existing blocks *)
           let%bind () =
-            Metrics.time ~label:"update_chain_status" (fun () ->
-                Block.update_chain_status
-                  (module Conn)
-                  ~genesis_constants ~block_id )
+            Metrics.time ~label:"zeko_update_chain_status" (fun () ->
+                Block.zeko_update_chain_status (module Conn) ~block_id )
           in
           let%bind () =
             match delete_older_than with

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -4308,6 +4308,12 @@ module Block = struct
          |sql} )
       (state_hash, height)
 
+  let mark_block_as_orphaned (module Conn : CONNECTION) ~state_hash =
+    Conn.exec
+      (Caqti_request.exec Caqti_type.string
+         {sql| UPDATE blocks SET chain_status='orphaned' WHERE state_hash = ? |sql} )
+      state_hash
+
   let find_common_ancestor_id_opt (module Conn : CONNECTION) ~a_id ~b_id =
     Conn.find_opt
       (Caqti_request.find_opt
@@ -4446,9 +4452,9 @@ module Block = struct
                    highest_canonical_block_id)" (fun () ->
                   Mina_caqti.deferred_result_list_fold orphaned_subchain
                     ~init:() ~f:(fun () block ->
-                      mark_as_orphaned
+                      mark_block_as_orphaned
                         (module Conn)
-                        ~state_hash:"never" ~height:block.height ) )
+                        ~state_hash:block.state_hash ) )
             in
             (* blocks between common ancestor and new block mark as canonical *)
             let%bind canonical_subchain =
@@ -4485,9 +4491,9 @@ module Block = struct
                 (fun () ->
                   Mina_caqti.deferred_result_list_fold orphaned_subchain
                     ~init:() ~f:(fun () block ->
-                      mark_as_orphaned
+                      mark_block_as_orphaned
                         (module Conn)
-                        ~state_hash:"never" ~height:block.height ) )
+                        ~state_hash:block.state_hash ) )
             in
             let%bind canonical_subchain =
               get_chain_from_root (module Conn) ~block_id

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -4333,14 +4333,13 @@ module Block = struct
                    ON a.id = $1
                   AND b.id = $2
 
-                UNION ALL
+                  UNION ALL
 
-                  -- move up: deeper side climbs; if equal heights, both climb
                   SELECT
                       CASE
-                          WHEN c.a_h > c.b_h THEN pa.id        -- move A up
-                          WHEN c.b_h > c.a_h THEN c.a_id       -- keep A
-                          ELSE pa.id                           -- equal heights: move A up
+                          WHEN c.a_h > c.b_h THEN pa.id
+                          WHEN c.b_h > c.a_h THEN c.a_id
+                          ELSE pa.id
                       END AS a_id,
                       CASE
                           WHEN c.a_h > c.b_h THEN pa.parent_id
@@ -4354,9 +4353,9 @@ module Block = struct
                       END AS a_h,
 
                       CASE
-                          WHEN c.b_h > c.a_h THEN pb.id        -- move B up
-                          WHEN c.a_h > c.b_h THEN c.b_id       -- keep B
-                          ELSE pb.id                           -- equal heights: move B up
+                          WHEN c.b_h > c.a_h THEN pb.id
+                          WHEN c.a_h > c.b_h THEN c.b_id
+                          ELSE pb.id
                       END AS b_id,
                       CASE
                           WHEN c.b_h > c.a_h THEN pb.parent_id
@@ -4371,11 +4370,11 @@ module Block = struct
                   FROM climb c
                   JOIN blocks pa ON pa.id = c.a_parent
                   JOIN blocks pb ON pb.id = c.b_parent
-                  WHERE c.a_id <> c.b_id       -- stop recursing once they're equal
+                  WHERE c.a_id <> c.b_id
               )
               SELECT a_id AS lca_id
               FROM climb
-              WHERE a_id = b_id               -- the row(s) where they meet
+              WHERE a_id = b_id
               LIMIT 1;
           |sql} )
       (a_id, b_id)
@@ -4392,14 +4391,12 @@ module Block = struct
       (Caqti_request.collect Caqti_type.int typ
          (sprintf
             {sql| WITH RECURSIVE chain AS (
-                  -- start at the given node
                   SELECT %s
                   FROM blocks
                   WHERE id = ?
 
                   UNION ALL
 
-                  -- walk upward to the root
                   SELECT %s
                   FROM blocks b
                   JOIN chain c ON b.id = c.parent_id

--- a/src/app/zeko/da_layer/lib/client.ml
+++ b/src/app/zeko/da_layer/lib/client.ml
@@ -452,6 +452,10 @@ let get_diffs_chain ~logger ~config ?max_length ~source_ledger_hash
       Rpc.get_diffs_chain ~logger ~node_location ?max_length
         ~source:source_ledger_hash ~target:target_ledger_hash () )
 
+let diff_exists ~logger ~config ~ledger_hash () =
+  try_all_nodes ~config ~f:(fun ~node_location () ->
+      Rpc.has_diff ~logger ~node_location ~ledger_hash )
+
 (** Lazily fetch chunks of diffs, used to minimize memory usage *)
 let get_lazy_diffs_chunks ~logger ~depth ~config ?(n = 100) ~source_ledger_hash
     ~target_ledger_hash () =

--- a/src/app/zeko/sequencer/archive_relay/run.ml
+++ b/src/app/zeko/sequencer/archive_relay/run.ml
@@ -217,12 +217,20 @@ let sync (t : t) () =
         | Error e ->
             failwith e
       in
-      time ~logger "Synced" (sync_archive t ~hash:ledger_hash) )
+      if%bind
+        Da_layer.Client.diff_exists ~logger ~config:t.da_config ~ledger_hash ()
+        >>| Or_error.ok_exn
+      then time ~logger "Synced" (sync_archive t ~hash:ledger_hash)
+      else (
+        [%log warn] "Diff does not exist yet, skipping sync" ;
+        return (Ok ()) ) )
 
 let rec run (t : t) ~sync_period () =
   let logger = t.logger in
   let () =
-    match sync t () with
+    match
+      (try Ok (sync t ()) with e -> Error (Error.of_exn e)) |> Or_error.join
+    with
     | Ok () ->
         (* wait *)
         Thread_safe.block_on_async_exn (fun () ->


### PR DESCRIPTION
Two things in the PR
1. Fix of the archive relay, now if da node does not have the state that sequencer is claiming to be the current, it just waits instead of resyncing.
2. Added `zeko-archive` which is alternative to `mina-archive`, but with correct canonical blocks marking for zeko. This means that with sequencer hard reset, the archive does not have to be reset as well.

fix ZK-383