### PR TITLE
Audit 04: DA nodes unsafely deserialize sparse ledgers

### DIFF
--- a/src/app/zeko/da_layer/lib/core.ml
+++ b/src/app/zeko/da_layer/lib/core.ml
@@ -16,18 +16,20 @@ let post_diff ~logger ~proof_cache_db ~kvdb ~network_id ~(signer : Keypair.t)
     ~ledger_openings ~acc_set_openings ~diff =
   (* 1 *)
   let%bind.Result () =
-    match
-      Ledger_hash.equal
-        (Sparse_ledger.merkle_root ledger_openings)
-        (Diff.source_ledger_hash diff)
-    with
-    | true ->
-        Ok ()
-    | false ->
-        Error
-          (Error.create "Source ledger hash mismatch"
-             (Diff.source_ledger_hash diff)
-             Ledger_hash.sexp_of_t )
+    try
+      match
+        Ledger_hash.equal
+          (Sparse_ledger.merkle_root_without_cache_exn ledger_openings)
+          (Diff.source_ledger_hash diff)
+      with
+      | true ->
+          Ok ()
+      | false ->
+          Error
+            (Error.create "Source ledger hash mismatch"
+               (Diff.source_ledger_hash diff)
+               Ledger_hash.sexp_of_t )
+    with e -> Error (Error.of_exn e)
   in
 
   (* 2 *)
@@ -88,7 +90,8 @@ let post_diff ~logger ~proof_cache_db ~kvdb ~network_id ~(signer : Keypair.t)
     @@ Random_oracle.hash
          ~init:(Hash_prefix_create.salt Zeko_constants.da_layer_check_salt)
          [| target_ledger_hash
-          ; Indexed_merkle_tree.Sparse.merkle_root acc_set_openings
+          ; Indexed_merkle_tree.Sparse.merkle_root_without_cache_exn
+              acc_set_openings
          |]
   in
   let signature =

--- a/src/app/zeko/da_layer/lib/core.ml
+++ b/src/app/zeko/da_layer/lib/core.ml
@@ -85,14 +85,17 @@ let post_diff ~logger ~proof_cache_db ~kvdb ~network_id ~(signer : Keypair.t)
   let target_ledger_hash = Sparse_ledger.merkle_root target_ledger in
 
   (* 5 *)
-  let message =
-    Random_oracle.Input.Chunked.field
-    @@ Random_oracle.hash
-         ~init:(Hash_prefix_create.salt Zeko_constants.da_layer_check_salt)
-         [| target_ledger_hash
-          ; Indexed_merkle_tree.Sparse.merkle_root_without_cache_exn
-              acc_set_openings
-         |]
+  let%bind.Result message =
+    try
+      Random_oracle.Input.Chunked.field
+      @@ Random_oracle.hash
+           ~init:(Hash_prefix_create.salt Zeko_constants.da_layer_check_salt)
+           [| target_ledger_hash
+            ; Indexed_merkle_tree.Sparse.merkle_root_without_cache_exn
+                acc_set_openings
+           |]
+      |> Result.return
+    with e -> Error (Error.of_exn e)
   in
   let signature =
     Schnorr.Chunked.sign ~signature_kind:network_id signer.private_key message

--- a/src/app/zeko/indexed_merkle_tree/indexed_merkle_tree.ml
+++ b/src/app/zeko/indexed_merkle_tree/indexed_merkle_tree.ml
@@ -102,7 +102,7 @@ module Hash = struct
     end
   end]
 
-  let merge = Ledger_hash.merge
+  let merge = Stable.Latest.merge
 end
 
 module Inputs = struct

--- a/src/lib/mina_base/sparse_ledger_base.ml
+++ b/src/lib/mina_base/sparse_ledger_base.ml
@@ -152,6 +152,7 @@ M.
   , add_path
   , add_wide_path_unsafe
   , merkle_root
+  , merkle_root_without_cache_exn
   , iteri )]
 
 let of_root ~depth (h : Ledger_hash.t) =

--- a/src/lib/mina_base/sparse_ledger_base.mli
+++ b/src/lib/mina_base/sparse_ledger_base.mli
@@ -33,6 +33,8 @@ module L : Ledger_intf.S with type t = t ref and type location = int
 
 val merkle_root : t -> Ledger_hash.t
 
+val merkle_root_without_cache_exn : t -> Ledger_hash.t
+
 val depth : t -> int
 
 val get_exn : t -> int -> Account.t

--- a/src/lib/sparse_ledger_lib/sparse_ledger.ml
+++ b/src/lib/sparse_ledger_lib/sparse_ledger.ml
@@ -89,6 +89,8 @@ module type S = sig
 
   val merkle_root : t -> hash
 
+  val merkle_root_without_cache_exn : t -> hash
+
   val depth : t -> int
 end
 
@@ -127,11 +129,29 @@ end = struct
     | Node (h, _, _) ->
         h
 
+  let rec hash_without_cache_exn ~depth : (Hash.t, Account.t) Tree.t -> Hash.t =
+    function
+    | Account a ->
+        Account.data_hash a
+    | Hash h ->
+        h
+    | Node (h, l, r) ->
+        let h' =
+          Hash.merge ~height:depth
+            (hash_without_cache_exn ~depth:(depth - 1) l)
+            (hash_without_cache_exn ~depth:(depth - 1) r)
+        in
+        assert (Hash.equal h h') ;
+        h
+
   type index = int [@@deriving sexp, yojson]
 
   let depth { T.depth; _ } = depth
 
   let merkle_root { T.tree; _ } = hash tree
+
+  let merkle_root_without_cache_exn { T.tree; depth; _ } =
+    hash_without_cache_exn ~depth:(depth - 1) tree
 
   let add_path_impl ~replace_self tree0 path0 account =
     (* Takes height, left and right children and builds a pair of sibling nodes


### PR DESCRIPTION
The DA node’s `post_diff` function accepts a client-supplied `ledger_openings` (a `Sparse_ledger.t` ) and validates it by checking that its Merkle root matches the diff’s `source_ledger_hash`. The sparse ledger data structure contains a tree of nodes, and in particular for each internal node, it contains a **cached hash** for the subtree. The `merkle_root` function simply delegates to `hash`, which for a `Node(h, _, _)` returns the **stored** hash `h` without verifying it is consistent with the node’s children:
```
let hash = function
    | Account a -> Account.data_hash a
    | Hash h -> h
    | Node (h, _, _) -> h
```
In particular, no recursion is done, and no checks are done to ensure this hash is consistent with the openings.

fix ZK-472