### PR TITLE
Audit 00: L2 actions are not enforced to be stored in DA

### DIFF
--- a/src/app/zeko/da_layer/lib/client.ml
+++ b/src/app/zeko/da_layer/lib/client.ml
@@ -923,7 +923,7 @@ let distribute_diff ~logger ~config ~ledger_openings ~acc_set_openings ~diff =
 (** One diff can be too big, split it into multiple smaller ones
     To have only one diff set [max_size] to [Int.max_value]
 *)
-let create_genesis_diffs ?(max_size = 50) ~logger ledger =
+let create_genesis_diffs ?(max_size = 50) ~logger ledger ~get_actions_for_aid =
   let%bind account_ids =
     Ledger.to_list ledger >>| List.map ~f:Account.identifier
   in
@@ -948,12 +948,16 @@ let create_genesis_diffs ?(max_size = 50) ~logger ledger =
         in
         List.iter chunk ~f:(fun (index, account) ->
             Ledger.set_at_index_exn ephemeral index account ) ;
+        let actions =
+          List.map chunk ~f:(fun (_, account) ->
+              let aid = Account.identifier account in
+              (aid, get_actions_for_aid (Account.identifier account)) )
+        in
         let diff =
           Diff.create_pending
             ~source_ledger_hash:(Sparse_ledger.merkle_root ledger_openings)
-            ~changed_accounts:chunk ~actions:(`Actions [])
+            ~changed_accounts:chunk ~actions:(`Actions actions)
         in
-        (* let () = failwith "TODO" in *)
         [%log debug] "Adding accounts to acc set db" ;
         Indexed_merkle_tree.In_memory.insert_batch_exn acc_set
           (List.map chunk ~f:(fun (_, account) ->
@@ -982,8 +986,8 @@ let create_genesis_diffs ?(max_size = 50) ~logger ledger =
   result
 
 (** Distribute diff of initial accounts *)
-let distribute_genesis_diff ~logger ~config ~ledger =
-  let%bind diffs = create_genesis_diffs ~logger ledger in
+let distribute_genesis_diff ~logger ~config ~ledger ~get_actions_for_aid =
+  let%bind diffs = create_genesis_diffs ~logger ledger ~get_actions_for_aid in
   Deferred.List.iter ~how:`Sequential diffs
     ~f:(fun (diff, ledger_openings, acc_set_openings, `Target _) ->
       distribute_diff ~logger ~config ~ledger_openings ~acc_set_openings ~diff )

--- a/src/app/zeko/da_layer/lib/client.ml
+++ b/src/app/zeko/da_layer/lib/client.ml
@@ -22,7 +22,7 @@ let rec keep_retrying ~logger ?(delay = Time_ns.Span.of_sec 5.) ~f () =
 
 module Diff_table = struct
   type t =
