### PR TITLE
ci: bump actions/checkout to v6

### DIFF
--- a/.github/workflows/build-docker-images.yaml
+++ b/.github/workflows/build-docker-images.yaml
@@ -28,7 +28,7 @@ jobs:
         package: [zeko, zeko-da, zeko-archive-relay, zeko-archive]
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: 🏷️ Generate Tag

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       # Prepare build environment(Go/OCaml/Rust)


### PR DESCRIPTION
Updates CI to use `actions/checkout@v6` for improved performance and security.

https://github.com/actions/checkout/releases/tag/v6.0.0