### PR TITLE
Audit 03: Unconstrained initializer in emergency DA folding

### DIFF
--- a/src/app/zeko/circuits/emergency_da_folder.ml
+++ b/src/app/zeko/circuits/emergency_da_folder.ml
@@ -36,7 +36,12 @@ module M = struct
   module Stmt = Stmt
   module Init = Stmt
 
-  let init ~check:_ (x : Init.var) = Checked.return x
+  let init ~check:_ (x : Init.var) =
+    let* () =
+      assert_equal ~label:__LOC__ Ledger_hash.typ x.source_ledger
+        x.target_ledger
+    in
+    Checked.return x
 
   let step (elem : Elem.var) (stmt : Stmt.var) =
     let* eq_ledger =

--- a/src/app/zeko/circuits/emergency_da_folder.ml
+++ b/src/app/zeko/circuits/emergency_da_folder.ml
@@ -41,6 +41,10 @@ module M = struct
       assert_equal ~label:__LOC__ Ledger_hash.typ x.source_ledger
         x.target_ledger
     in
+    let* () =
+      assert_equal ~label:__LOC__ Account_set.typ x.source_acc_set
+        x.target_acc_set
+    in
     Checked.return x
 
   let step (elem : Elem.var) (stmt : Stmt.var) =


### PR DESCRIPTION
The emergency DA folder’s init function applies no
constraints to the initial statement:
```
let init ~check:_ (x : Init.var) = Checked.return x
```
The `init_arg` field of the folder witness is therefore a free, prover-chosen value. In the folder code, the get function calls `get_full` but discards the source:
```
let%snarkydef_ get ?check t =
  let*| `Source _source, `Target target, verify =
    get_full ?check t
  in
  (target, verify)
```
so the caller never sees or constrains what the initial state was.

fix ZK-469