-    { diff : Diff.Stable.V1.t
+    { diff : Diff.Pending.Stable.V1.t
     ; ledger_openings : Sparse_ledger.t
     ; acc_set_openings : Indexed_merkle_tree.Sparse.t
     ; genesis : bool
@@ -47,7 +47,7 @@ module Diff_table = struct
           ; ( if genesis then None
             else Some (Ledger_hash.to_decimal_string diff.source_ledger_hash) )
           ; Binable.to_bigstring
-              (module Diff.Stable.V1.With_top_version_tag)
+              (module Diff.Pending.Stable.V1.With_top_version_tag)
               diff
             |> Bigstring.to_string
           ; Sparse_ledger.to_yojson ledger_openings |> Yojson.Safe.to_string
@@ -69,7 +69,7 @@ module Diff_table = struct
         in
         { diff =
             Binable.of_bigstring
-              (module Diff.Stable.V1.With_top_version_tag)
+              (module Diff.Pending.Stable.V1.With_top_version_tag)
               (Bigstring.of_string diff)
         ; ledger_openings =
             Sparse_ledger.of_yojson (Yojson.Safe.from_string ledger_openings)
@@ -279,7 +279,9 @@ module Rpc = struct
     dispatch_with_fallback_same_query ~max_tries:1 ~logger node_location
       ledger_hash
       ~versions:
-        [ Versioned_rpc_same_query.V (Rpc.Get_diff.V3.t, Fn.id)
+        [ Versioned_rpc_same_query.V (Rpc.Get_diff.V4.t, Fn.id)
+        ; Versioned_rpc_same_query.V
+            (Rpc.Get_diff.V3.t, Option.map ~f:Diff.Stable.V3.to_latest)
         ; Versioned_rpc_same_query.V
             (Rpc.Get_diff.V2.t, Option.map ~f:Diff.Stable.V2.to_latest)
         ; Versioned_rpc_same_query.V
@@ -322,7 +324,7 @@ module Rpc = struct
       ?max_length ~source ~target () =
     [%log debug] "Getting diffs chain from da node %s"
       (Host_and_port.to_string node_location.value) ;
-    dispatch ~max_tries:1 ~logger node_location Rpc.Get_diffs_chain.V1.t
+    dispatch ~max_tries:1 ~logger node_location Rpc.Get_diffs_chain.V2.t
       { source; target; max_length }
 
   let has_diff ~logger
@@ -384,7 +386,7 @@ module Rpc = struct
       ~target () =
     [%log debug] "Getting diffs stream from da node %s"
       (Host_and_port.to_string node_location.value) ;
-    pipe_dispatch Rpc.Diffs_stream.V2.t { source; target } node_location.value
+    pipe_dispatch Rpc.Diffs_stream.V3.t { source; target } node_location.value
 end
 
 module Config = struct
@@ -817,7 +819,7 @@ let map_diffs :
          (   current_chunk:int
           -> current_diff:int
           -> chunks_length:int
-          -> Diff.Stable.V3.t
+          -> Diff.Stable.V4.t
           -> 'a Deferred.t )
     -> unit
     -> ('a list, Error.t) Deferred.Result.t =
@@ -861,7 +863,7 @@ let iter_diffs :
          (   current_chunk:int
           -> current_diff:int
           -> chunks_length:int
-          -> Diff.Stable.V3.t
+          -> Diff.Stable.V4.t
           -> unit Deferred.t )
     -> unit
     -> (unit, Error.t) Deferred.Result.t =
@@ -947,10 +949,11 @@ let create_genesis_diffs ?(max_size = 50) ~logger ledger =
         List.iter chunk ~f:(fun (index, account) ->
             Ledger.set_at_index_exn ephemeral index account ) ;
         let diff =
-          Diff.create
+          Diff.create_pending
             ~source_ledger_hash:(Sparse_ledger.merkle_root ledger_openings)
-            ~changed_accounts:chunk ~command_with_action_step_flags:None
+            ~changed_accounts:chunk ~actions:(`Actions [])
         in
+        (* let () = failwith "TODO" in *)
         [%log debug] "Adding accounts to acc set db" ;
         Indexed_merkle_tree.In_memory.insert_batch_exn acc_set
           (List.map chunk ~f:(fun (_, account) ->

--- a/src/app/zeko/da_layer/lib/core.ml
+++ b/src/app/zeko/da_layer/lib/core.ml
@@ -13,8 +13,8 @@ open Signature_lib
     8. Store the diff under the [target_ledger_hash].
     9. Sign [target_ledger_hash]. *)
 let post_diff ~logger ~proof_cache_db ~kvdb ~network_id
-    ~(signer : Signer_service.Signer.t) ~ledger_openings ~acc_set_openings ~diff
-    =
+    ~(signer : Signer_service.Signer.t) ~ledger_openings ~acc_set_openings
+    ~(diff : Diff.Pending.t) =
   (* 1 *)
   let%bind.Result () =
     try
@@ -35,37 +35,34 @@ let post_diff ~logger ~proof_cache_db ~kvdb ~network_id
 
   (* 2 *)
   let%bind.Result () =
-    match Db.get_diff kvdb ~ledger_hash:(Diff.source_ledger_hash diff) with
+    match Db.get_diff kvdb ~ledger_hash:diff.source_ledger_hash with
     | Some _ ->
         Ok ()
     | None ->
         if
-          Ledger_hash.equal
-            (Diff.source_ledger_hash diff)
+          Ledger_hash.equal diff.source_ledger_hash
             (Diff.empty_ledger_hash
                ~depth:(Sparse_ledger.depth ledger_openings) )
         then Ok ()
         else
           Error
             (Error.create "Source ledger not found in the database"
-               (Diff.source_ledger_hash diff)
-               Ledger_hash.sexp_of_t )
+               diff.source_ledger_hash Ledger_hash.sexp_of_t )
   in
 
   (* 3 *)
-  let indices = List.map (Diff.changed_accounts diff) ~f:fst in
+  let indices = List.map diff.changed_accounts ~f:fst in
   let%bind.Result () =
     match List.contains_dup ~compare:Int.compare indices with
     | false ->
         Ok ()
     | true ->
-        Error
-          (Error.create "Duplicate indices" diff [%sexp_of: Diff.Stable.V1.t])
+        Error (Error.create "Duplicate indices" diff [%sexp_of: Diff.Pending.t])
   in
 
   (* 4 *)
   let%bind.Result target_ledger =
-    List.fold_result (Diff.changed_accounts diff) ~init:ledger_openings
+    List.fold_result diff.changed_accounts ~init:ledger_openings
       ~f:(fun ledger (diff_index, account) ->
         try
           (* Check that the index of the account matches the index in the diff *)
@@ -102,10 +99,10 @@ let post_diff ~logger ~proof_cache_db ~kvdb ~network_id
         Ok account.receipt_chain_hash
   in
   let%bind.Result applied_hashes =
-    match Diff.command_with_action_step_flags diff with
-    | None ->
+    match diff.actions with
+    | `Actions _todo ->
         Ok Account_id.Map.empty
-    | Some (Signed_command command, _) ->
+    | `Command_with_action_step_flags (Signed_command command, _) ->
         (* For signed command only the fee payer gets the receipt *)
         let account_id = Signed_command.fee_payer command in
         let%bind.Result old_receipt_chain_hash =
@@ -119,7 +116,7 @@ let post_diff ~logger ~proof_cache_db ~kvdb ~network_id
         Ok
           (Account_id.Map.set Account_id.Map.empty ~key:account_id
              ~data:new_receipt_chain_hash )
-    | Some (Zkapp_command command, _) ->
+    | `Command_with_action_step_flags (Zkapp_command command, _) ->
         let command =
           Zkapp_command.write_all_proofs_to_disk ~signature_kind:network_id
             ~proof_cache_db command
@@ -159,35 +156,37 @@ let post_diff ~logger ~proof_cache_db ~kvdb ~network_id
         Ok acc
   in
   let%bind.Result () =
-    if Option.is_none (Diff.command_with_action_step_flags diff) then Ok ()
-    else
-      List.fold_result (Diff.changed_accounts diff) ~init:()
-        ~f:(fun _ (_, account) ->
-          (* account's target_receipt_chain_hash needs to be either unchanged or the same as in [applied_hashes] *)
-          let account_id = Account.identifier account in
-          let%bind.Result target_account =
-            get_account target_ledger account_id
-          in
-          let target_receipt_chain_hash = target_account.receipt_chain_hash in
-          let%bind.Result applied_receipt_chain_hash =
-            get_account's_receipt_chain_hash applied_hashes account_id
-          in
-          if
-            Receipt.Chain_hash.equal target_receipt_chain_hash
-              applied_receipt_chain_hash
-          then Ok ()
-          else
-            Error
-              (Error.create "Receipt chain hash mismatch"
-                 (target_receipt_chain_hash, applied_receipt_chain_hash)
-                 [%sexp_of: Receipt.Chain_hash.t * Receipt.Chain_hash.t] ) )
+    match diff.actions with
+    | `Actions _todo ->
+        Ok ()
+    | `Command_with_action_step_flags _ ->
+        List.fold_result diff.changed_accounts ~init:()
+          ~f:(fun _ (_, account) ->
+            (* account's target_receipt_chain_hash needs to be either unchanged or the same as in [applied_hashes] *)
+            let account_id = Account.identifier account in
+            let%bind.Result target_account =
+              get_account target_ledger account_id
+            in
+            let target_receipt_chain_hash = target_account.receipt_chain_hash in
+            let%bind.Result applied_receipt_chain_hash =
+              get_account's_receipt_chain_hash applied_hashes account_id
+            in
+            if
+              Receipt.Chain_hash.equal target_receipt_chain_hash
+                applied_receipt_chain_hash
+            then Ok ()
+            else
+              Error
+                (Error.create "Receipt chain hash mismatch"
+                   (target_receipt_chain_hash, applied_receipt_chain_hash)
+                   [%sexp_of: Receipt.Chain_hash.t * Receipt.Chain_hash.t] ) )
   in
 
   (* 6 *)
   let%bind.Result () =
     try
       let new_accounts =
-        List.filter (Diff.changed_accounts diff) ~f:(fun (index, _) ->
+        List.filter diff.changed_accounts ~f:(fun (index, _) ->
             Account.equal
               (Sparse_ledger.get_exn ledger_openings index)
               Account.empty )
@@ -226,7 +225,7 @@ let post_diff ~logger ~proof_cache_db ~kvdb ~network_id
 
   (* 7 *)
   (* V2 was added time *)
-  let diff : Diff.Stable.V3.t =
+  let diff : Diff.Stable.V4.t =
     Diff.add_time_and_acc_set ~logger diff
       ~acc_set:(Indexed_merkle_tree.Sparse.merkle_root acc_set_openings)
   in

--- a/src/app/zeko/da_layer/lib/core.ml
+++ b/src/app/zeko/da_layer/lib/core.ml
@@ -2,33 +2,41 @@ open Core_kernel
 open Mina_base
 open Mina_ledger
 open Signature_lib
+module Field = Snark_params.Tick.Field
 
 (** 1. Check that [root ledger_openings = diff.source_ledger_hash].
     2. Check that [diff.source_ledger_hash] is either in the databse or an empty ledger.
     3. Check that the indices in [diff.diff] are unique. 
     4. Set each account in [diff.diff] to the [ledger_openings] and call the resulting ledger hash [target_ledger_hash].
-    5. Check that after applying all the receipts of the command, the receipt chain hashes match the target ledger.
-    6. Check that new accounts in ledger openings are in same order as in acc set openings.
-    7. Attach timestamp and acc set root.
-    8. Store the diff under the [target_ledger_hash].
-    9. Sign [target_ledger_hash]. *)
+    5. Apply all the actions in [diff.diff] to the [ledger_openings] and check it matches the target ledger..
+    6. Check that after applying all the receipts of the command, the receipt chain hashes match the target ledger.
+    7. Check that new accounts in ledger openings are in same order as in acc set openings.
+    8. Attach timestamp and acc set root.
+    9. Store the diff under the [target_ledger_hash]. 
+    10. Sign [target_ledger_hash]. *)
 let post_diff ~logger ~proof_cache_db ~kvdb ~network_id
     ~(signer : Signer_service.Signer.t) ~ledger_openings ~acc_set_openings
     ~(diff : Diff.Pending.t) =
+  let get_account ledger account_id =
+    try
+      let index = Sparse_ledger.find_index_exn ledger account_id in
+      Ok (Sparse_ledger.get_exn ledger index)
+    with e -> Error (Error.of_exn e)
+  in
+
   (* 1 *)
   let%bind.Result () =
     try
       match
         Ledger_hash.equal
           (Sparse_ledger.merkle_root_without_cache_exn ledger_openings)
-          (Diff.source_ledger_hash diff)
+          diff.source_ledger_hash
       with
       | true ->
           Ok ()
       | false ->
           Error
-            (Error.create "Source ledger hash mismatch"
-               (Diff.source_ledger_hash diff)
+            (Error.create "Source ledger hash mismatch" diff.source_ledger_hash
                Ledger_hash.sexp_of_t )
     with e -> Error (Error.of_exn e)
   in
@@ -83,12 +91,91 @@ let post_diff ~logger ~proof_cache_db ~kvdb ~network_id
   let target_ledger_hash = Sparse_ledger.merkle_root target_ledger in
 
   (* 5 *)
-  let get_account ledger account_id =
-    try
-      let index = Sparse_ledger.find_index_exn ledger account_id in
-      Ok (Sparse_ledger.get_exn ledger index)
-    with e -> Error (Error.of_exn e)
+  let get_action_state account =
+    Option.value_map account.Account.zkapp
+      ~default:Zkapp_account.Actions.empty_state_element ~f:(fun zkapp ->
+        Pickles_types.Vector.to_list zkapp.action_state |> List.hd_exn )
   in
+  let apply_actions action_state (actions : Field.t list list) =
+    Zkapp_account.Actions_impl.(
+      push_hash action_state (hash (List.map actions ~f:Array.of_list)))
+  in
+  let actions_in_diff : (Account_id.t * Field.t list list list) list =
+    match diff.actions with
+    | `Actions actions ->
+        actions
+    | `Command_with_action_step_flags (Signed_command _, _) ->
+        []
+    | `Command_with_action_step_flags (Zkapp_command command, _) ->
+        let command =
+          Zkapp_command.write_all_proofs_to_disk ~signature_kind:network_id
+            ~proof_cache_db command
+        in
+        Zkapp_command.all_account_updates_list command
+        |> List.fold ~init:Account_id.Map.empty ~f:(fun acc account_update ->
+               match account_update.body.actions with
+               | [] ->
+                   acc
+               | actions ->
+                   let account_id =
+                     let aid = Account_update.account_id account_update in
+                     if
+                       Public_key.Compressed.(Account_id.public_key aid = empty)
+                     then Zeko_constants.inner_account_id
+                     else aid
+                   in
+                   let actions = List.map actions ~f:Array.to_list in
+                   Map.update acc account_id ~f:(function
+                     | None ->
+                         [ actions ]
+                     | Some prev ->
+                         prev @ [ actions ] ) )
+        |> Map.to_alist
+  in
+  let%bind.Result applied_action_states =
+    let%bind.Result initial_action_states =
+      List.fold_result diff.changed_accounts ~init:Account_id.Map.empty
+        ~f:(fun acc (_, changed_account) ->
+          let account_id = Account.identifier changed_account in
+          let%map.Result source_account =
+            get_account ledger_openings account_id
+          in
+          Map.set acc ~key:account_id ~data:(get_action_state source_account) )
+    in
+    List.fold_result actions_in_diff ~init:initial_action_states
+      ~f:(fun acc (account_id, actions_list) ->
+        let%bind.Result start_action_state =
+          match Map.find acc account_id with
+          | Some action_state ->
+              Ok action_state
+          | None ->
+              Error
+                (Error.create
+                   "Actions reference account not in changed_accounts"
+                   account_id Account_id.sexp_of_t )
+        in
+        let action_state =
+          List.fold actions_list ~init:start_action_state ~f:apply_actions
+        in
+        Ok (Map.set acc ~key:account_id ~data:action_state) )
+  in
+  let%bind.Result () =
+    List.fold_result diff.changed_accounts ~init:() ~f:(fun _ (_, account) ->
+        let account_id = Account.identifier account in
+        let%bind.Result target_account = get_account target_ledger account_id in
+        let target_action_state = get_action_state target_account in
+        let applied_action_state =
+          Map.find_exn applied_action_states account_id
+        in
+        if Field.equal target_action_state applied_action_state then Ok ()
+        else
+          Error
+            (Error.create "Action state mismatch"
+               (account_id, target_action_state, applied_action_state)
+               [%sexp_of: Account_id.t * Field.t * Field.t] ) )
+  in
+
+  (* 6 *)
   (* First try to find in [map] and fallback to the [ledger_openings] *)
   let get_account's_receipt_chain_hash map account_id =
     match Account_id.Map.find map account_id with
@@ -100,7 +187,7 @@ let post_diff ~logger ~proof_cache_db ~kvdb ~network_id
   in
   let%bind.Result applied_hashes =
     match diff.actions with
-    | `Actions _todo ->
+    | `Actions _ ->
         Ok Account_id.Map.empty
     | `Command_with_action_step_flags (Signed_command command, _) ->
         (* For signed command only the fee payer gets the receipt *)
@@ -157,7 +244,7 @@ let post_diff ~logger ~proof_cache_db ~kvdb ~network_id
   in
   let%bind.Result () =
     match diff.actions with
-    | `Actions _todo ->
+    | `Actions _ ->
         Ok ()
     | `Command_with_action_step_flags _ ->
         List.fold_result diff.changed_accounts ~init:()
@@ -182,7 +269,7 @@ let post_diff ~logger ~proof_cache_db ~kvdb ~network_id
                    [%sexp_of: Receipt.Chain_hash.t * Receipt.Chain_hash.t] ) )
   in
 
-  (* 6 *)
+  (* 7 *)
   let%bind.Result () =
     try
       let new_accounts =
@@ -223,14 +310,14 @@ let post_diff ~logger ~proof_cache_db ~kvdb ~network_id
     with e -> Error (Error.of_exn e)
   in
 
-  (* 7 *)
+  (* 8 *)
   (* V2 was added time *)
   let diff : Diff.Stable.V4.t =
     Diff.add_time_and_acc_set ~logger diff
       ~acc_set:(Indexed_merkle_tree.Sparse.merkle_root acc_set_openings)
   in
 
-  (* 8 *)
+  (* 9 *)
   (* We don't care if the diff already existed *)
   let () =
     match Db.add_diff kvdb ~ledger_hash:target_ledger_hash ~diff with
@@ -242,7 +329,7 @@ let post_diff ~logger ~proof_cache_db ~kvdb ~network_id
           (Ledger_hash.to_decimal_string target_ledger_hash)
   in
 
-  (* 9 *)
+  (* 10 *)
   let%bind.Result message =
     try
       Random_oracle.hash

--- a/src/app/zeko/da_layer/lib/db.ml
+++ b/src/app/zeko/da_layer/lib/db.ml
@@ -3,7 +3,7 @@ open Mina_base
 
 module Key_value = struct
   type _ t =
-    | Diff : (Ledger_hash.t * Diff.Stable.V3.t) t
+    | Diff : (Ledger_hash.t * Diff.Stable.V4.t) t
     | Migration : (unit * int) t
 
   let serialize_key : type k v. (k * v) t -> k -> Bigstring.t =

--- a/src/app/zeko/da_layer/lib/diff.ml
+++ b/src/app/zeko/da_layer/lib/diff.ml
@@ -3,11 +3,47 @@ open Mina_base
 open Mina_ledger
 open Snark_params.Tick
 
+module Actions = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t =
+        [ `Command_with_action_step_flags of
+          User_command.Stable.V2.t * bool list
+        | `Actions of
+          (Account_id.Stable.V2.t * (Field.t[@version_asserted]) list list list)
+          list ]
+      [@@deriving yojson, sexp, compare]
+
+      let to_latest = Fn.id
+    end
+  end]
+
+  let of_legacy_command_with_action_step_flags = function
+    | Some (command, flags) ->
+        `Command_with_action_step_flags (command, flags)
+    | None ->
+        `Actions []
+end
+
 [%%versioned
 module Stable = struct
   [@@@with_top_version_tag]
 
   [@@@no_toplevel_latest_type]
+
+  module V4 = struct
+    type t =
+      { source_ledger_hash : Ledger_hash.Stable.V1.t
+      ; changed_accounts : (int * Account.Stable.V2.t) list
+      ; actions : Actions.Stable.V1.t
+      ; timestamp : Block_time.Stable.V1.t
+      ; acc_set : (Field.t[@version_asserted])
+      }
+    [@@deriving yojson, fields, sexp_of, compare]
+
+    let to_latest = Fn.id
+  end
 
   module V3 = struct
     type t =
@@ -20,7 +56,15 @@ module Stable = struct
       }
     [@@deriving yojson, fields, sexp_of, compare]
 
-    let to_latest = Fn.id
+    let to_latest t =
+      { V4.source_ledger_hash = t.source_ledger_hash
+      ; changed_accounts = t.changed_accounts
+      ; actions =
+          Actions.of_legacy_command_with_action_step_flags
+            t.command_with_action_step_flags
+      ; timestamp = t.timestamp
+      ; acc_set = t.acc_set
+      }
   end
 
   module V2 = struct
@@ -34,9 +78,11 @@ module Stable = struct
     [@@deriving yojson, fields, sexp_of, compare]
 
     let to_latest t =
-      { V3.source_ledger_hash = t.source_ledger_hash
+      { V4.source_ledger_hash = t.source_ledger_hash
       ; changed_accounts = t.changed_accounts
-      ; command_with_action_step_flags = t.command_with_action_step_flags
+      ; actions =
+          Actions.of_legacy_command_with_action_step_flags
+            t.command_with_action_step_flags
       ; timestamp = t.timestamp
       ; acc_set = Field.zero
       }
@@ -53,53 +99,63 @@ module Stable = struct
 
     let to_latest ?(timestamp = Block_time.zero) ?(acc_set = Field.zero) (t : t)
         =
-      { V3.source_ledger_hash = t.source_ledger_hash
+      { V4.source_ledger_hash = t.source_ledger_hash
       ; changed_accounts = t.changed_accounts
-      ; command_with_action_step_flags = t.command_with_action_step_flags
+      ; actions =
+          Actions.of_legacy_command_with_action_step_flags
+            t.command_with_action_step_flags
       ; timestamp
       ; acc_set
       }
   end
 end]
 
-type t =
+module Pending = struct
+  [%%versioned
+  module Stable = struct
+    [@@@with_top_version_tag]
+
+    module V1 = struct
+      type t =
+        { source_ledger_hash : Ledger_hash.Stable.V1.t
+        ; changed_accounts : (int * Account.Stable.V2.t) list
+        ; actions : Actions.Stable.V1.t
+        }
+      [@@deriving yojson, fields, sexp]
+
+      let to_latest = Fn.id
+    end
+  end]
+end
+
+type t = Stable.V4.t =
   { source_ledger_hash : Ledger_hash.t
   ; changed_accounts : (int * Account.t) list
-  ; command_with_action_step_flags : (User_command.t * bool list) option
+  ; actions : Actions.t
   ; timestamp : Block_time.t
+  ; acc_set : (Field.t[@version_asserted])
   }
 [@@deriving to_yojson, fields, sexp_of]
 
-let create ~source_ledger_hash ~changed_accounts ~command_with_action_step_flags
-    =
-  { Stable.V1.source_ledger_hash
-  ; changed_accounts
-  ; command_with_action_step_flags
-  }
-
-let changed_accounts { Stable.V1.changed_accounts; _ } = changed_accounts
-
-let source_ledger_hash { Stable.V1.source_ledger_hash; _ } = source_ledger_hash
-
-let command_with_action_step_flags
-    { Stable.V1.command_with_action_step_flags; _ } =
-  command_with_action_step_flags
+let create_pending ~source_ledger_hash ~changed_accounts ~actions =
+  { Pending.source_ledger_hash; changed_accounts; actions }
 
 let add_time_and_acc_set ~logger t ~acc_set =
-  Stable.V1.to_latest
-    ~timestamp:(Block_time.now (Block_time.Controller.basic ~logger))
-    ~acc_set t
+  { Stable.V4.source_ledger_hash = t.Pending.source_ledger_hash
+  ; changed_accounts = t.changed_accounts
+  ; actions = t.actions
+  ; timestamp = Block_time.now (Block_time.Controller.basic ~logger)
+  ; acc_set
+  }
 
 let drop_time
-    { Stable.V3.source_ledger_hash
+    { Stable.V4.source_ledger_hash
     ; changed_accounts
-    ; command_with_action_step_flags
-    ; _
+    ; actions
+    ; acc_set = _
+    ; timestamp = _
     } =
-  { Stable.V1.source_ledger_hash
-  ; changed_accounts
-  ; command_with_action_step_flags
-  }
+  { Pending.source_ledger_hash; changed_accounts; actions }
 
 let to_bigstring =
   Binable.to_bigstring (module Stable.Latest.With_top_version_tag)
@@ -123,6 +179,6 @@ let%test_unit "diff versioning" =
   let v1_serialized =
     Binable.to_bigstring (module Stable.V1.With_top_version_tag) v1
   in
-  let v3 = of_bigstring v1_serialized |> Or_error.ok_exn in
+  let v4 = of_bigstring v1_serialized |> Or_error.ok_exn in
 
-  [%test_eq: Stable.V3.t] (Stable.V1.to_latest v1) (Stable.V3.to_latest v3)
+  [%test_eq: Stable.V4.t] (Stable.V1.to_latest v1) (Stable.V4.to_latest v4)

--- a/src/app/zeko/da_layer/lib/node.ml
+++ b/src/app/zeko/da_layer/lib/node.ml
@@ -60,7 +60,7 @@ let get_ledger_hashes_chain t
         >>| fun diff ->
         Option.value_exn ~here:[%here]
           ~message:"Get_ledger_hashes_chain: diff not found" diff
-        |> Diff.Stable.V3.source_ledger_hash
+        |> Diff.Stable.V4.source_ledger_hash
       in
       let%map next = go (n - 1) source in
       current :: next
@@ -89,11 +89,7 @@ let implementations t =
                 [%log warn] "Error posting diff: %s" (Error.to_string_hum e) ;
                 failwith (Error.to_string_hum e) )
       ; (* Get_diff *)
-        Rpc.Rpc.implement Rpc_def.Get_diff.V1.t (fun () query ->
-            let%map v2_diff = Db.Async.get_diff t.db ~ledger_hash:query in
-            let v1_diff = Option.map v2_diff ~f:Diff.drop_time in
-            v1_diff )
-      ; Rpc.Rpc.implement Rpc_def.Get_diff.V3.t (fun () query ->
+        Rpc.Rpc.implement Rpc_def.Get_diff.V4.t (fun () query ->
             Db.Async.get_diff t.db ~ledger_hash:query )
       ; (* Has_diff *)
         Rpc.Rpc.implement Rpc_def.Has_diff.V1.t (fun () query ->
@@ -123,7 +119,7 @@ let implementations t =
         Rpc.Rpc.implement Rpc_def.Get_ledger_hashes_chain.V1.t (fun () query ->
             get_ledger_hashes_chain t query )
       ; (* Get_diffs_chain *)
-        Rpc.Rpc.implement Rpc_def.Get_diffs_chain.V1.t
+        Rpc.Rpc.implement Rpc_def.Get_diffs_chain.V2.t
           (fun () { source; target; max_length } ->
             let logger = t.logger in
             let%bind chain =
@@ -153,7 +149,7 @@ let implementations t =
                 >>| fun diff ->
                 Option.value_exn ~here:[%here] ~message:"Diff not found" diff ) )
       ; (* Diffs_stream *)
-        Rpc.Pipe_rpc.implement Rpc_def.Diffs_stream.V2.t
+        Rpc.Pipe_rpc.implement Rpc_def.Diffs_stream.V3.t
           (fun () { source; target } ->
             let logger = t.logger in
             let r, w = Pipe.create () in

--- a/src/app/zeko/da_layer/lib/rpc.ml
+++ b/src/app/zeko/da_layer/lib/rpc.ml
@@ -20,7 +20,7 @@ module Post_diff = struct
       (* Use Diff.V1 without timestamp, the node determines the timestamp itself *)
       type t =
         { ledger_openings : Sparse_ledger.Stable.V2.t
-        ; diff : Diff.Stable.V1.t
+        ; diff : Diff.Pending.Stable.V1.t
         ; acc_set_openings : Indexed_merkle_tree.Sparse.Stable.V1.t
         }
       [@@deriving bin_io_unversioned]
@@ -66,6 +66,16 @@ module Get_diff = struct
 
     let t : (Ledger_hash.t, Response.t) Rpc.Rpc.t =
       Rpc.Rpc.create ~name:"Get_diff" ~version:3
+        ~bin_query:Ledger_hash.Stable.V1.bin_t ~bin_response:Response.bin_t
+  end
+
+  module V4 = struct
+    module Response = struct
+      type t = Diff.Stable.V4.t option [@@deriving bin_io_unversioned]
+    end
+
+    let t : (Ledger_hash.t, Response.t) Rpc.Rpc.t =
+      Rpc.Rpc.create ~name:"Get_diff" ~version:4
         ~bin_query:Ledger_hash.Stable.V1.bin_t ~bin_response:Response.bin_t
   end
 end
@@ -143,7 +153,7 @@ end
 
 (* val get_diffs_chain : source:Ledger_hash.t option -> target:Ledger_hash.t -> Diff.t list *)
 module Get_diffs_chain = struct
-  module V1 = struct
+  module V2 = struct
     module Query = struct
       type t =
         { source : [ `Genesis | `Specific of Ledger_hash.Stable.V1.t ]
@@ -154,18 +164,18 @@ module Get_diffs_chain = struct
     end
 
     module Response = struct
-      type t = Diff.Stable.V3.t list [@@deriving bin_io_unversioned]
+      type t = Diff.Stable.V4.t list [@@deriving bin_io_unversioned]
     end
 
     let t : (Query.t, Response.t) Rpc.Rpc.t =
-      Rpc.Rpc.create ~name:"Get_diffs_chain" ~version:1 ~bin_query:Query.bin_t
+      Rpc.Rpc.create ~name:"Get_diffs_chain" ~version:2 ~bin_query:Query.bin_t
         ~bin_response:Response.bin_t
   end
 end
 
 (* val diffs_stream : source:Ledger_hash.t option -> target:Ledger_hash.t -> Diff.t stream *)
 module Diffs_stream = struct
-  module V2 = struct
+  module V3 = struct
     module Query = struct
       type t =
         { source : [ `Genesis | `Specific of Ledger_hash.Stable.V1.t ]
@@ -175,11 +185,11 @@ module Diffs_stream = struct
     end
 
     module Response = struct
-      type t = Diff.Stable.V3.t [@@deriving bin_io_unversioned]
+      type t = Diff.Stable.V4.t [@@deriving bin_io_unversioned]
     end
 
     let t : (Query.t, Response.t, Error.t) Rpc.Pipe_rpc.t =
-      Rpc.Pipe_rpc.create ~name:"Diffs_stream" ~version:2 ~bin_query:Query.bin_t
+      Rpc.Pipe_rpc.create ~name:"Diffs_stream" ~version:3 ~bin_query:Query.bin_t
         ~bin_response:Response.bin_t ~bin_error:Error.bin_t ()
   end
 end

--- a/src/app/zeko/sequencer/archive_relay/archive_relay.ml
+++ b/src/app/zeko/sequencer/archive_relay/archive_relay.ml
@@ -303,12 +303,12 @@ let sync_archive (t : t) ~hash =
       in
       List.iter changed_accounts ~f:(fun (index, account) ->
           Ledger.set_at_index_exn ledger index account ) ;
-      match Da_layer.Diff.Stable.Latest.command_with_action_step_flags diff with
-      | None ->
+      match diff.actions with
+      | `Actions _ ->
           [%log info] "No command with action step flags, committing ledger" ;
           Ledger.commit ledger ;
           return ()
-      | Some (command, _) -> (
+      | `Command_with_action_step_flags (command, _) -> (
           let command =
             User_command.write_all_proofs_to_disk ~signature_kind:t.chain
               ~proof_cache_db:t.proof_cache_db command

--- a/src/app/zeko/sequencer/cli.ml
+++ b/src/app/zeko/sequencer/cli.ml
@@ -1253,11 +1253,8 @@ let sync_ledger =
                Ledger.Mask.Attached.commit mask ;
 
                let () =
-                 match
-                   Da_layer.Diff.Stable.Latest.command_with_action_step_flags
-                     diff
-                 with
-                 | Some (Zkapp_command command, _) ->
+                 match diff.actions with
+                 | `Command_with_action_step_flags (Zkapp_command command, _) ->
                      Sequencer.apply_events_and_actions ledger
                        (Archive.create ~kvdb:(Ledger.Db.zeko_kvdb ledger))
                        (Zkapp_command.write_all_proofs_to_disk
@@ -1266,7 +1263,9 @@ let sync_ledger =
                             (Proof_cache_tag.create_identity_db ())
                           command )
                      |> Or_error.ok_exn
-                 | _ ->
+                 | `Command_with_action_step_flags (Signed_command _, _) ->
+                     ( (* No events nor actions to add *) )
+                 | `Actions _ ->
                      ( (* No events nor actions to add *) )
                in
 

--- a/src/app/zeko/sequencer/cli.ml
+++ b/src/app/zeko/sequencer/cli.ml
@@ -547,12 +547,11 @@ let update_inner_verification_keys =
 
            (* Distribute diff to DA layer *)
            let diff =
-             Da_layer.Diff.create ~source_ledger_hash ~changed_accounts:diff
-               ~command_with_action_step_flags:None
+             Da_layer.Diff.create_pending ~source_ledger_hash
+               ~changed_accounts:diff ~actions:(`Actions [])
            in
            let new_accounts_keys =
-             List.filter (Da_layer.Diff.changed_accounts diff)
-               ~f:(fun (index, _) ->
+             List.filter diff.changed_accounts ~f:(fun (index, _) ->
                  Account.equal
                    (Sparse_ledger.get_exn ledger_openings index)
                    Account.empty )

--- a/src/app/zeko/sequencer/deploy.ml
+++ b/src/app/zeko/sequencer/deploy.ml
@@ -60,8 +60,17 @@ let run ~l1_uri ~sk ~ledger_input ~faucet_aid ~da_nodes ~pause_key
             let sequencer_account =
               { Account.empty with public_key = Even_PC.to_pc sequencer_key }
             in
-            List.iter [ inner_account; holder_account; sequencer_account ]
-              ~f:(fun acc ->
+            let fee_recipient_account =
+              { Account.empty with
+                public_key = Zeko_circuits_config.Inputs.bridge_fee_recipient_l2
+              }
+            in
+            List.iter
+              [ inner_account
+              ; holder_account
+              ; sequencer_account
+              ; fee_recipient_account
+              ] ~f:(fun acc ->
                 L.create_new_account_exn ledger
                   (Account_id.create acc.public_key acc.token_id)
                   acc ) ;

--- a/src/app/zeko/sequencer/deploy.ml
+++ b/src/app/zeko/sequencer/deploy.ml
@@ -239,7 +239,7 @@ let run ~l1_uri ~sk ~ledger_input ~faucet_aid ~da_nodes ~pause_key
               "(* Post the whole genesis diff with all the accounts *)"
           in
           Da_layer.Client.distribute_genesis_diff ~logger ~config:da_config
-            ~ledger:new_ledger
+            ~ledger:new_ledger ~get_actions_for_aid:(fun _aid -> [])
       in
 
       print_endline "(* Deploy contract *)" ;

--- a/src/app/zeko/sequencer/deploy.ml
+++ b/src/app/zeko/sequencer/deploy.ml
@@ -212,10 +212,10 @@ let run ~l1_uri ~sk ~ledger_input ~faucet_aid ~da_nodes ~pause_key
                 failwith "Unreachable"
           in
           let diff =
-            Da_layer.Diff.create
+            Da_layer.Diff.create_pending
               ~source_ledger_hash:
                 (Sparse_ledger.merkle_root old_ledger_openings)
-              ~changed_accounts ~command_with_action_step_flags:None
+              ~changed_accounts ~actions:(`Actions [])
           in
           let new_accounts_keys =
             List.filter changed_accounts ~f:(fun (index, _) ->

--- a/src/app/zeko/sequencer/lib/archive.ml
+++ b/src/app/zeko/sequencer/lib/archive.ml
@@ -14,8 +14,7 @@ let ok_exn x =
 
 module Field = struct
   open Ppx_deriving_yojson_runtime.Result
-
-  type t = Snark_params.Tick.Field.t [@@deriving sexp]
+  include Snark_params.Tick.Field
 
   let to_yojson t = `String (Field.to_string t)
 
@@ -190,6 +189,20 @@ module Archive = struct
         in
         let previous = query_actions t account in
         store_actions t account (action :: previous)
+
+  let add_raw_actions t aid actions =
+    let action =
+      { Account_update_actions.block_info = None
+      ; transaction_info = None
+      ; action_state =
+          Pickles_types.Vector.Vector_5.of_list_exn
+            [ Field.zero; Field.zero; Field.zero; Field.zero; Field.zero ]
+      ; account_update_id = 0
+      ; actions
+      }
+    in
+    let previous = query_actions t aid in
+    store_actions t aid (action :: previous)
 
   let add_events t ?(height = 0) (account_update : Account_update.t)
       transaction_info =

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -80,9 +80,11 @@ type t =
   ; verification_keys : Zeko_prover.Prover.Verification_key_hashes.t
   ; preverify_l1 : preverify_fn
   ; preverify_l2 : preverify_fn
+  ; bridge_txn_fee : Currency.Fee.t
   }
 
-let create ~provers ~proof_cache_db ~preverify_l1 ~preverify_l2 =
+let create ~provers ~proof_cache_db ~preverify_l1 ~preverify_l2 ~bridge_txn_fee
+    =
   let%map verification_keys =
     Zeko_prover.Client.verification_keys provers >>| Or_error.ok_exn
   in
@@ -92,6 +94,7 @@ let create ~provers ~proof_cache_db ~preverify_l1 ~preverify_l2 =
   ; verification_keys
   ; preverify_l1
   ; preverify_l2
+  ; bridge_txn_fee
   }
 
 (** For [Finalize_cancelled_deposit] and [Finalize_withdrawal] the helper
@@ -233,7 +236,7 @@ let execute_request ?label t ~logger ~(executor : Executor.t) (key, d) =
             Account_update.Fee_payer.make
               ~body:
                 { public_key = Signer_service.Signer.public_key executor.signer
-                ; fee = Currency.Fee.of_mina_string_exn "0.1"
+                ; fee = t.bridge_txn_fee
                 ; valid_until = None
                 ; nonce = Account.Nonce.zero
                 }

--- a/src/app/zeko/sequencer/lib/committer.ml
+++ b/src/app/zeko/sequencer/lib/committer.ml
@@ -67,7 +67,7 @@ end
 
 let prove_commit ~logger ~proof_cache_db ~provers ~(executor : Executor.t)
     ~l1_uri ~(archive : Archive.t) ~zkapp_pk ~archive_uri ~l1_config
-    ~commit_validity_period
+    ~commit_validity_period ~commit_fee
     ({ old_inner_ledger
      ; new_inner_ledger
      ; processed_actions_pointer
@@ -190,7 +190,7 @@ let prove_commit ~logger ~proof_cache_db ~provers ~(executor : Executor.t)
     { fee_payer =
         { Account_update.Fee_payer.body =
             { public_key = Signer_service.Signer.public_key executor.signer
-            ; fee = Currency.Fee.of_mina_int_exn 1
+            ; fee = commit_fee
             ; valid_until = None
             ; nonce = Unsigned.UInt32.zero
             }
@@ -206,7 +206,7 @@ let prove_commit ~logger ~proof_cache_db ~provers ~(executor : Executor.t)
 
 let recommit_all ~logger ~proof_cache_db ~db_pool ~provers
     ~(executor : Executor.t) ~l1_uri ~archive ~zkapp_pk ~archive_uri ~l1_config
-    ~commit_validity_period =
+    ~commit_validity_period ~commit_fee =
   let open Deferred.Result.Let_syntax in
   let%bind { ledger_hash; _ } =
     Gql_client.infer_state ~logger l1_uri ~zkapp_pk
@@ -239,7 +239,7 @@ let recommit_all ~logger ~proof_cache_db ~db_pool ~provers
         let%bind command =
           prove_commit ~logger ~proof_cache_db ~provers ~executor ~l1_uri
             ~archive ~zkapp_pk ~archive_uri ~l1_config ~commit_validity_period
-            witness
+            ~commit_fee witness
         in
         let%bind _hash = Executor.send_zkapp_command ~logger executor command in
         recommit_next target_ledger_hash

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -27,6 +27,7 @@ module Sequencer = struct
       ; l1_config : Utils.Slot.l1_config
       ; slot_acceptance : Time.Span.t
       ; commit_validity_period : Global_slot_span.t
+      ; commit_fee : Currency.Fee.t
       }
   end
 
@@ -176,7 +177,7 @@ module Sequencer = struct
                   ~zkapp_pk:Zeko_circuits_config.Inputs.zeko_l1
                   ~archive_uri:config.archive_uri ~l1_config:config.l1_config
                   ~commit_validity_period:config.commit_validity_period
-                  commit_witness
+                  ~commit_fee:config.commit_fee commit_witness
               in
               let%bind _hash =
                 Executor.send_zkapp_command ~logger executor command
@@ -800,11 +801,11 @@ module Sequencer = struct
 
     [%log info] "Init root: %s" Ledger_hash.(to_decimal_string (get_root t)) ;
 
-    let%bind () =
+    let%bind inserted_genesis =
       match source with
       | `Genesis ->
           [%log info] "Syncing from genesis" ;
-          return ()
+          return false
       | `Specific ledger_hash ->
           [%log info] "Syncing from specific ledger hash: %s"
             (Ledger_hash.to_decimal_string ledger_hash) ;
@@ -817,20 +818,26 @@ module Sequencer = struct
                 Archive.query_actions t.archive aid
                 |> List.map ~f:(fun x -> List.map x.actions ~f:Array.to_list) )
           in
-          let%bind () =
-            Deferred.List.iteri ~how:`Sequential diffs
+          let%bind inserted_genesis =
+            Deferred.List.foldi ~init:false diffs
               ~f:(fun
                    i
+                   acc
                    ( diff
                    , ledger_openings
                    , acc_set_openings
                    , `Target target_ledger_hash )
                  ->
-                Da_layer.Client.enqueue_diff t.da_client ~diff ~ledger_openings
-                  ~acc_set_openings ~target_ledger_hash ~genesis:(i = 0) )
+                let genesis = i = 0 in
+                let%map () =
+                  Da_layer.Client.enqueue_diff t.da_client ~diff
+                    ~ledger_openings ~acc_set_openings ~target_ledger_hash
+                    ~genesis
+                in
+                genesis || acc )
           in
           [%log info] "Enqueued genesis diff" ;
-          return ()
+          return inserted_genesis
     in
 
     (* apply diffs from DA layer *)
@@ -884,7 +891,8 @@ module Sequencer = struct
               ~diff:(Da_layer.Diff.drop_time diff)
               ~ledger_openings ~acc_set_openings
               ~target_ledger_hash:(L.Db.merkle_root t.ledger)
-              ~genesis:(current_chunk = 0 && current_diff = 0)
+              ~genesis:
+                ((not inserted_genesis) && current_chunk = 0 && current_diff = 0)
           in
 
           (* Add events and actions *)
@@ -1026,7 +1034,7 @@ module Sequencer = struct
       ~da_quorum ~db_dir ~checkpoints_dir ~postgres_uri ~l1_uri ~archive_uri
       ~(signer : Signer_service.Signer.t) ~deposit_delay_blocks ~mq_host
       ~fee_modifier ~minimum_fee ~slot_acceptance ~proof_cache_db ~l1_config
-      ~commit_validity_period =
+      ~commit_validity_period ~commit_fee ~bridge_txn_fee =
     [%log info] "Precomputing srs" ;
     Pickles.Side_loaded.srs_precomputation () ;
     let db_dir =
@@ -1058,6 +1066,7 @@ module Sequencer = struct
         ; l1_config
         ; slot_acceptance
         ; commit_validity_period
+        ; commit_fee
         }
     in
     let%bind db_pool = Db.create_and_migrate ~postgres_uri ~logger in
@@ -1204,6 +1213,7 @@ module Sequencer = struct
     in
     let%bind bridge_prover =
       Bridge_prover.create ~provers ~proof_cache_db ~preverify_l1 ~preverify_l2
+        ~bridge_txn_fee
     in
 
     let t =
@@ -1235,6 +1245,7 @@ module Sequencer = struct
         ~l1_uri:config.l1_uri ~archive ~db_pool
         ~zkapp_pk:Zeko_circuits_config.Inputs.zeko_l1
         ~archive_uri:config.archive_uri ~l1_config ~commit_validity_period
+        ~commit_fee
       >>| Or_error.ok_exn
     in
     let () =

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -488,18 +488,18 @@ module Sequencer = struct
                 (index, L.get_at_index_exn l index) )
           in
           let diff =
-            Da_layer.Diff.create
+            Da_layer.Diff.create_pending
               ~source_ledger_hash:(Sparse_ledger.merkle_root source_ledger)
               ~changed_accounts
-              ~command_with_action_step_flags:
-                (Some
-                   ( User_command.read_all_proofs_from_disk command
-                   , match command with
-                     | Signed_command _ ->
-                         []
-                     | Zkapp_command command ->
-                         Zkapp_command.all_account_updates_list command
-                         |> List.map ~f:(fun _ -> true) ) )
+              ~actions:
+                (`Command_with_action_step_flags
+                  ( User_command.read_all_proofs_from_disk command
+                  , match command with
+                    | Signed_command _ ->
+                        []
+                    | Zkapp_command command ->
+                        Zkapp_command.all_account_updates_list command
+                        |> List.map ~f:(fun _ -> true) ) )
           in
           let new_accounts_keys =
             List.filter changed_accounts ~f:(fun (index, _) ->
@@ -577,9 +577,9 @@ module Sequencer = struct
             in
             let diff =
               (* FIXME: add fee transfer command to DA *)
-              Da_layer.Diff.create
+              Da_layer.Diff.create_pending
                 ~source_ledger_hash:(Sparse_ledger.merkle_root source_ledger)
-                ~changed_accounts ~command_with_action_step_flags:None
+                ~changed_accounts ~actions:(`Actions [])
             in
             let new_accounts_keys =
               List.filter changed_accounts ~f:(fun (index, _) ->
@@ -851,9 +851,7 @@ module Sequencer = struct
           (* Apply accounts diff *)
           let mask = L.of_database t.ledger in
           let ledger_openings =
-            Da_layer.Client.get_ledger_openings
-              ~diff:(Da_layer.Diff.drop_time diff)
-              ~ledger:mask
+            Da_layer.Client.get_ledger_openings ~diff ~ledger:mask
           in
           let changed_accounts =
             Da_layer.Diff.Stable.Latest.changed_accounts diff
@@ -873,9 +871,8 @@ module Sequencer = struct
               () ) ;
 
           let acc_set_openings =
-            Da_layer.Client.get_acc_set_openings ~logger
-              ~diff:(Da_layer.Diff.drop_time diff)
-              ~ledger_openings ~imt:t.imt
+            Da_layer.Client.get_acc_set_openings ~logger ~diff ~ledger_openings
+              ~imt:t.imt
           in
 
           (* Store diff to DA client *)
@@ -889,15 +886,16 @@ module Sequencer = struct
 
           (* Add events and actions *)
           let result =
-            match
-              Da_layer.Diff.Stable.Latest.command_with_action_step_flags diff
-            with
-            | Some (Zkapp_command command, _) ->
+            match diff.actions with
+            | `Command_with_action_step_flags (Zkapp_command command, _) ->
                 apply_events_and_actions t.ledger t.archive
                   (Zkapp_command.write_all_proofs_to_disk
                      ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
                      ~proof_cache_db:t.merger_ctx.proof_cache_db command )
-            | _ ->
+            | `Command_with_action_step_flags (Signed_command _, _) ->
+                Ok ( (* No events or actions in signed command *) )
+            | `Actions _actions ->
+                (* let () = failwith "TODO" in *)
                 Ok ( (* No events nor actions to add *) )
           in
           return

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -813,6 +813,9 @@ module Sequencer = struct
           let ledger = L.of_database t.ledger in
           let%bind diffs =
             Da_layer.Client.create_genesis_diffs ~logger ledger
+              ~get_actions_for_aid:(fun aid ->
+                Archive.query_actions t.archive aid
+                |> List.map ~f:(fun x -> List.map x.actions ~f:Array.to_list) )
           in
           let%bind () =
             Deferred.List.iteri ~how:`Sequential diffs
@@ -895,7 +898,6 @@ module Sequencer = struct
             | `Command_with_action_step_flags (Signed_command _, _) ->
                 Ok ( (* No events or actions in signed command *) )
             | `Actions _actions ->
-                (* let () = failwith "TODO" in *)
                 Ok ( (* No events nor actions to add *) )
           in
           return

--- a/src/app/zeko/sequencer/run.ml
+++ b/src/app/zeko/sequencer/run.ml
@@ -10,7 +10,7 @@ module Sequencer = Zeko_sequencer.Sequencer
 let run ~logger ~port ~max_pool_size ~commitment_period ~da_config ~da_keys
     ~da_quorum ~db_dir ~checkpoints_dir ~postgres_uri ~l1_uri ~archive_uri
     ~signer ~deposit_delay_blocks ~mq_host ~fee_modifier ~minimum_fee
-    ~slot_acceptance ~commit_validity_period () =
+    ~slot_acceptance ~commit_validity_period ~commit_fee ~bridge_txn_fee () =
   let proof_cache_db = Proof_cache_tag.create_identity_db () in
   let l1_config : Utils.Slot.l1_config =
     let genesis_timestamp =
@@ -39,7 +39,7 @@ let run ~logger ~port ~max_pool_size ~commitment_period ~da_config ~da_keys
           ~postgres_uri ~l1_uri ~archive_uri
           ~commitment_period_sec:commitment_period ~deposit_delay_blocks ~signer
           ~mq_host ~fee_modifier ~minimum_fee ~slot_acceptance ~proof_cache_db
-          ~l1_config ~commit_validity_period )
+          ~l1_config ~commit_validity_period ~commit_fee ~bridge_txn_fee )
   in
 
   Sequencer.run_committer sequencer ;
@@ -138,6 +138,14 @@ let () =
          ~doc:"int Commit validity period in slots"
      and signer =
        flag "--signer" (required string) ~doc:"string Signer service host:port"
+     and commit_fee =
+       flag "--commit-fee"
+         (optional_with_default 0.1 float)
+         ~doc:"string Commit fee in mina"
+     and bridge_txn_fee =
+       flag "--bridge-txn-fee"
+         (optional_with_default 0.1 float)
+         ~doc:"string Bridge transaction fee in mina"
      in
      let slot_acceptance = Time.Span.of_min slot_acceptance_m in
      let da_config = Da_layer.Client.Config.of_string_list da_nodes in
@@ -153,9 +161,15 @@ let () =
      let commit_validity_period =
        Mina_numbers.Global_slot_span.of_int commit_validity_period
      in
+     let commit_fee =
+       Currency.Fee.of_mina_string_exn (Float.to_string commit_fee)
+     in
+     let bridge_txn_fee =
+       Currency.Fee.of_mina_string_exn (Float.to_string bridge_txn_fee)
+     in
      Stdout_log.setup log_json log_level ;
      run ~logger ~port ~max_pool_size ~commitment_period ~da_config ~da_keys
        ~da_quorum ~db_dir ~checkpoints_dir ~postgres_uri ~l1_uri ~archive_uri
        ~signer ~deposit_delay_blocks ~mq_host ~fee_modifier ~minimum_fee
-       ~slot_acceptance ~commit_validity_period )
+       ~slot_acceptance ~commit_validity_period ~commit_fee ~bridge_txn_fee )
   |> Command_unix.run

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -238,6 +238,8 @@ let () =
                 ~l1_config
                 ~commit_validity_period:
                   (Mina_numbers.Global_slot_span.of_int 10)
+                ~commit_fee:(Currency.Fee.of_mina_int_exn 1)
+                ~bridge_txn_fee:(Currency.Fee.of_mina_string_exn "0.1")
             in
             [%test_eq: Frozen_ledger_hash.t] (get_root new_sequencer)
               final_ledger_hash ;
@@ -339,7 +341,9 @@ let () =
               ~minimum_fee:0.01 ~slot_acceptance
               ~proof_cache_db:(Proof_cache_tag.create_identity_db ())
               ~l1_config
-              ~commit_validity_period:(Mina_numbers.Global_slot_span.of_int 10) )
+              ~commit_validity_period:(Mina_numbers.Global_slot_span.of_int 10)
+              ~commit_fee:(Currency.Fee.of_mina_int_exn 1)
+              ~bridge_txn_fee:(Currency.Fee.of_mina_string_exn "0.1") )
       in
 
       print_endline "(* Requeue witnesses and commit with quorum 3 *)" ;
@@ -469,7 +473,9 @@ let () =
               ~da_keys ~fee_modifier:1.0 ~minimum_fee:0.01 ~slot_acceptance
               ~proof_cache_db:(Proof_cache_tag.create_identity_db ())
               ~l1_config
-              ~commit_validity_period:(Mina_numbers.Global_slot_span.of_int 10) )
+              ~commit_validity_period:(Mina_numbers.Global_slot_span.of_int 10)
+              ~commit_fee:(Currency.Fee.of_mina_int_exn 1)
+              ~bridge_txn_fee:(Currency.Fee.of_mina_string_exn "0.1") )
       in
 
       print_endline "(* Check that all da nodes are synced *)" ;
@@ -575,7 +581,9 @@ let () =
               ~minimum_fee:0.01 ~slot_acceptance
               ~proof_cache_db:(Proof_cache_tag.create_identity_db ())
               ~l1_config
-              ~commit_validity_period:(Mina_numbers.Global_slot_span.of_int 10) )
+              ~commit_validity_period:(Mina_numbers.Global_slot_span.of_int 10)
+              ~commit_fee:(Currency.Fee.of_mina_int_exn 1)
+              ~bridge_txn_fee:(Currency.Fee.of_mina_string_exn "0.1") )
       in
 
       print_endline "(* Check that after restart it recommited *)" ;

--- a/src/app/zeko/sequencer/tests/test_spec.ml
+++ b/src/app/zeko/sequencer/tests/test_spec.ml
@@ -554,7 +554,9 @@ module Sequencer_spec = struct
             ~archive_uri:gql_uri ~signer ~deposit_delay_blocks:delay_deposit
             ~mq_host ~fee_modifier:1.0 ~minimum_fee:0.01 ~slot_acceptance
             ~proof_cache_db:(Proof_cache_tag.create_identity_db ())
-            ~l1_config ~commit_validity_period ~checkpoints_dir )
+            ~l1_config ~commit_validity_period ~checkpoints_dir
+            ~commit_fee:(Currency.Fee.of_mina_int_exn 1)
+            ~bridge_txn_fee:(Currency.Fee.of_mina_string_exn "0.1") )
     in
     let l1_executor =
       Executor.create ~kind:(`L1 gql_uri)

--- a/src/app/zeko/sequencer/tests/test_spec.ml
+++ b/src/app/zeko/sequencer/tests/test_spec.ml
@@ -108,6 +108,7 @@ module Transaction_spec = struct
     ; sender : Keypair.t * Account_nonce.t
     ; receiver : Public_key.Compressed.t
     ; amount : Currency.Amount.t
+    ; actions : Field.t list list option
     }
   [@@deriving sexp]
 
@@ -152,7 +153,15 @@ module Transaction_spec = struct
     let%bind fee = gen_fee () in
     let%bind amount = gen_amount () in
     let nonces = Map.set nonces ~key:sender ~data:(Account_nonce.succ nonce) in
-    let spec = { fee; amount; receiver; sender = (sender, nonce) } in
+    let%bind actions = List.gen_non_empty Field.gen in
+    let spec =
+      { fee
+      ; amount
+      ; receiver
+      ; sender = (sender, nonce)
+      ; actions = Some [ actions ]
+      }
+    in
     return (spec, nonces)
 end
 
@@ -179,8 +188,12 @@ module Test_spec = struct
 end
 
 let command_send ?chain ?(valid_until = Global_slot_since_genesis.max_value)
-    { Transaction_spec.fee; sender = sender, sender_nonce; receiver; amount } :
-    Signed_command.t =
+    { Transaction_spec.fee
+    ; sender = sender, sender_nonce
+    ; receiver
+    ; amount
+    ; actions = _
+    } : Signed_command.t =
   let sender_pk = Public_key.compress sender.public_key in
   let signature_kind =
     match chain with
@@ -207,8 +220,12 @@ let account_update_send ?chain ?(use_full_commitment = true)
       (Zkapp_basic.Or_ignore.Ignore, Zkapp_basic.Or_ignore.Ignore))
     ?(global_slot_precondition =
       (Zkapp_basic.Or_ignore.Ignore, Zkapp_basic.Or_ignore.Ignore))
-    { Transaction_spec.fee; sender = sender, sender_nonce; receiver; amount } :
-    Zkapp_command.t =
+    { Transaction_spec.fee
+    ; sender = sender, sender_nonce
+    ; receiver
+    ; amount
+    ; actions
+    } : Zkapp_command.t =
   let signature_kind =
     Option.value ~default:Mina_signature_kind.t_DEPRECATED chain
   in
@@ -245,7 +262,8 @@ let account_update_send ?chain ?(use_full_commitment = true)
               ; balance_change = Amount.Signed.(negate (of_unsigned amount))
               ; increment_nonce = double_sender_nonce
               ; events = []
-              ; actions = []
+              ; actions =
+                  Option.value ~default:[] actions |> List.map ~f:Array.of_list
               ; call_data = Snark_params.Tick.Field.zero
               ; call_depth = 0
               ; preconditions =
@@ -474,7 +492,7 @@ module Sequencer_spec = struct
     print_endline "(* Post genesis batch *)" ;
     run (fun () ->
         Da_layer.Client.distribute_genesis_diff ~logger ~config:da_config
-          ~ledger:ephemeral_ledger ) ;
+          ~ledger:ephemeral_ledger ~get_actions_for_aid:(fun _aid -> []) ) ;
 
     print_endline "(* Deploy zkapp *)" ;
     run (fun () ->


### PR DESCRIPTION
In emergency DA, only atomic changes to account data
are recorded. Actions posted on the L2 are not enforced to be
available: only the updated action state of modified accounts is stored,
which can make certain ASEs unprovable.

For example, consider an emergency commit that updates the inner
action state on the outer account. If the user does not publish the L2
action data, any action state extension aiming to claim something
about a previous action prior to the newly pushed action state
becomes unprovable, since the action openings that lead to the current
action state are unknown.

fix ZK-468