### PR TITLE
Audit 02: Emergency DA does not enforce a strict ordering of transactions, allowing permuting the IMT tree leaves

### DIFF
--- a/src/app/zeko/circuits/emergency_da_folder.ml
+++ b/src/app/zeko/circuits/emergency_da_folder.ml
@@ -6,6 +6,8 @@ module Stmt = struct
   type t =
     { source_ledger : Ledger_hash.t
     ; target_ledger : Ledger_hash.t
+    ; source_acc_set : Account_set.t
+    ; target_acc_set : Account_set.t
     ; target_action_state : F.t
     }
   [@@deriving snarky]
@@ -24,6 +26,8 @@ module M = struct
     ; action =
         { source_ledger_hash = Ledger_hash.empty_hash
         ; target_ledger_hash = Ledger_hash.empty_hash
+        ; source_acc_set = Account_set.dummy
+        ; target_acc_set = Account_set.dummy
         ; ledger_index = Checked32.zero
         ; account = Account.empty
         }
@@ -35,9 +39,15 @@ module M = struct
   let init ~check:_ (x : Init.var) = Checked.return x
 
   let step (elem : Elem.var) (stmt : Stmt.var) =
-    let* eq =
+    let* eq_ledger =
       Ledger_hash.equal_var stmt.target_ledger elem.action.source_ledger_hash
     in
+    let* eq_acc_set =
+      Checked.(
+        var_equal Account_set.typ stmt.target_acc_set elem.action.source_acc_set
+        >>= Boolean.Expr.eval)
+    in
+    let* eq = Boolean.(eq_ledger && eq_acc_set) in
     let* ok =
       if_ elem.advance ~typ:Boolean.typ ~then_:eq ~else_:Boolean.true_
     in
@@ -47,13 +57,18 @@ module M = struct
       if_ elem.advance ~typ:Ledger_hash.typ
         ~then_:elem.action.target_ledger_hash ~else_:stmt.target_ledger
     in
+    let* target_acc_set =
+      if_ elem.advance ~typ:Account_set.typ ~then_:elem.action.target_acc_set
+        ~else_:stmt.target_acc_set
+    in
     let* actions = var_to_actions Rule_emergency_da.Action.typ elem.action in
     let* target_action_state =
       make_checked (fun () ->
           Zkapp_account.Actions.push_events_checked stmt.target_action_state
             actions )
     in
-    Checked.return { stmt with target_ledger; target_action_state }
+    Checked.return
+      { stmt with target_ledger; target_acc_set; target_action_state }
 
   let leaf_iterations =
     Zeko_constants.Folder_iterations.Emergency_da.leaf_iterations

--- a/src/app/zeko/circuits/indexed_merkle_tree.ml
+++ b/src/app/zeko/circuits/indexed_merkle_tree.ml
@@ -23,6 +23,8 @@ struct
 
   let typ = F.typ
 
+  let dummy = Field.zero
+
   module PathStep = struct
     type t = { hash_other : F.t; is_right : Boolean.t } [@@deriving snarky]
   end

--- a/src/app/zeko/circuits/indexed_merkle_tree.mli
+++ b/src/app/zeko/circuits/indexed_merkle_tree.mli
@@ -33,6 +33,8 @@ end) : sig
 
   val typ : (var, t) Typ.t
 
+  val dummy : t
+
   val to_input_var : var -> Field.Var.t Random_oracle.Input.Chunked.t
 
   module PathStep : sig

--- a/src/app/zeko/circuits/rule_commit.ml
+++ b/src/app/zeko/circuits/rule_commit.ml
@@ -286,6 +286,14 @@ struct
             assert_equal ~label:__LOC__ Ledger_hash.typ
               emergency_da_stmt.target_ledger target_ledger
           in
