### PR TITLE
Audit 08: Unsigned 32-bit element overflow in index_of_path

### DIFF
--- a/src/app/zeko/circuits/emergency_da_folder.ml
+++ b/src/app/zeko/circuits/emergency_da_folder.ml
@@ -28,7 +28,7 @@ module M = struct
         ; target_ledger_hash = Ledger_hash.empty_hash
         ; source_acc_set = Account_set.dummy
         ; target_acc_set = Account_set.dummy
-        ; ledger_index = Checked32.zero
+        ; ledger_index = Checked64.zero
         ; account = Account.empty
         }
     }

--- a/src/app/zeko/circuits/rule_emergency_da.ml
+++ b/src/app/zeko/circuits/rule_emergency_da.ml
@@ -29,7 +29,7 @@ module Action = struct
     ; target_ledger_hash : Ledger_hash.t
     ; source_acc_set : Account_set.t
     ; target_acc_set : Account_set.t
-    ; ledger_index : Checked32.t
+    ; ledger_index : Checked64.t
     ; account : Account.t
     }
   [@@deriving snarky]
@@ -56,15 +56,15 @@ let implied_root (account : Account.var) (path : Ledger_path.Path.var) =
       let* right = Field.Checked.if_ is_right ~then_:acc ~else_:hash_other in
       make_checked @@ fun () -> Ledger_hash.merge_var ~height left right )
 
-let index_of_path (path : Ledger_path.Path.var) : Checked32.var Checked.t =
-  Checked.List.foldi path ~init:Checked32.Checked.zero
+let index_of_path (path : Ledger_path.Path.var) : Checked64.var Checked.t =
+  Checked.List.foldi path ~init:Checked64.Checked.zero
     ~f:(fun height acc Ledger_path.Step.{ is_right; _ } ->
       let* add =
-        if_ is_right ~typ:Checked32.typ
-          ~then_:(Checked32.Checked.constant (Checked32.of_int (1 lsl height)))
-          ~else_:Checked32.Checked.zero
+        if_ is_right ~typ:Checked64.typ
+          ~then_:(Checked64.Checked.constant (Checked64.of_int (1 lsl height)))
+          ~else_:Checked64.Checked.zero
       in
-      Checked32.Checked.add acc add )
+      Checked64.Checked.add acc add )
 
 module Make (Inputs : sig
   val chain_l1 : Mina_signature_kind.t

--- a/src/app/zeko/circuits/zeko_util.ml
+++ b/src/app/zeko/circuits/zeko_util.ml
@@ -419,6 +419,12 @@ module Checked32 = struct
   type var = Checked.t
 end
 
+module Checked64 = struct
+  include Mina_numbers.Nat.Make64 ()
+
+  type var = Checked.t
+end
+
 let push_actions_var ~actions state =
   let@ () = make_checked in
   Random_oracle.Checked.hash ~init:Hash_prefix_states.zkapp_actions

--- a/src/app/zeko/circuits/zeko_util.mli
+++ b/src/app/zeko/circuits/zeko_util.mli
@@ -193,6 +193,12 @@ module Checked32 : sig
   type var = Checked.t
 end
 
+module Checked64 : sig
+  include module type of Mina_numbers.Nat.Make64 ()
+
+  type var = Checked.t
+end
+
 val push_actions_var :
   actions:Field.Var.t -> Field.Var.t -> Field.Var.t Checked.t
 


### PR DESCRIPTION
The function `index_of_path` reconstructs a ledger account index from a Merkle authentication path by accumulating `1 << height` for each right-hand step into a `Checked32` accumulator a 32-bit unsigned integer in-circuit. The ledger depth is configured to `35`, so valid account indices span from `0` to `2^35 − 1`. At heights `32`, `33`, and `34`, the OCaml expression `Checked32.of_int (1 lsl height)` overflows the 32-bit type and evaluates to `0`, meaning those three high-order bits are never accumulated. As a result, any account with an index greater than or equal to `2^32` cannot be witnessed through this circuit: the index reconstructed from the path will not match the actual account index.

**Impact**. A malicious sequencer could store a new account at an index greater than `2^32`, which in case of an emergency commit would be locked, since openings cannot be witnessed, and cannot be pushed to emergency DA actions.

fix ZK-470