+          let* () =
+            assert_equal ~label:__LOC__ Account_set.typ
+              emergency_da_stmt.source_acc_set source_acc_set
+          in
+          let* () =
+            assert_equal ~label:__LOC__ Account_set.typ
+              emergency_da_stmt.target_acc_set target_acc_set
+          in
           Checked.return None
     in
 

--- a/src/app/zeko/circuits/rule_emergency_da.ml
+++ b/src/app/zeko/circuits/rule_emergency_da.ml
@@ -2,6 +2,13 @@ open Snark_params.Tick
 open Mina_base
 module PC = Signature_lib.Public_key.Compressed
 open Zeko_util
+open Txn_state
+
+module Acc_set_witness = struct
+  type t = update_acc_set_witness
+end
+
+module Acc_set_witness_V = Mk_V (Acc_set_witness)
 
 module Ledger_path = struct
   module Step = struct
@@ -20,6 +27,8 @@ module Action = struct
   type t =
     { source_ledger_hash : Ledger_hash.t
     ; target_ledger_hash : Ledger_hash.t
+    ; source_acc_set : Account_set.t
+    ; target_acc_set : Account_set.t
     ; ledger_index : Checked32.t
     ; account : Account.t
     }
@@ -33,6 +42,8 @@ module Witness = struct
     ; old_account : Account.t
     ; new_account : Account.t
     ; ledger_path : Ledger_path.Path.t
+    ; source_acc_set : Account_set.t
+    ; acc_set_witness : Acc_set_witness_V.t
     }
   [@@deriving snarky]
 end
@@ -62,20 +73,41 @@ struct
   open Inputs
 
   let%snarkydef_ main (w : Witness.t V.t) =
-    let* Witness.{ public_key; vk_hash; old_account; new_account; ledger_path }
-        =
+    let* Witness.
+           { public_key
+           ; vk_hash
+           ; old_account
+           ; new_account
+           ; ledger_path
+           ; source_acc_set
+           ; acc_set_witness
+           } =
       exists Witness.typ ~compute:(V.get w)
     in
     let* source_root = implied_root old_account ledger_path in
     let* target_root = implied_root new_account ledger_path in
     let source_ledger_hash = Ledger_hash.var_of_hash_packed source_root in
     let target_ledger_hash = Ledger_hash.var_of_hash_packed target_root in
+    let* is_new_account =
+      let* old_account_digest = Account.Checked.digest old_account in
+      Field.Checked.equal old_account_digest
+        (constant F.typ (Lazy.force Account.empty_digest))
+    in
+    let* target_acc_set =
+      update_acc_set
+        [ ( Account_id.Checked.create new_account.public_key new_account.token_id
+          , is_new_account )
+        ]
+        source_acc_set ~witness:(V.get acc_set_witness)
+    in
     let* ledger_index = index_of_path ledger_path in
     let* actions =
       var_to_actions Action.typ
         Action.
           { source_ledger_hash
           ; target_ledger_hash
+          ; source_acc_set
+          ; target_acc_set
           ; ledger_index
           ; account = new_account
           }


### PR DESCRIPTION
Suppose we have the following two transactions:
- Account _B1_ sends some money to a new account _A1_. Call this transaction _T1_.
- Account _B2_ send some money to a new account _A2_. Call this transaction _T2_.
Clearly, from a ledger state _A_, applying first _T1_ and then _T2_, or applying _T2_ and then _T1_ will lead to the same ledger state _C_, given that the positions of the new accounts in the ledger are identical.

In particular, if we want to do an emergency commit including both transactions, we can push to emergency DA actions either path - `A -> B -> C` or `A -> B' -> C`

However, the IMT is **sensitive to the ordering of new accounts**: they have to be inserted left to right in the same order of the transactions being processed.

**Impact**. An external observer looking at DA actions cannot distinguish a priori what the ordering of transactions is in one commit.

This mechanism can be extended to, say, 128 new accounts, which renders it infeasible to reconstruct the actual transaction ordering from the IMT root alone.

fix ZK-479