### PR TITLE
Pay for bridge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,4 +101,4 @@ jobs:
           opam exec -- dune build --profile=devnet src/app/zeko/da_layer
           opam exec -- dune build --profile=devnet src/app/zeko/signer
       - name: 🧪 Run sequencer tests
-        run: ./src/app/zeko/sequencer/tests/run-sequencer-test.sh real 1
+        run: ./src/app/zeko/sequencer/tests/run-sequencer-test.sh real 1 false true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,13 @@
 # AGENTS.md
 
 ## Repo overview
+
 - This is a fork of the Mina blockchain repository for the L2 project Zeko.
 - Zeko-specific code lives under `src/app/zeko`.
 - Changes to upstream Mina code are either prefixed with `zeko_` or marked by a `ZEKO NOTE` comment.
 
 ## Key directories
+
 - `src/app/zeko/circuits`: zero-knowledge circuits for the rollup smart contract.
 - `src/app/zeko/circuits/design`: rollup and bridge design docs/specs (see notes below).
 - `src/app/zeko/da_layer`: multisig DA layer code.
@@ -13,14 +15,22 @@
 - `src/app/zeko/sequencer/prover`: proving service used by the sequencer.
 
 ## Build
+
 - Build the Zeko project with:
-  - `dune build ./src/app/zeko/sequencer`
+  - `dune build ./src/app/zeko/sequencer ./src/app/zeko/da_layer ./src/app/zeko/signer`
 - The build can take longer than 10 seconds; prefer running with a longer timeout (e.g., 120s) in CI or local scripts.
 
+## Testing
+
+- Build the Zeko project first
+- run ./src/app/zeko/tests/run-sequencer-test.sh fake 3 true false
+
 ## Project language
+
 - OCaml (Dune build system).
 
 ## Design docs (circuits)
+
 - Primary, current spec: `src/app/zeko/circuits/design/rollup-centralized-spec.md`.
 - `src/app/zeko/circuits/design/README.md` notes that other files may be out of date; treat `src/app/zeko/circuits/design/old` as historical context only.
 - Core rollup model: outer (L1) and inner (L2) accounts with action states; commits synchronize a prefix of the outer action state into the inner account; inner steps append to outer action state and advance its length.
@@ -31,6 +41,7 @@
 - Bridge governance: may be separate from rollup governance; circuits can enforce vk hash matching across inner/outer bridge accounts; a failsafe design rotates multiple outer bank accounts to limit impact of a circuit bug.
 
 ## Circuits (code concepts)
+
 - Action states are typed fields with optional length tracking (`rollup_state.ml`); inner app state stores the outer action state+length, outer app state stores the ledger hash, inner action state+length, sequencer key, pause key, DA multisig commitment, and account-set root.
 - Outer actions are either `Commit` (rollup step summary) or `Witness` (arbitrary action payload); inner actions are `Witness` only (`rollup_state.ml`).
 - `rule_commit.ml` verifies the transaction SNARK, DA multisig signatures over the target ledger hash, slot-range bounds, and action-state-extension proofs; it updates outer app state, emits a `Commit` action, and requires a sequencer signature as a child update.
@@ -46,6 +57,7 @@
 - `folder.ml`/`folder.mli` implement a generic recursive “state machine” folding circuit (leaf/extend/merge rules) used by action-state extension proofs; it folds arrays of elements with optional mid-proof selection and configurable iteration counts.
 
 ## DA layer (code concepts)
+
 - Each DA node stores and signs diffs that deterministically transform a source ledger hash into a target ledger hash; signatures attest the node can reconstruct the target ledger.
 - `diff.ml` defines the DA diff format: source ledger hash, changed accounts (index + account), optional command with action-step flags, and a timestamp (V2 adds time; V1 is time-less).
 - `core.ml` validates a posted diff by checking source hash, DB presence/genesis, unique indices, and recomputed target hash; it also validates receipt-chain updates for included commands before signing the target hash and persisting the diff.
@@ -55,6 +67,7 @@
 - `db.ml` is the KV storage for diffs plus an index and migration marker; `migrations.ml` handles version upgrades (e.g., adding the top-level version tag).
 
 ## Sequencer (core flow)
+
 - `zeko_sequencer.ml` is the main orchestrator: it validates incoming user commands, applies them to the local ledger/IMT, queues proofs, posts DA diffs, and periodically commits to L1.
 - Transaction application uses `zeko_transaction_logic.ml`, which applies Mina signed payments and zkapp commands to the local ledger, updates the indexed merkle tree, and returns `Txn_snark_witness` segments plus a sparse source ledger for proof inputs.
 - Command validation checks pool capacity, minimum fee (dynamic based on prover queue size), slot-range bounds, and signature/proof validity via `verifier.ml` before applying to state.
@@ -67,6 +80,7 @@
 - `executor.ml` is the L1 sender: it signs zkapp commands, infers/refreshes nonce, retries on transient failures, and serializes submissions to avoid nonce races.
 
 ## Circuits (engineering knowhow)
+
 - Zkapp action payloads are limited to ~100 field elements; large data should be compressed into hashes or split across transactions (emergency DA uses a single account per tx).
 - Action payload encoding is done via `zeko_util.var_to_actions`, which pushes a struct’s field elements into actions as data-as-hash.
 - Action-state extension proofs (A.S.E.) are built with `ase.ml` + `folder.ml`; these are the canonical way to prove action-state progression with bounded iterations.
@@ -74,6 +88,7 @@
 - Valid-while ranges are inclusive in Mina; commit rules enforce max window size and subset checks against transaction snark slot ranges.
 
 ## Mina zkApp model (transaction logic)
+
 - zkApp transactions are a call forest of account updates; execution walks the forest with a call stack, deriving `caller_id` based on `may_use_token` and parent relationships.
 - Each account update checks: account/ledger inclusion, account preconditions, protocol-state preconditions, valid-while range, and authorization (proof or signature) against the transaction commitment.
 - Transaction commitments are computed from the account-update call forest; `use_full_commitment` switches between transaction and full commitments for authorization and replay protection.
@@ -84,6 +99,7 @@
 - Failed zkapp updates are disallowed on Zeko: local_state.success must hold for the last account update; failed transactions are rejected rather than partially applied.
 
 ## Transaction SNARK structure
+
 - Transaction snarks support base proofs for signed commands and zkapp command segments, plus merge proofs that combine two proofs into one.
 - Zkapp command segments are categorized by authorization pattern: `Opt_signed`, `Opt_signed_opt_signed`, or `Proved`; proved segments require a side-loaded verification key.
 - The zkapp snark uses implied merkle roots from account+path to validate ledger inclusion and ensures consistent commitments across segments.

--- a/src/app/zeko/circuits/ase.mli
+++ b/src/app/zeko/circuits/ase.mli
@@ -3,10 +3,20 @@
 open Snark_params.Tick
 open Zeko_util
 
-module With_length : sig
+module M_with_length : sig
   module Stmt : sig
     type t = { action_state : F.t; length : Checked32.t } [@@deriving snarky]
   end
+
+  module Init = Stmt
+
+  val init : check:'a -> Init.var -> Stmt.var Checked.t
+
+  val step : field_var -> Stmt.var -> Stmt.var Checked.t
+end
+
+module With_length : sig
+  module Stmt = M_with_length.Stmt
 
   type trans = { source : Stmt.t; target : Stmt.t }
 
@@ -77,8 +87,17 @@ module With_length : sig
   end
 end
 
-module Without_length : sig
+module M_without_length : sig
   module Stmt = F
+  module Init = Stmt
+
+  val init : check:'a -> Init.var -> Stmt.var Checked.t
+
+  val step : field_var -> Stmt.var -> Stmt.var Checked.t
+end
+
+module Without_length : sig
+  module Stmt = M_without_length.Stmt
 
   type trans = { source : field; target : field }
 

--- a/src/app/zeko/circuits/bridge_rules.ml
+++ b/src/app/zeko/circuits/bridge_rules.ml
@@ -43,6 +43,10 @@ struct
         let chain_l1 = Inputs.chain_l1
 
         module Deposit_params = Deposit_params_base
+
+        let bridge_fee_recipient_l1 = Inputs.bridge_fee_recipient_l1
+
+        let bridge_proof_fee = Inputs.bridge_proof_fee
       end)
       ()
 
@@ -164,6 +168,10 @@ struct
         let chain_l1 = Inputs.chain_l1
 
         module Deposit_params = Deposit_params_custom
+
+        let bridge_fee_recipient_l1 = Inputs.bridge_fee_recipient_l1
+
+        let bridge_proof_fee = Inputs.bridge_proof_fee
       end)
       ()
 

--- a/src/app/zeko/circuits/bridge_rules.ml
+++ b/src/app/zeko/circuits/bridge_rules.ml
@@ -15,6 +15,12 @@ module Make_mina (Inputs : sig
 
   val withdrawal_delay : Mina_numbers.Global_slot_span.t
 
+  val bridge_proof_fee : Currency.Amount.t
+
+  val bridge_fee_recipient_l1 : PC.t
+
+  val bridge_fee_recipient_l2 : PC.t
+
   val holder_account_l1_permissions_enabled : Mina_base.Permissions.t
 
   val holder_account_l1_permissions_disabled : Mina_base.Permissions.t
@@ -129,6 +135,12 @@ module Make_custom (Inputs : sig
   val holder_account_l2 : PC.t
 
   val withdrawal_delay : Mina_numbers.Global_slot_span.t
+
+  val bridge_proof_fee : Currency.Amount.t
+
+  val bridge_fee_recipient_l1 : PC.t
+
+  val bridge_fee_recipient_l2 : PC.t
 
   val holder_account_l1_permissions_enabled : Mina_base.Permissions.t
 

--- a/src/app/zeko/circuits/bridge_rules.ml
+++ b/src/app/zeko/circuits/bridge_rules.ml
@@ -21,6 +21,8 @@ module Make_mina (Inputs : sig
 
   val bridge_fee_recipient_l2 : PC.t
 
+  val outer_account_creation_fee : Currency.Fee.t
+
   val holder_account_l1_permissions_enabled : Mina_base.Permissions.t
 
   val holder_account_l1_permissions_disabled : Mina_base.Permissions.t
@@ -145,6 +147,8 @@ module Make_custom (Inputs : sig
   val bridge_fee_recipient_l1 : PC.t
 
   val bridge_fee_recipient_l2 : PC.t
+
+  val outer_account_creation_fee : Currency.Fee.t
 
   val holder_account_l1_permissions_enabled : Mina_base.Permissions.t
 

--- a/src/app/zeko/circuits/bridge_state.ml
+++ b/src/app/zeko/circuits/bridge_state.ml
@@ -230,7 +230,8 @@ end
 let deposit_action (type deposit_params_var) ~chain_l1
     ~(holder_accounts_l1 : PC.t list) ~(token_owner_l1 : Account_id.t option)
     (module Deposit_params : DEPOSIT_PARAMS with type var = deposit_params_var)
-    (params : deposit_params_var) :
+    (params : deposit_params_var) ~(bridge_fee_recipient_l1 : PC.var)
+    ~(bridge_proof_fee : Currency.Amount.var) :
     Rollup_state.Outer_action.Witness.var Checked.t =
   let open Checked.Let_syntax in
   (* The chosen account must be one of the valid holder accounts.
@@ -261,6 +262,18 @@ let deposit_action (type deposit_params_var) ~chain_l1
         constant Account_update.Authorization_kind.typ None_given
     }
   in
+  let fee_payout =
+    { default_account_update with
+      public_key = bridge_fee_recipient_l1
+    ; token_id = constant Token_id.typ Token_id.default
+    ; balance_change =
+        Currency.Amount.Signed.Checked.of_unsigned bridge_proof_fee
+    ; may_use_token =
+        constant Account_update.May_use_token.typ Parents_own_token
+    ; authorization_kind =
+        constant Account_update.Authorization_kind.typ None_given
+    }
+  in
   let@ () = with_label __LOC__ in
   let a', (children : Calls.t) =
     match token_owner_l1 with
@@ -285,7 +298,8 @@ let deposit_action (type deposit_params_var) ~chain_l1
   in
   let@ () = with_label __LOC__ in
   let* children' =
-    Calls.hash ~chain:chain_l1 ((a', children) :: Raw base_params.children)
+    Calls.hash ~chain:chain_l1
+      ((a', children) :: (fee_payout, []) :: Raw base_params.children)
   in
   let@ () = with_label __LOC__ in
   let hash_prefix = Zeko_constants.deposit_salt in

--- a/src/app/zeko/circuits/bridge_state.ml
+++ b/src/app/zeko/circuits/bridge_state.ml
@@ -313,7 +313,7 @@ let deposit_action (type deposit_params_var) ~chain_l1
 
 let withdrawal_action (type withdrawal_params_var) ~chain_l2
     ~(holder_account_l2 : PC.t) ~(token_owner_l2 : Account_id.t option)
-    ~l2_holder_vk_hash
+    ~l2_holder_vk_hash ~bridge_fee_recipient_l2 ~bridge_proof_fee
     (module Withdrawal_params : WITHDRAWAL_PARAMS
       with type var = withdrawal_params_var ) (params : Withdrawal_params.var) :
     Rollup_state.Inner_action.var Checked.t =
@@ -343,6 +343,18 @@ let withdrawal_action (type withdrawal_params_var) ~chain_l2
             } )
     }
   in
+  let fee_payout =
+    { default_account_update with
+      public_key = bridge_fee_recipient_l2
+    ; token_id = constant Token_id.typ Token_id.default
+    ; balance_change =
+        Currency.Amount.Signed.Checked.of_unsigned bridge_proof_fee
+    ; may_use_token =
+        constant Account_update.May_use_token.typ Parents_own_token
+    ; authorization_kind =
+        constant Account_update.Authorization_kind.typ None_given
+    }
+  in
   let a', (children : Calls.t) =
     match token_owner_l2 with
     | None ->
@@ -365,7 +377,8 @@ let withdrawal_action (type withdrawal_params_var) ~chain_l2
         , (a, []) :: Raw custom_params.nested_children )
   in
   let* children' =
-    Calls.hash ~chain:chain_l2 ((a', children) :: Raw base_params.children)
+    Calls.hash ~chain:chain_l2
+      ((a', children) :: (fee_payout, []) :: Raw base_params.children)
   in
   let hash_prefix = Zeko_constants.withdrawal_salt in
   let* aux = var_to_hash ~init:hash_prefix Withdrawal_params.typ params in

--- a/src/app/zeko/circuits/check_accepted_make.ml
+++ b/src/app/zeko/circuits/check_accepted_make.ml
@@ -2,6 +2,7 @@ open Mina_base
 open Snark_params.Tick
 open Zeko_util
 open Checked.Let_syntax
+module PC = Signature_lib.Public_key.Compressed
 
 module Make (Inputs : sig
   module Deposit_params : Bridge_state.DEPOSIT_PARAMS
@@ -11,6 +12,10 @@ module Make (Inputs : sig
   val token_owner_l1 : Account_id.t option
 
   val chain_l1 : Mina_signature_kind.t
+
+  val bridge_fee_recipient_l1 : Signature_lib.Public_key.Compressed.t
+
+  val bridge_proof_fee : Currency.Amount.t
 end)
 () =
 struct
@@ -51,8 +56,10 @@ struct
         ({ params; original_action_state; deposit_index } : Init.var) :
         Stmt.var Checked.t =
       let* witness =
-        Bridge_state.deposit_action ~chain_l1 ~holder_accounts_l1
-          ~token_owner_l1
+        Bridge_state.deposit_action ~chain_l1
+          ~bridge_fee_recipient_l1:(constant PC.typ bridge_fee_recipient_l1)
+          ~bridge_proof_fee:(constant Currency.Amount.typ bridge_proof_fee)
+          ~holder_accounts_l1 ~token_owner_l1
           (module Deposit_params)
           params
       in

--- a/src/app/zeko/circuits/design/bridge-explanation.md
+++ b/src/app/zeko/circuits/design/bridge-explanation.md
@@ -10,6 +10,46 @@ These accounts are separate from the outer and inner account of the rollup.
 We will thus refer to this new pair of accounts as the token outer and inner accounts.
 For disambiguation purposes, the ones for the rollup are prefixed with rollup.
 
+## Bridge proof fee
+
+The sequencer is the party that ultimately spends compute proving the
+finalize/cancel transactions. To pay it for that work, every bridging
+request bakes a fixed `bridge_proof_fee` into the transaction so that
+the sequencer's `bridge_fee_recipient` accounts collect a fee whether the
+request is a deposit, a withdrawal, or a cancelled deposit.
+
+The fee is enforced inside the circuits, not by the sequencer's choice,
+so a malicious sequencer cannot redirect the funds:
+
+- On submitDeposit/submitWithdrawal, the deposit/withdrawal action that the
+  user signs already carries a sibling account update
+  paying `bridge_proof_fee` to `bridge_fee_recipient_l1` (deposit) or
+  `bridge_fee_recipient_l2` (withdrawal). The user's transferrer must
+  cover `amount + bridge_proof_fee`.
+- On the finalize\* actions, the action update on the holder/zeko account
+  has two additional child account updates appended to its calls: one paying
+  `(amount - bridge_proof_fee)` (or, if the helper account is new, also minus
+  the helper's account creation fee) to the recipient, and one paying
+  `bridge_proof_fee` to the bridge fee recipient.
+
+Because the user pays `amount + bridge_proof_fee` on submit but only
+receives `(amount - bridge_proof_fee)` on finalize, the sequencer's
+`bridge_fee_recipient` ends up with `2 × bridge_proof_fee` per completed
+bridging request — one half collected at submit time, one half at
+finalize time.
+
+### Pre-signing the helper account update
+
+Finalize transactions go through the sequencer, but the user authorizes
+the helper account update with their own signature (replay-protected by
+incrementing the helper's nonce). To make pre-signing safe — i.e. signing
+before knowing who pays the fee_payer fee — the helper update sets
+`use_full_commitment = false`. That way the user's signature commits only
+to the account-updates hash, not to the memo/fee_payer hash, so the
+sequencer can wrap the proven forest in any fee-payer of its own without
+invalidating the signature. Replay is prevented by the constant-nonce
+precondition + `increment_nonce = true` on the helper update.
+
 ## Deposits
 
 Deposits are made by posting an action on the rollup outer account,
@@ -18,6 +58,11 @@ The user specifies an upper bound (slot) after which point if not
 processed, the deposit will timeout and the funds will be recoverible.
 The action will be a Witness action that witnesses the deposit to the
 token outer account.
+
+The `Witness` action also includes a sibling fee-payout account update
+that sends `bridge_proof_fee` to `bridge_fee_recipient_l1` from the
+parent's token. This is what compensates the sequencer for proving and
+posting the corresponding finalize-deposit transaction later.
 
 As explained above, on commit, the sequencer will also post an action on the
 rollup outer account that details what kind of commit we made, along with the
@@ -40,18 +85,35 @@ After this, the index is updated to be the index of the new deposit.
 Notably, it is possible to "skip" a deposit erroneously, but it is on the user
 not to do this accidentally.
 
+The helper account update is signed by the user with the partial
+transaction commitment (`use_full_commitment = false`), increments its own
+nonce, and pins down its old nonce via a constant-nonce precondition. This
+way the user can pre-sign the update without knowing the fee_payer, and the
+nonce increment plus precondition keeps the signature single-use.
+
 In this process we must match on the rollup outer action state as stored
 in the inner account. This value can change, and cause the preconditions
 to fail, but this is of no worry since failed transactions are feeless on Zeko.
 
 The funds are then minted or sent by the token inner account,
-depending on what kind of token it is.
+depending on what kind of token it is. They're not sent to a recipient of
+the sequencer's choosing — the finalize circuit hardcodes two sibling
+account updates inside the action update: one for the recipient (for
+`amount - bridge_proof_fee`, minus another `account_creation_fee` if the
+helper account is new) and one for the bridge fee recipient (for
+`bridge_proof_fee`). Because both are children of the action update with
+no authorization of their own, they ride along with the proof and the
+sequencer can't redirect or skip them.
 
 ## Withdrawals
 
 To do withdrawals, we similarly post an action on the rollup inner action state.
 We use the Witness action to show that we've either burned or sent the tokens
-back to the token inner account.
+back to the token inner account. As with deposits, the `Witness` action also
+includes a sibling fee-payout account update paying `bridge_proof_fee` to
+`bridge_fee_recipient_l2` (from the parent's token) so the sequencer is
+compensated for the corresponding finalize-withdrawal transaction it'll
+post on L1 later.
 
 To withdraw, a constant number of slots must have roughly passed since the
 withdrawal was added. We figure out when a withdrawal was processed
@@ -70,7 +132,16 @@ FIXME: fix #177.
 As in the deposit case, we need to prevent double spends, thus similarly,
 we have helper accounts on the outside too.
 As with deposits, the helper account keeps track of the index of the last withdrawal
-processed.
+processed. The helper update is signed with `use_full_commitment = false`
+and `increment_nonce = true`, with a constant-nonce precondition, so the
+user can pre-sign without knowing the fee_payer and replays are blocked.
+
+The finalize-withdrawal circuit also appends two sibling payout account
+updates to the action update: one to the recipient for
+`amount - bridge_proof_fee` (or further minus `outer_account_creation_fee`
+if the helper account is new), and one to `bridge_fee_recipient_l1` for
+`bridge_proof_fee`. Same as in the deposit case, these are determined by
+the proof and not by the sequencer.
 We also have to consider emergency changes.
 The rollup inner action state might "roll back" and procede in another direction
 due to this, and this is why we store the inner action state in the outer
@@ -95,6 +166,14 @@ We use the same helper account as for withdrawals,
 thus the helper account on the outside keeps track of two indices,
 one for the index of the last withdrawal processed, and
 one for the index of the last cancelled deposit processed.
+
+The same fee-payout treatment applies as in the withdrawal case: the
+helper signature uses the partial commitment (with constant-nonce
+precondition + `increment_nonce`), and the finalize-cancelled-deposit
+circuit appends a recipient payout (`amount - bridge_proof_fee`, minus
+`outer_account_creation_fee` if the helper is new) and a fixed
+`bridge_proof_fee` payout to `bridge_fee_recipient_l1` as siblings of the
+action update.
 
 ## Governance (separate)
 

--- a/src/app/zeko/circuits/design/bridge-spec.md
+++ b/src/app/zeko/circuits/design/bridge-spec.md
@@ -11,6 +11,7 @@ define the circuit for the verification keys for the L1-side of the bridge contr
 Likewise, the ones for `account_id_l2` define the circuit for the L2-side.
 
 Things to consider:
+
 - State of rollup can arbitrarily change potentially through governance.
 - How much historical data do you need to prove a deposit?
 
@@ -33,6 +34,31 @@ NB: We don't require that user actions are only done in the enabled period.
 This wouldn't improve security, and would increase circuit size and complexity.
 OTOH, users should not use an L1 account/bank which is soon to become disabled.
 
+## Bridge proof fee
+
+Each bridging request pays a fixed `bridge_proof_fee` to the sequencer's
+`bridge_fee_recipient_{l1,l2}` accounts. The fee is paid in two halves so
+that the sequencer is compensated regardless of whether the request
+completes:
+
+- On submitDeposit / submitWithdrawal, the `Witness` action carries a
+  sibling `(bridge_fee_recipient, default_token, +bridge_proof_fee,
+Parents_own_token)` account update. The user's transferrer must cover
+  `amount + bridge_proof_fee`.
+- On finalize\* (deposit / cancelled deposit / withdrawal), the action
+  update on the holder/zeko account has two extra child account updates
+  appended: a recipient payout for `amount - bridge_proof_fee` (further
+  minus `account_creation_fee` / `outer_account_creation_fee` if the
+  helper account is new) and a fixed `bridge_proof_fee` payout to the
+  bridge fee recipient. Both use `may_use_token = Parents_own_token` and
+  have no authorization, so the sequencer cannot redirect them.
+
+The helper account update on finalize* is signed by the user with the
+*partial\* transaction commitment (`use_full_commitment = false`) so the
+user can pre-sign before the sequencer attaches the fee_payer.
+Single-use is enforced by `increment_nonce = true` together with the
+constant-nonce precondition on the helper account.
+
 ```ocaml
 val helper_token_owner_l1 : Public_key.t
 val public_key_l2 : Public_key.t
@@ -40,6 +66,10 @@ val token_id_l1 : Token_id.t
 val token_id_l2 : Token_id.t
 val holder_accounts_l1 : Public_key.t list
 val window_size : nat
+val bridge_proof_fee : nat
+val bridge_fee_recipient_l1 : Public_key.t
+val bridge_fee_recipient_l2 : Public_key.t
+val outer_account_creation_fee : Currency.Fee.t
 let helper_token_id_l1 = Account_id.create helper_token_owner_l1 Token_id.default
 
 let account_id_l2 = Account_id.create public_key_l2 token_id_l2
@@ -98,7 +128,16 @@ let deposit_action (params : deposit_params) : outer_action =
       ; children = a :: params.nested_children
       }
   in
-  let children = a' :: params.children in
+  (* Fee paid to the sequencer for proving the corresponding finalize. *)
+  let fee_payout =
+    { public_key = bridge_fee_recipient_l1
+    ; token_id = Token_id.default
+    ; balance_change = bridge_proof_fee
+    ; may_use_token = Parents_own_token
+    ; authorization_kind = None_given
+    }
+  in
+  let children = a' :: fee_payout :: params.children in
   Witness { aux = params.deposit ; children ; valid_while = infinite_valid_while }
 
 type withdrawal_params =
@@ -130,7 +169,16 @@ let withdraw_action
       ; children = a :: params.nested_children
       }
   in
-  let children = a' :: params.children in
+  (* Fee paid to the sequencer for proving the corresponding finalize. *)
+  let fee_payout =
+    { public_key = bridge_fee_recipient_l2
+    ; token_id = Token_id.default
+    ; balance_change = bridge_proof_fee
+    ; may_use_token = Parents_own_token
+    ; authorization_kind = None_given
+    }
+  in
+  let children = a' :: fee_payout :: params.children in
   Witness { aux = params.withdrawal ; children }
 
 
@@ -167,6 +215,8 @@ let do_finalize_deposit
   ~actions_after_deposit
   ~action_state_before_deposit
   ~prev_next_deposit
+  ~prev_nonce
+  ~helper_account_new
   ~may_use_token
   ~inner_authorization_kind
   ~deposit_index
@@ -182,6 +232,14 @@ let do_finalize_deposit
   let outer_action_state_length =
     List.length actions_after_deposit + 1 + deposit_index
   in
+  (* The user receives the deposit amount minus the bridge fee, and pays the
+     helper account creation fee out of their share if their helper account
+     is new. The bridge fee recipient is fixed by the circuit, so the
+     sequencer can't redirect funds. *)
+  let recipient_payout_amount =
+    deposit.amount - bridge_proof_fee
+    - if helper_account_new then account_creation_fee else 0
+  in
   { account_id = account_id_l2
   ; balance_change = -deposit.amount
   ; may_use_token
@@ -190,13 +248,19 @@ let do_finalize_deposit
     [ { public_key = deposit.recipient
       ; token_id = account_id_l2
       ; authorization_kind = Signature
-      ; use_full_commitment = true
+        (* Signature is on the partial commitment so the user can pre-sign
+           without knowing the fee_payer. Replays are prevented by
+           [increment_nonce] + the constant-nonce precondition below. *)
+      ; use_full_commitment = false
+      ; increment_nonce = true
       ; may_use_token = Parents_own_token
       ; app_state =
         { next_deposit = deposit_index + 1
         }
       ; preconditions =
-        { app_state =
+        { is_new = helper_account_new
+        ; nonce = { lower = prev_nonce ; upper = prev_nonce }
+        ; app_state =
           { next_deposit = prev_next_deposit
           }
         }
@@ -204,6 +268,20 @@ let do_finalize_deposit
     ; { public_key = inner_pk
       ; preconditions = { app_state = { outer_action_state ; outer_action_state_length } }
       ; authorization_kind = inner_authorization_kind
+      }
+    ; { public_key = deposit.recipient
+      ; token_id = token_id_l2
+      ; balance_change = recipient_payout_amount
+      ; may_use_token = Parents_own_token
+      ; authorization_kind = None_given
+      ; implicit_account_creation_fee = true
+      }
+    ; { public_key = bridge_fee_recipient_l2
+      ; token_id = token_id_l2
+      ; balance_change = bridge_proof_fee
+      ; may_use_token = Parents_own_token
+      ; authorization_kind = None_given
+      ; implicit_account_creation_fee = true
       }
     ]
   }
@@ -214,14 +292,14 @@ let do_finalize_deposit
   We do this by showing that there is a historical action state after
   which our deposit comes, and after which there are actions that reject it
   before accepting it.
-  
+
   We then update the stored next_cancelled_deposit index as done in the other cases.
-  
+
   The challenge lies in that we need to prove that the deposit index is correct,
   since we're counting from the beginning, and not from the end.
   We need to know that there indeed was that many actions before our deposit,
   but we would like to prevent having to count back to the dawn of our rollup.
-  
+
   We instead find a commit in the past to use its synchronization point to skip
   most of the history.
   We count from the synchronization point to the current outer action state to
@@ -233,6 +311,8 @@ let do_finalize_cancelled_deposit
   ~actions_after_deposit
   ~action_state_before_deposit
   ~prev_next_cancelled_deposit
+  ~prev_nonce
+  ~helper_account_new
   ~outer_authorization_kind
   ~deposit_index
   ~may_use_token
@@ -262,6 +342,10 @@ let do_finalize_cancelled_deposit
     List.length actions_after_synchronization + commit.synchronized_outer_action_state_length
   in
   assert outer_action_state_length = outer_action_state_length' ;
+  let recipient_payout_amount =
+    deposit.amount - bridge_proof_fee
+    - if helper_account_new then outer_account_creation_fee else 0
+  in
   { account_id = deposit_params.holder_account_l1
   ; balance_change = -deposit.amount
   ; may_use_token
@@ -273,13 +357,16 @@ let do_finalize_cancelled_deposit
         [ { public_key = deposit.recipient
           ; token_id = helper_token_id_l1
           ; authorization_kind = Signature
-          ; use_full_commitment = true
+          ; use_full_commitment = false
+          ; increment_nonce = true
           ; may_use_token = Parents_own_token
           ; app_state =
             { next_cancelled_deposit = deposit_index + 1
             }
           ; preconditions =
-            { app_state =
+            { is_new = helper_account_new
+            ; nonce = { lower = prev_nonce ; upper = prev_nonce }
+            ; app_state =
               { next_cancelled_deposit = prev_next_deposit
               }
             }
@@ -294,6 +381,20 @@ let do_finalize_cancelled_deposit
           }
         }
       ; authorization_kind = outer_authorization_kind
+      }
+    ; { public_key = deposit.recipient
+      ; token_id = token_id_l1
+      ; balance_change = recipient_payout_amount
+      ; may_use_token = Parents_own_token
+      ; authorization_kind = None_given
+      ; implicit_account_creation_fee = true
+      }
+    ; { public_key = bridge_fee_recipient_l1
+      ; token_id = token_id_l1
+      ; balance_change = bridge_proof_fee
+      ; may_use_token = Parents_own_token
+      ; authorization_kind = None_given
+      ; implicit_account_creation_fee = true
       }
     ]
   }
@@ -307,6 +408,8 @@ let do_finalize_cancelled_deposit_simple
   ~deposit_params
   ~actions_after_deposit
   ~prev_next_cancelled_deposit
+  ~prev_nonce
+  ~helper_account_new
   ~outer_authorization_kind
   ~may_use_token
   =
@@ -316,6 +419,10 @@ let do_finalize_cancelled_deposit_simple
   assert prev_next_cancelled_deposit <= deposit_index ;
   let outer_action_state =
     List.append actions_after_deposit (deposit_action deposit_params :: action_state_before_deposit)
+  in
+  let recipient_payout_amount =
+    deposit.amount - bridge_proof_fee
+    - if helper_account_new then outer_account_creation_fee else 0
   in
   { account_id = deposit_params.holder_account_l1
   ; balance_change = -deposit.amount
@@ -328,13 +435,16 @@ let do_finalize_cancelled_deposit_simple
         [ { public_key = deposit.recipient
           ; token_id = helper_token_id_l1
           ; authorization_kind = Signature
-          ; use_full_commitment = true
+          ; use_full_commitment = false
+          ; increment_nonce = true
           ; may_use_token = Parents_own_token
           ; app_state =
             { next_cancelled_deposit = deposit_index + 1
             }
           ; preconditions =
-            { app_state =
+            { is_new = helper_account_new
+            ; nonce = { lower = prev_nonce ; upper = prev_nonce }
+            ; app_state =
               { next_cancelled_deposit = prev_next_deposit
               }
             }
@@ -349,6 +459,20 @@ let do_finalize_cancelled_deposit_simple
           }
         }
       ; authorization_kind = outer_authorization_kind
+      }
+    ; { public_key = deposit.recipient
+      ; token_id = token_id_l1
+      ; balance_change = recipient_payout_amount
+      ; may_use_token = Parents_own_token
+      ; authorization_kind = None_given
+      ; implicit_account_creation_fee = true
+      }
+    ; { public_key = bridge_fee_recipient_l1
+      ; token_id = token_id_l1
+      ; balance_change = bridge_proof_fee
+      ; may_use_token = Parents_own_token
+      ; authorization_kind = None_given
+      ; implicit_account_creation_fee = true
       }
     ]
   }
@@ -364,6 +488,8 @@ let do_finalize_withdrawal
   ~action_state_before_commit
   ~commit
   ~prev_next_withdrawal
+  ~prev_nonce
+  ~helper_account_new
   ~withdrawal_index
   ~outer_authorization_kind
   ~may_use_token
@@ -385,6 +511,10 @@ let do_finalize_withdrawal
   *)
   assert commit.inner_action_state = inner_action_state ;
   assert commit.inner_action_state_length = inner_action_state_length ;
+  let recipient_payout_amount =
+    withdrawal.amount - bridge_proof_fee
+    - if helper_account_new then outer_account_creation_fee else 0
+  in
   { account_id = holder_account_l1
   ; balance_change = -withdrawal.amount
   ; may_use_token
@@ -396,13 +526,16 @@ let do_finalize_withdrawal
         [ { public_key = withdrawal.recipient
           ; token_id = helper_token_id_l1
           ; authorization_kind = Signature
-          ; use_full_commitment = true
+          ; use_full_commitment = false
+          ; increment_nonce = true
           ; may_use_token = Parents_own_token
           ; app_state =
             { next_withdrawal = withdrawal_index + 1
             }
          ; preconditions =
-            { app_state =
+            { is_new = helper_account_new
+            ; nonce = { lower = prev_nonce ; upper = prev_nonce }
+            ; app_state =
               { next_withdrawal = prev_next_withdrawal
               }
             }
@@ -418,6 +551,20 @@ let do_finalize_withdrawal
           { lower = commit.valid_while.upper + withdrawal_delay
           ; upper = infinity }
         }
+      }
+    ; { public_key = withdrawal.recipient
+      ; token_id = token_id_l1
+      ; balance_change = recipient_payout_amount
+      ; may_use_token = Parents_own_token
+      ; authorization_kind = None_given
+      ; implicit_account_creation_fee = true
+      }
+    ; { public_key = bridge_fee_recipient_l1
+      ; token_id = token_id_l1
+      ; balance_change = bridge_proof_fee
+      ; may_use_token = Parents_own_token
+      ; authorization_kind = None_given
+      ; implicit_account_creation_fee = true
       }
     ]
   }
@@ -449,6 +596,7 @@ let do_disable ~disabled_vk ~disable_offset_lower ~disable_offset_upper ~disable
 ```
 
 Circuit when disabled
+
 ```ocaml
 let do_enable ~enabled_vk ~enable_offset_lower ~enable_offset_upper ~enable_period idx =
   { account_id = holder_accounts_l1.(account_idx)
@@ -477,6 +625,7 @@ let do_enable ~enabled_vk ~enable_offset_lower ~enable_offset_upper ~enable_peri
 ```
 
 Init state
+
 ```ocaml
 let init_inner =
   { Account.empty with

--- a/src/app/zeko/circuits/multisig.ml
+++ b/src/app/zeko/circuits/multisig.ml
@@ -88,10 +88,10 @@ let of_witness_var ({ signatures; quorum; _ } : Witness.var) :
         ~init:(Hash_prefix_create.salt Zeko_constants.multisig_salt)
         (Random_oracle.Checked.pack_input input) )
 
-let check ~signature_kind ({ signatures; quorum = _ } : Witness.var) payload =
+let check ~signature_kind ({ signatures; quorum } : Witness.var) payload =
   let payload = Random_oracle.Input.Chunked.field payload in
   let@ () = with_label __LOC__ in
-  let* _valid_signatures_count =
+  let* valid_signatures_count =
     foldl
       (Array.to_list signatures.array)
       ~init:Field.(Var.constant zero)
@@ -113,7 +113,6 @@ let check ~signature_kind ({ signatures; quorum = _ } : Witness.var) payload =
           ~else_:acc )
   in
   let@ () = with_label __LOC__ in
-  Checked.return ()
-(* Comparison_gadget.assert_greater_than_full valid_signatures_count
-   (* sub 1 to do the >= *)
-   Field.Var.(sub quorum (constant Field.one)) *)
+  Comparison_gadget.assert_greater_than_full valid_signatures_count
+    (* sub 1 to do the >= *)
+    Field.Var.(sub quorum (constant Field.one))

--- a/src/app/zeko/circuits/multisig.ml
+++ b/src/app/zeko/circuits/multisig.ml
@@ -88,10 +88,10 @@ let of_witness_var ({ signatures; quorum; _ } : Witness.var) :
         ~init:(Hash_prefix_create.salt Zeko_constants.multisig_salt)
         (Random_oracle.Checked.pack_input input) )
 
-let check ~signature_kind ({ signatures; quorum } : Witness.var) payload =
+let check ~signature_kind ({ signatures; quorum = _ } : Witness.var) payload =
   let payload = Random_oracle.Input.Chunked.field payload in
   let@ () = with_label __LOC__ in
-  let* valid_signatures_count =
+  let* _valid_signatures_count =
     foldl
       (Array.to_list signatures.array)
       ~init:Field.(Var.constant zero)
@@ -113,6 +113,7 @@ let check ~signature_kind ({ signatures; quorum } : Witness.var) payload =
           ~else_:acc )
   in
   let@ () = with_label __LOC__ in
-  Comparison_gadget.assert_greater_than_full valid_signatures_count
-    (* sub 1 to do the >= *)
-    Field.Var.(sub quorum (constant Field.one))
+  Checked.return ()
+(* Comparison_gadget.assert_greater_than_full valid_signatures_count
+   (* sub 1 to do the >= *)
+   Field.Var.(sub quorum (constant Field.one)) *)

--- a/src/app/zeko/circuits/outer_rules.ml
+++ b/src/app/zeko/circuits/outer_rules.ml
@@ -5,6 +5,8 @@ module Make (Inputs : sig
 
   val chain_l1 : Mina_signature_kind.t
 
+  val chain_l2 : Mina_signature_kind.t
+
   val multisig_key : Multisig.t
 
   val max_sequencer_inactivity : int

--- a/src/app/zeko/circuits/rule_action_witness.ml
+++ b/src/app/zeko/circuits/rule_action_witness.ml
@@ -20,6 +20,20 @@ struct
       exists ~compute:(V.get w) Witness.typ
     in
     let* actions = Outer_action.witness_to_actions_var witness in
+    let* () =
+      let open Mina_base in
+      let@ () = make_checked in
+      let@ () = Run.as_prover in
+      let children =
+        Run.As_prover.read Zkapp_call_forest.typ witness.children
+      in
+      let hash = Zkapp_command.Call_forest.hash children in
+      Core.printf "children: %s\n"
+        ( Yojson.Safe.to_string @@ Zkapp_command.account_updates_to_json
+        @@ Zkapp_command.Call_forest.map children
+             ~f:Account_update.read_all_proofs_from_disk ) ;
+      Core.printf !"Hash: %{sexp: Field.t}\n" (hash :> Field.t)
+    in
     let valid_while = Slot_range.Checked.to_valid_while witness.slot_range in
     let* status_flags_precondition =
       Outer_state.Status_flags.of_bools_var ~paused:Boolean.false_

--- a/src/app/zeko/circuits/rule_action_witness.ml
+++ b/src/app/zeko/circuits/rule_action_witness.ml
@@ -20,20 +20,6 @@ struct
       exists ~compute:(V.get w) Witness.typ
     in
     let* actions = Outer_action.witness_to_actions_var witness in
-    let* () =
-      let open Mina_base in
-      let@ () = make_checked in
-      let@ () = Run.as_prover in
-      let children =
-        Run.As_prover.read Zkapp_call_forest.typ witness.children
-      in
-      let hash = Zkapp_command.Call_forest.hash children in
-      Core.printf "children: %s\n"
-        ( Yojson.Safe.to_string @@ Zkapp_command.account_updates_to_json
-        @@ Zkapp_command.Call_forest.map children
-             ~f:Account_update.read_all_proofs_from_disk ) ;
-      Core.printf !"Hash: %{sexp: Field.t}\n" (hash :> Field.t)
-    in
     let valid_while = Slot_range.Checked.to_valid_while witness.slot_range in
     let* status_flags_precondition =
       Outer_state.Status_flags.of_bools_var ~paused:Boolean.false_

--- a/src/app/zeko/circuits/rule_bridge_finalize_cancelled_deposit.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_cancelled_deposit.ml
@@ -26,6 +26,8 @@ module Make (Inputs : sig
 
   val bridge_proof_fee : Currency.Amount.t
 
+  val outer_account_creation_fee : Currency.Fee.t
+
   module Deposit_params : Bridge_state.DEPOSIT_PARAMS
 
   module Check_accepted :
@@ -173,6 +175,8 @@ struct
       ; verify_check_accepted_and_ase : Verify_check_accepted_and_ase.t
       ; prev_next_cancelled_deposit : Checked32.t
       ; helper_token_owner_l1_vk_hash : F.t
+      ; prev_nonce : Checked32.t
+      ; helper_account_new : Boolean.t
       }
     [@@deriving snarky]
   end
@@ -190,6 +194,8 @@ struct
                ; verify_check_accepted_and_ase
                ; prev_next_cancelled_deposit
                ; helper_token_owner_l1_vk_hash
+               ; prev_nonce
+               ; helper_account_new
                } =
           exists Witness.typ ~compute:(V.get w)
         in
@@ -283,12 +289,17 @@ struct
               authorization_vk_hash helper_token_owner_l1_vk_hash
           }
         in
+        let prev_nonce =
+          Mina_numbers.Account_nonce.Checked.Unsafe.of_field
+            (Checked32.Checked.to_field prev_nonce)
+        in
         let helper_account =
           { default_account_update with
             public_key = base_params.recipient
           ; token_id = helper_token_id
           ; authorization_kind = authorization_signed ()
-          ; use_full_commitment = Boolean.true_
+          ; use_full_commitment = Boolean.false_
+          ; increment_nonce = Boolean.true_
           ; may_use_token = constant May_use_token.typ Parents_own_token
           ; implicit_account_creation_fee = constant Boolean.typ false
           ; update =
@@ -304,13 +315,21 @@ struct
               { default_account_update.preconditions with
                 account =
                   { default_account_update.preconditions.account with
-                    state =
+                    is_new =
+                      Zkapp_basic.Or_ignore.Checked.make_unsafe Boolean.true_
+                        helper_account_new
+                  ; state =
                       Outer_user_state.fine
                         { next_cancelled_deposit =
                             Some prev_next_cancelled_deposit
                         ; next_withdrawal = None
                         }
                       |> var_to_precondition_fine
+                  ; nonce =
+                      Zkapp_basic.Or_ignore.Checked.make_unsafe Boolean.true_
+                        { Zkapp_precondition.Closed_interval.lower = prev_nonce
+                        ; upper = prev_nonce
+                        }
                   }
               }
           }
@@ -357,11 +376,54 @@ struct
                 of_unsigned base_params.amount |> negate)
           }
         in
+        let bridge_proof_fee = constant Currency.Amount.typ bridge_proof_fee in
+        let* recipient_payout =
+          let* recipient_payout, `Underflow underflow =
+            Currency.Amount.Checked.sub_flagged base_params.amount
+              bridge_proof_fee
+          in
+          let* () = Boolean.Assert.is_true (Boolean.not underflow) in
+          let account_creation_fee =
+            constant Currency.Amount.typ
+              (Currency.Amount.of_fee outer_account_creation_fee)
+          in
+          let* paid_for_helper_account_creation, `Underflow underflow =
+            Currency.Amount.Checked.sub_flagged recipient_payout
+              account_creation_fee
+          in
+          let* () = Boolean.Assert.is_true (Boolean.not underflow) in
+          if_ ~typ:Currency.Amount.typ helper_account_new
+            ~then_:paid_for_helper_account_creation ~else_:recipient_payout
+        in
+        let recipient_payout =
+          { default_account_update with
+            public_key = base_params.recipient
+          ; token_id = constant Token_id.typ token_id_l1
+          ; may_use_token = constant May_use_token.typ Parents_own_token
+          ; authorization_kind = constant A.typ None_given
+          ; balance_change =
+              Currency.Amount.Signed.Checked.of_unsigned recipient_payout
+          ; implicit_account_creation_fee = constant Boolean.typ true
+          }
+        in
+        let sequencer_fee_payout =
+          { default_account_update with
+            public_key = constant PC.typ bridge_fee_recipient_l1
+          ; token_id = constant Token_id.typ token_id_l1
+          ; may_use_token = constant May_use_token.typ Parents_own_token
+          ; authorization_kind = constant A.typ None_given
+          ; balance_change =
+              Currency.Amount.Signed.Checked.of_unsigned bridge_proof_fee
+          ; implicit_account_creation_fee = constant Boolean.typ true
+          }
+        in
         let@ () = with_label __LOC__ in
         let*| out =
           make_outputs ~chain:chain_l1 account_update
             [ (helper_token_owner, [ (helper_account, []) ])
             ; (witness_outer, [])
+            ; (recipient_payout, [])
+            ; (sequencer_fee_payout, [])
             ]
         in
         Compile_simple.

--- a/src/app/zeko/circuits/rule_bridge_finalize_cancelled_deposit.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_cancelled_deposit.ml
@@ -22,6 +22,10 @@ module Make (Inputs : sig
 
   val chain_l1 : Mina_signature_kind.t
 
+  val bridge_fee_recipient_l1 : PC.t
+
+  val bridge_proof_fee : Currency.Amount.t
+
   module Deposit_params : Bridge_state.DEPOSIT_PARAMS
 
   module Check_accepted :
@@ -35,6 +39,10 @@ module Make (Inputs : sig
             module Deposit_params = Deposit_params
 
             let chain_l1 = chain_l1
+
+            let bridge_fee_recipient_l1 = bridge_fee_recipient_l1
+
+            let bridge_proof_fee = bridge_proof_fee
           end)
           ()
 end)

--- a/src/app/zeko/circuits/rule_bridge_finalize_deposit.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_deposit.ml
@@ -24,6 +24,8 @@ module Make (Inputs : sig
 
   val bridge_proof_fee : Currency.Amount.t
 
+  val bridge_fee_recipient_l1 : PC.t
+
   val bridge_fee_recipient_l2 : PC.t
 
   val chain_l1 : Mina_signature_kind.t
@@ -41,6 +43,10 @@ module Make (Inputs : sig
             module Deposit_params = Deposit_params
 
             let chain_l1 = chain_l1
+
+            let bridge_fee_recipient_l1 = bridge_fee_recipient_l1
+
+            let bridge_proof_fee = bridge_proof_fee
           end)
           ()
 end) =

--- a/src/app/zeko/circuits/rule_bridge_finalize_deposit.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_deposit.ml
@@ -85,6 +85,7 @@ struct
       ; check_accepted : Check_accepted_inst.t
       ; prev_next_deposit : Checked32.t
       ; prev_nonce : Checked32.t
+      ; helper_account_new : Boolean.t
       }
     [@@deriving snarky]
   end
@@ -101,6 +102,7 @@ struct
            ; check_accepted
            ; prev_next_deposit
            ; prev_nonce
+           ; helper_account_new
            } =
       exists Witness.typ ~compute:(V.get w)
     in
@@ -181,7 +183,10 @@ struct
           { default_account_update.preconditions with
             account =
               { default_account_update.preconditions.account with
-                state =
+                is_new =
+                  Zkapp_basic.Or_ignore.Checked.make_unsafe Boolean.true_
+                    helper_account_new
+              ; state =
                   Inner_user_state.fine
                     { next_deposit = Some prev_next_deposit }
                   |> var_to_precondition_fine
@@ -239,23 +244,35 @@ struct
       ; events
       }
     in
-    let fee_balance_change =
-      Currency.Amount.Signed.Checked.of_unsigned
-        (constant Currency.Amount.typ bridge_proof_fee)
+    let bridge_proof_fee = constant Currency.Amount.typ bridge_proof_fee in
+    let* recipient_payout =
+      let* recipient_payout, `Underflow underflow =
+        Currency.Amount.Checked.sub_flagged base_params.amount bridge_proof_fee
+      in
+      let* () = Boolean.Assert.is_true (Boolean.not underflow) in
+      let account_creation_fee =
+        constant Currency.Amount.typ
+          (Currency.Amount.of_fee
+             Zeko_constants.constraint_constants.account_creation_fee )
+      in
+      let* paid_for_helper_account_creation, `Underflow underflow =
+        Currency.Amount.Checked.sub_flagged recipient_payout
+          account_creation_fee
+      in
+      let* () = Boolean.Assert.is_true (Boolean.not underflow) in
+      if_ ~typ:Currency.Amount.typ helper_account_new
+        ~then_:paid_for_helper_account_creation ~else_:recipient_payout
     in
-    let* recipient_balance_change =
-      Currency.Amount.Signed.Checked.add
-        (Currency.Amount.Signed.Checked.of_unsigned base_params.amount)
-        (Currency.Amount.Signed.Checked.negate fee_balance_change)
-    in
+
     let recipient_payout =
       { default_account_update with
         public_key = base_params.recipient
       ; token_id = constant Token_id.typ token_id_l2
       ; may_use_token = constant May_use_token.typ Parents_own_token
       ; authorization_kind = constant A.typ None_given
-      ; balance_change = recipient_balance_change
-      ; implicit_account_creation_fee = constant Boolean.typ false
+      ; balance_change =
+          Currency.Amount.Signed.Checked.of_unsigned recipient_payout
+      ; implicit_account_creation_fee = constant Boolean.typ true
       }
     in
     let sequencer_fee_payout =
@@ -264,8 +281,9 @@ struct
       ; token_id = constant Token_id.typ token_id_l2
       ; may_use_token = constant May_use_token.typ Parents_own_token
       ; authorization_kind = constant A.typ None_given
-      ; balance_change = fee_balance_change
-      ; implicit_account_creation_fee = constant Boolean.typ false
+      ; balance_change =
+          Currency.Amount.Signed.Checked.of_unsigned bridge_proof_fee
+      ; implicit_account_creation_fee = constant Boolean.typ true
       }
     in
     let@ () = with_label __LOC__ in

--- a/src/app/zeko/circuits/rule_bridge_finalize_deposit.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_deposit.ml
@@ -22,6 +22,10 @@ module Make (Inputs : sig
 
   val zeko_l2 : PC.t
 
+  val bridge_proof_fee : Currency.Amount.t
+
+  val bridge_fee_recipient_l2 : PC.t
+
   val chain_l1 : Mina_signature_kind.t
 
   val chain_l2 : Mina_signature_kind.t
@@ -157,7 +161,7 @@ struct
         public_key = base_params.recipient
       ; token_id = helper_token_id
       ; authorization_kind = authorization_signed ()
-      ; use_full_commitment = Boolean.true_
+      ; use_full_commitment = Boolean.false_
       ; may_use_token = constant May_use_token.typ Parents_own_token
       ; implicit_account_creation_fee = constant Boolean.typ false
       ; update =
@@ -223,10 +227,43 @@ struct
       ; events
       }
     in
+    let fee_balance_change =
+      Currency.Amount.Signed.Checked.of_unsigned
+        (constant Currency.Amount.typ bridge_proof_fee)
+    in
+    let* recipient_balance_change =
+      Currency.Amount.Signed.Checked.add
+        (Currency.Amount.Signed.Checked.of_unsigned base_params.amount)
+        (Currency.Amount.Signed.Checked.negate fee_balance_change)
+    in
+    let recipient_payout =
+      { default_account_update with
+        public_key = base_params.recipient
+      ; token_id = constant Token_id.typ token_id_l2
+      ; may_use_token = constant May_use_token.typ Parents_own_token
+      ; authorization_kind = constant A.typ None_given
+      ; balance_change = recipient_balance_change
+      ; implicit_account_creation_fee = constant Boolean.typ false
+      }
+    in
+    let sequencer_fee_payout =
+      { default_account_update with
+        public_key = constant PC.typ bridge_fee_recipient_l2
+      ; token_id = constant Token_id.typ token_id_l2
+      ; may_use_token = constant May_use_token.typ Parents_own_token
+      ; authorization_kind = constant A.typ None_given
+      ; balance_change = fee_balance_change
+      ; implicit_account_creation_fee = constant Boolean.typ false
+      }
+    in
     let@ () = with_label __LOC__ in
     let*| out =
       make_outputs ~chain:chain_l2 account_update
-        [ (helper_account, []); (witness_inner, []) ]
+        [ (helper_account, [])
+        ; (witness_inner, [])
+        ; (recipient_payout, [])
+        ; (sequencer_fee_payout, [])
+        ]
     in
     Compile_simple.
       { prevs = Two_prevs (verify_check_accepted, verify_ase); out }

--- a/src/app/zeko/circuits/rule_bridge_finalize_deposit.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_deposit.ml
@@ -84,6 +84,7 @@ struct
       ; ase : Ase_inst.t
       ; check_accepted : Check_accepted_inst.t
       ; prev_next_deposit : Checked32.t
+      ; prev_nonce : Checked32.t
       }
     [@@deriving snarky]
   end
@@ -99,6 +100,7 @@ struct
            ; ase
            ; check_accepted
            ; prev_next_deposit
+           ; prev_nonce
            } =
       exists Witness.typ ~compute:(V.get w)
     in
@@ -156,12 +158,17 @@ struct
     let@ () = with_label __LOC__ in
     let base_params = Deposit_params.base params in
     let@ () = with_label __LOC__ in
+    let prev_nonce =
+      Mina_numbers.Account_nonce.Checked.Unsafe.of_field
+        (Checked32.Checked.to_field prev_nonce)
+    in
     let helper_account =
       { default_account_update with
         public_key = base_params.recipient
       ; token_id = helper_token_id
       ; authorization_kind = authorization_signed ()
       ; use_full_commitment = Boolean.false_
+      ; increment_nonce = Boolean.true_
       ; may_use_token = constant May_use_token.typ Parents_own_token
       ; implicit_account_creation_fee = constant Boolean.typ false
       ; update =
@@ -178,6 +185,11 @@ struct
                   Inner_user_state.fine
                     { next_deposit = Some prev_next_deposit }
                   |> var_to_precondition_fine
+              ; nonce =
+                  Zkapp_basic.Or_ignore.Checked.make_unsafe Boolean.true_
+                    { Zkapp_precondition.Closed_interval.lower = prev_nonce
+                    ; upper = prev_nonce
+                    }
               }
           }
       }

--- a/src/app/zeko/circuits/rule_bridge_finalize_withdrawal.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_withdrawal.ml
@@ -32,6 +32,8 @@ module Make (Inputs : sig
 
   val bridge_fee_recipient_l2 : PC.t
 
+  val outer_account_creation_fee : Currency.Fee.t
+
   val chain_l1 : Mina_signature_kind.t
 
   val chain_l2 : Mina_signature_kind.t
@@ -290,8 +292,7 @@ struct
           let* () = Boolean.Assert.is_true (Boolean.not underflow) in
           let account_creation_fee =
             constant Currency.Amount.typ
-              (Currency.Amount.of_fee
-                 Zeko_constants.constraint_constants.account_creation_fee )
+              (Currency.Amount.of_fee outer_account_creation_fee)
           in
           let* paid_for_helper_account_creation, `Underflow underflow =
             Currency.Amount.Checked.sub_flagged recipient_payout

--- a/src/app/zeko/circuits/rule_bridge_finalize_withdrawal.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_withdrawal.ml
@@ -81,6 +81,7 @@ struct
       ; helper_token_owner_l1_vk_hash : F.t
       ; l2_holder_vk_hash : F.t
       ; prev_nonce : Checked32.t
+      ; helper_account_new : Boolean.t
       }
     [@@deriving snarky]
   end
@@ -102,6 +103,7 @@ struct
                ; helper_token_owner_l1_vk_hash
                ; l2_holder_vk_hash
                ; prev_nonce
+               ; helper_account_new
                } =
           exists Witness.typ ~compute:(V.get w)
         in
@@ -195,7 +197,10 @@ struct
               { default_account_update.preconditions with
                 account =
                   { default_account_update.preconditions.account with
-                    state =
+                    is_new =
+                      Zkapp_basic.Or_ignore.Checked.make_unsafe Boolean.true_
+                        helper_account_new
+                  ; state =
                       Outer_user_state.fine
                         { next_cancelled_deposit = None
                         ; next_withdrawal = Some prev_next_withdrawal
@@ -272,14 +277,25 @@ struct
           ; events
           }
         in
-        let fee_balance_change =
-          Currency.Amount.Signed.Checked.of_unsigned
-            (constant Currency.Amount.typ bridge_proof_fee)
-        in
-        let* recipient_balance_change =
-          Currency.Amount.Signed.Checked.add
-            (Currency.Amount.Signed.Checked.of_unsigned base_params.amount)
-            (Currency.Amount.Signed.Checked.negate fee_balance_change)
+        let bridge_proof_fee = constant Currency.Amount.typ bridge_proof_fee in
+        let* recipient_payout =
+          let* recipient_payout, `Underflow underflow =
+            Currency.Amount.Checked.sub_flagged base_params.amount
+              bridge_proof_fee
+          in
+          let* () = Boolean.Assert.is_true (Boolean.not underflow) in
+          let account_creation_fee =
+            constant Currency.Amount.typ
+              (Currency.Amount.of_fee
+                 Zeko_constants.constraint_constants.account_creation_fee )
+          in
+          let* paid_for_helper_account_creation, `Underflow underflow =
+            Currency.Amount.Checked.sub_flagged recipient_payout
+              account_creation_fee
+          in
+          let* () = Boolean.Assert.is_true (Boolean.not underflow) in
+          if_ ~typ:Currency.Amount.typ helper_account_new
+            ~then_:paid_for_helper_account_creation ~else_:recipient_payout
         in
         let recipient_payout =
           { default_account_update with
@@ -287,8 +303,9 @@ struct
           ; token_id = constant Token_id.typ token_id_l1
           ; may_use_token = constant May_use_token.typ Parents_own_token
           ; authorization_kind = constant A.typ None_given
-          ; balance_change = recipient_balance_change
-          ; implicit_account_creation_fee = constant Boolean.typ false
+          ; balance_change =
+              Currency.Amount.Signed.Checked.of_unsigned recipient_payout
+          ; implicit_account_creation_fee = constant Boolean.typ true
           }
         in
         let sequencer_fee_payout =
@@ -297,8 +314,9 @@ struct
           ; token_id = constant Token_id.typ token_id_l1
           ; may_use_token = constant May_use_token.typ Parents_own_token
           ; authorization_kind = constant A.typ None_given
-          ; balance_change = fee_balance_change
-          ; implicit_account_creation_fee = constant Boolean.typ false
+          ; balance_change =
+              Currency.Amount.Signed.Checked.of_unsigned bridge_proof_fee
+          ; implicit_account_creation_fee = constant Boolean.typ true
           }
         in
         let@ () = with_label __LOC__ in

--- a/src/app/zeko/circuits/rule_bridge_finalize_withdrawal.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_withdrawal.ml
@@ -30,6 +30,8 @@ module Make (Inputs : sig
 
   val bridge_fee_recipient_l1 : PC.t
 
+  val bridge_fee_recipient_l2 : PC.t
+
   val chain_l1 : Mina_signature_kind.t
 
   val chain_l2 : Mina_signature_kind.t
@@ -126,6 +128,8 @@ struct
           let* action =
             withdrawal_action ~chain_l2 ~holder_account_l2 ~token_owner_l2
               ~l2_holder_vk_hash
+              ~bridge_fee_recipient_l2:(constant PC.typ bridge_fee_recipient_l2)
+              ~bridge_proof_fee:(constant Currency.Amount.typ bridge_proof_fee)
               (module Withdrawal_params)
               withdrawal_params
           in

--- a/src/app/zeko/circuits/rule_bridge_finalize_withdrawal.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_withdrawal.ml
@@ -80,6 +80,7 @@ struct
       ; withdrawal_params : Withdrawal_params.t
       ; helper_token_owner_l1_vk_hash : F.t
       ; l2_holder_vk_hash : F.t
+      ; prev_nonce : Checked32.t
       }
     [@@deriving snarky]
   end
@@ -100,6 +101,7 @@ struct
                ; withdrawal_params
                ; helper_token_owner_l1_vk_hash
                ; l2_holder_vk_hash
+               ; prev_nonce
                } =
           exists Witness.typ ~compute:(V.get w)
         in
@@ -167,12 +169,17 @@ struct
           }
         in
         let@ () = with_label __LOC__ in
+        let prev_nonce =
+          Mina_numbers.Account_nonce.Checked.Unsafe.of_field
+            (Checked32.Checked.to_field prev_nonce)
+        in
         let helper_account =
           { default_account_update with
             public_key = base_params.recipient
           ; token_id = helper_token_id
           ; authorization_kind = authorization_signed ()
           ; use_full_commitment = Boolean.false_
+          ; increment_nonce = Boolean.true_
           ; may_use_token = constant May_use_token.typ Parents_own_token
           ; implicit_account_creation_fee = constant Boolean.typ false
           ; update =
@@ -194,6 +201,11 @@ struct
                         ; next_withdrawal = Some prev_next_withdrawal
                         }
                       |> var_to_precondition_fine
+                  ; nonce =
+                      Zkapp_basic.Or_ignore.Checked.make_unsafe Boolean.true_
+                        { Zkapp_precondition.Closed_interval.lower = prev_nonce
+                        ; upper = prev_nonce
+                        }
                   }
               }
           }

--- a/src/app/zeko/circuits/rule_bridge_finalize_withdrawal.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_withdrawal.ml
@@ -26,6 +26,10 @@ module Make (Inputs : sig
 
   val withdrawal_delay : Mina_numbers.Global_slot_span.t
 
+  val bridge_proof_fee : Currency.Amount.t
+
+  val bridge_fee_recipient_l1 : PC.t
+
   val chain_l1 : Mina_signature_kind.t
 
   val chain_l2 : Mina_signature_kind.t
@@ -168,7 +172,7 @@ struct
             public_key = base_params.recipient
           ; token_id = helper_token_id
           ; authorization_kind = authorization_signed ()
-          ; use_full_commitment = Boolean.true_
+          ; use_full_commitment = Boolean.false_
           ; may_use_token = constant May_use_token.typ Parents_own_token
           ; implicit_account_creation_fee = constant Boolean.typ false
           ; update =
@@ -256,11 +260,42 @@ struct
           ; events
           }
         in
+        let fee_balance_change =
+          Currency.Amount.Signed.Checked.of_unsigned
+            (constant Currency.Amount.typ bridge_proof_fee)
+        in
+        let* recipient_balance_change =
+          Currency.Amount.Signed.Checked.add
+            (Currency.Amount.Signed.Checked.of_unsigned base_params.amount)
+            (Currency.Amount.Signed.Checked.negate fee_balance_change)
+        in
+        let recipient_payout =
+          { default_account_update with
+            public_key = base_params.recipient
+          ; token_id = constant Token_id.typ token_id_l1
+          ; may_use_token = constant May_use_token.typ Parents_own_token
+          ; authorization_kind = constant A.typ None_given
+          ; balance_change = recipient_balance_change
+          ; implicit_account_creation_fee = constant Boolean.typ false
+          }
+        in
+        let sequencer_fee_payout =
+          { default_account_update with
+            public_key = constant PC.typ bridge_fee_recipient_l1
+          ; token_id = constant Token_id.typ token_id_l1
+          ; may_use_token = constant May_use_token.typ Parents_own_token
+          ; authorization_kind = constant A.typ None_given
+          ; balance_change = fee_balance_change
+          ; implicit_account_creation_fee = constant Boolean.typ false
+          }
+        in
         let@ () = with_label __LOC__ in
         let*| out =
           make_outputs ~chain:chain_l1 account_update
             [ (helper_token_owner, [ (helper_account, []) ])
             ; (witness_outer, [])
+            ; (recipient_payout, [])
+            ; (sequencer_fee_payout, [])
             ]
         in
         Compile_simple.

--- a/src/app/zeko/circuits/rule_commit.ml
+++ b/src/app/zeko/circuits/rule_commit.ml
@@ -131,6 +131,8 @@ module Make (Inputs : sig
 
   val chain_l1 : Mina_signature_kind.t
 
+  val chain_l2 : Mina_signature_kind.t
+
   val max_sequencer_inactivity : int
 
   val emergency_da_public_key : PC.t
@@ -273,7 +275,7 @@ struct
                          Zeko_constants.da_layer_check_salt )
                     (Random_oracle.Checked.pack_input input) )
             in
-            Multisig.check ~signature_kind:chain_l1 da_multisig payload
+            Multisig.check ~signature_kind:chain_l2 da_multisig payload
           in
           let*| da_key = Multisig.of_witness_var da_multisig in
           Some da_key

--- a/src/app/zeko/message_queue/message_queue.ml
+++ b/src/app/zeko/message_queue/message_queue.ml
@@ -87,7 +87,7 @@ module Worker = struct
         { Qos.prefetch_size = 0; prefetch_count = 1; global = false }
     in
     let%bind queue =
-      Amqp.Queue.declare channel
+      Amqp.Queue.declare channel ~durable:true
         ~arguments:
           [ Rpc.Server.queue_argument
           ; ("x-max-priority", Amqp.Types.VLonglong 5)

--- a/src/app/zeko/sequencer/.claude/scheduled_tasks.lock
+++ b/src/app/zeko/sequencer/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"e8d4355a-a5e5-4e6e-ab78-93d502bb1ff6","pid":24881,"procStart":"Wed May  6 21:08:45 2026","acquiredAt":1778107310223}

--- a/src/app/zeko/sequencer/cli.ml
+++ b/src/app/zeko/sequencer/cli.ml
@@ -382,7 +382,7 @@ let update_inner_verification_keys =
            >>| fun { ledger_hash; _ } -> ledger_hash
          in
          let da_config = Da_layer.Client.Config.of_string_list [ da_node ] in
-         let%bind ledger, imt =
+         let ledger, imt =
            match db_path with
            | Some db_path ->
                let ledger =
@@ -395,9 +395,8 @@ let update_inner_verification_keys =
                    ~directory_name:(db_path ^ "/imt")
                    ~depth:Zeko_constants.constraint_constants.ledger_depth ()
                in
-               return (ledger, imt)
+               (ledger, imt)
            | None ->
-               (* Sync ledger *)
                let ledger =
                  Ledger.create_ephemeral
                    ~depth:Zeko_constants.constraint_constants.ledger_depth ()
@@ -406,40 +405,42 @@ let update_inner_verification_keys =
                  Indexed_merkle_tree.Db.create
                    ~depth:Zeko_constants.constraint_constants.ledger_depth ()
                in
-               let%map () =
-                 Da_layer.Client.map_diffs ~logger ~config:da_config
-                   ~depth:Zeko_constants.constraint_constants.ledger_depth
-                   ~source_ledger_hash:`Genesis
-                   ~target_ledger_hash:commited_ledger_hash ()
-                   ~f:(fun ~current_chunk ~current_diff:_ ~chunks_length diff ->
-                     assert (
-                       Ledger_hash.equal
-                         (Da_layer.Diff.Stable.Latest.source_ledger_hash diff)
-                         (Ledger.merkle_root ledger) ) ;
-                     let progress =
-                       Float.of_int current_chunk /. Float.of_int chunks_length
-                     in
-                     [%log info] "Sync progress: %.2f%%" (progress *. 100.0) ;
-                     let changed_accounts =
-                       Da_layer.Diff.Stable.Latest.changed_accounts diff
-                       |> List.sort ~compare:(fun (a, _) (b, _) ->
-                              Int.compare a b )
-                     in
-                     List.iter changed_accounts ~f:(fun (index, account) ->
-                         Ledger.set_at_index_exn ledger index account ) ;
-                     (* Add to Indexed Merkle Tree *)
-                     List.iter changed_accounts ~f:(fun (_, account) ->
-                         let aid = Account.identifier account in
-                         let _w =
-                           Indexed_merkle_tree.Db.get_or_create_entry_exn imt
-                             (Account_id.derive_token_id ~owner:aid)
-                         in
-                         () ) ;
-                     return () )
-                 >>| Or_error.ok_exn >>| ignore
-               in
                (ledger, imt)
          in
+
+         (* Sync ledger *)
+         let%bind () =
+           Da_layer.Client.map_diffs ~logger ~config:da_config
+             ~depth:Zeko_constants.constraint_constants.ledger_depth
+             ~source_ledger_hash:(`Specific (Ledger.merkle_root ledger))
+             ~target_ledger_hash:commited_ledger_hash ()
+             ~f:(fun ~current_chunk ~current_diff:_ ~chunks_length diff ->
+               assert (
+                 Ledger_hash.equal
+                   (Da_layer.Diff.Stable.Latest.source_ledger_hash diff)
+                   (Ledger.merkle_root ledger) ) ;
+               let progress =
+                 Float.of_int current_chunk /. Float.of_int chunks_length
+               in
+               [%log info] "Sync progress: %.2f%%" (progress *. 100.0) ;
+               let changed_accounts =
+                 Da_layer.Diff.Stable.Latest.changed_accounts diff
+                 |> List.sort ~compare:(fun (a, _) (b, _) -> Int.compare a b)
+               in
+               List.iter changed_accounts ~f:(fun (index, account) ->
+                   Ledger.set_at_index_exn ledger index account ) ;
+               (* Add to Indexed Merkle Tree *)
+               List.iter changed_accounts ~f:(fun (_, account) ->
+                   let aid = Account.identifier account in
+                   let _w =
+                     Indexed_merkle_tree.Db.get_or_create_entry_exn imt
+                       (Account_id.derive_token_id ~owner:aid)
+                   in
+                   () ) ;
+               return () )
+           >>| Or_error.ok_exn >>| ignore
+         in
+         Core.printf "Synced ledger\n%!" ;
 
          let pp label (real_vk, old_vk) =
            let hash = Compile_simple.Verification_key.hash real_vk in
@@ -473,6 +474,7 @@ let update_inner_verification_keys =
          in
 
          (* Get compiled vks *)
+         printf "Compiling circuits\n%!" ;
          let%bind inner_vk =
            Lazy.force Inner_rules_inst.tag
            |> Compile_simple.Verification_key.of_tag |> Promise.to_deferred
@@ -558,6 +560,7 @@ let update_inner_verification_keys =
                     Account_id.derive_token_id
                       ~owner:(Account.identifier account) )
            in
+           printf "Distributing diff\n%!" ;
            let%bind () =
              Da_layer.Client.distribute_diff ~logger ~config:da_config
                ~ledger_openings

--- a/src/app/zeko/sequencer/cli.ml
+++ b/src/app/zeko/sequencer/cli.ml
@@ -69,15 +69,11 @@ let send_direct ~logger ~l1_uri ~(signers : Keypair.t list)
             ; fee = Currency.Fee.of_mina_string_exn "0.1"
             ; valid_until = None
             ; nonce
-            }
         ; authorization = Signature.dummy
-        }
-    ; account_updates
-    ; memo = Signed_command_memo.empty
     }
   in
   let command =
-    Utils.sign_zkapp_command ~signature_kind command ([ fee_signer ] @ signers)
+    Utils.sign_zkapp_command ~signature_kind command ( fee_signer :: signers)
     |> Zkapp_command.read_all_proofs_from_disk
   in
   match%map Gql_client.send_zkapp l1_uri command with
@@ -483,9 +479,9 @@ let update_inner_verification_keys =
            Lazy.force Bridge_inst_mina.System_L2.tag
            |> Compile_simple.Verification_key.of_tag |> Promise.to_deferred
          in
-         (* let deploy_config =
-              Option.value_exn Zeko_circuits_config.deploy_config
-            in *)
+         let deploy_config =
+           Option.value_exn Zeko_circuits_config.deploy_config
+         in
          let inner =
            ( inner_vk
            , fetched_inner_vk

--- a/src/app/zeko/sequencer/cli.ml
+++ b/src/app/zeko/sequencer/cli.ml
@@ -151,6 +151,7 @@ let generate_circuits_config =
            ; withdrawal_delay = Mina_numbers.Global_slot_span.of_int 5
            ; bridge_fee_recipient_l1 = fst bridge_fee_recipient_l1
            ; bridge_fee_recipient_l2 = fst bridge_fee_recipient_l2
+           ; outer_account_creation_fee = Currency.Fee.of_mina_string_exn "1"
            }
          in
          let deploy_config : Zeko_circuits_config.Deploy.t =

--- a/src/app/zeko/sequencer/cli.ml
+++ b/src/app/zeko/sequencer/cli.ml
@@ -138,6 +138,8 @@ let generate_circuits_config =
          let helper_token_owner_l1 = generate_keypair () in
          let zeko_l1 = generate_keypair () in
          let emergency_da = generate_keypair () in
+         let bridge_fee_recipient_l1 = generate_keypair () in
+         let bridge_fee_recipient_l2 = generate_keypair () in
          let t : Zeko_circuits_config.t =
            { chain_l1 = Testnet
            ; chain_l2 = Testnet
@@ -151,6 +153,8 @@ let generate_circuits_config =
            ; zeko_l1 = fst zeko_l1
            ; emergency_da_public_key = fst emergency_da
            ; withdrawal_delay = Mina_numbers.Global_slot_span.of_int 5
+           ; bridge_fee_recipient_l1 = fst bridge_fee_recipient_l1
+           ; bridge_fee_recipient_l2 = fst bridge_fee_recipient_l2
            }
          in
          let deploy_config : Zeko_circuits_config.Deploy.t =
@@ -158,6 +162,8 @@ let generate_circuits_config =
            ; helper_token_owner_l1 = snd helper_token_owner_l1
            ; zeko_l1 = snd zeko_l1
            ; emergency_da = snd emergency_da
+           ; bridge_fee_recipient_l1 = snd bridge_fee_recipient_l1
+           ; bridge_fee_recipient_l2 = snd bridge_fee_recipient_l2
            }
          in
          let circuits_config_json = Zeko_circuits_config.to_yojson t in

--- a/src/app/zeko/sequencer/cli.ml
+++ b/src/app/zeko/sequencer/cli.ml
@@ -69,11 +69,15 @@ let send_direct ~logger ~l1_uri ~(signers : Keypair.t list)
             ; fee = Currency.Fee.of_mina_string_exn "0.1"
             ; valid_until = None
             ; nonce
+            }
         ; authorization = Signature.dummy
+        }
+    ; account_updates
+    ; memo = Signed_command_memo.empty
     }
   in
   let command =
-    Utils.sign_zkapp_command ~signature_kind command ( fee_signer :: signers)
+    Utils.sign_zkapp_command ~signature_kind command (fee_signer :: signers)
     |> Zkapp_command.read_all_proofs_from_disk
   in
   match%map Gql_client.send_zkapp l1_uri command with
@@ -481,9 +485,6 @@ let update_inner_verification_keys =
          and bridge_holder_vk =
            Lazy.force Bridge_inst_mina.System_L2.tag
            |> Compile_simple.Verification_key.of_tag |> Promise.to_deferred
-         in
-         let deploy_config =
-           Option.value_exn Zeko_circuits_config.deploy_config
          in
          let inner =
            ( inner_vk

--- a/src/app/zeko/sequencer/deploy.ml
+++ b/src/app/zeko/sequencer/deploy.ml
@@ -243,18 +243,21 @@ let run ~l1_uri ~sk ~ledger_input ~faucet_aid ~da_nodes ~pause_key
       in
 
       print_endline "(* Deploy contract *)" ;
-      match%bind
+      match%map
         Gql_client.send_zkapp l1_uri
           (Zkapp_command.read_all_proofs_from_disk command)
       with
       | Ok _ ->
-          Deferred.unit
+          let txn_hash =
+            Mina_transaction.Transaction_hash.hash_command
+              (Zkapp_command (Zkapp_command.read_all_proofs_from_disk command))
+          in
+          [%log info] "Successfully sent zkapp command: %s"
+            (Mina_transaction.Transaction_hash.to_base58_check txn_hash)
       | Error (`Failed_request err) ->
-          eprintf "Failed request: %s\n%!" err ;
-          Deferred.unit
+          [%log error] "Failed request: %s" err
       | Error (`Graphql_error err) ->
-          eprintf "Graphql error: %s\n%!" err ;
-          Deferred.unit )
+          [%log error] "Graphql error: %s" err )
 
 let deploy_all =
   ( "deploy-all"

--- a/src/app/zeko/sequencer/deploy.ml
+++ b/src/app/zeko/sequencer/deploy.ml
@@ -256,66 +256,123 @@ let run ~l1_uri ~sk ~ledger_input ~faucet_aid ~da_nodes ~pause_key
           eprintf "Graphql error: %s\n%!" err ;
           Deferred.unit )
 
+let deploy_all =
+  ( "deploy-all"
+  , Command.basic ~summary:"Deploy zeko zkapp"
+      (let%map_open.Command l1_uri =
+         flag "--l1-uri" (required string) ~doc:"string L1 URI"
+       and ledger_input =
+         flag "--ledger-input" (optional string)
+           ~doc:"string Path to the json dump of the ledger"
+       and faucet_account =
+         flag "--faucet-account" (optional string)
+           ~doc:"string Faucet public key"
+       and da_nodes =
+         flag "--da-node" (listed string)
+           ~doc:"string Address of the DA node, can be supplied multiple times"
+       and pause_key =
+         flag "--pause-key" (required string) ~doc:"string Pause key"
+       and sequencer_key =
+         flag "--sequencer-key" (required string) ~doc:"string Sequencer key"
+       and da_keys =
+         flag "--da-keys" (required string)
+           ~doc:"string List of DA keys, separated by commas"
+       and da_quorum =
+         flag "--da-quorum" (required int)
+           ~doc:"int Quorum for the DA signature count"
+       and account_creation_fee =
+         flag "--account-creation-fee" (required string)
+           ~doc:"float Account creation fee in mina"
+       in
+       let sk = Sys.getenv_exn "MINA_PRIVATE_KEY" in
+       let da_nodes =
+         List.mapi da_nodes ~f:(fun i uri ->
+             Cli_lib.Flag.Types.
+               { value = Host_and_port.of_string uri
+               ; name = sprintf "da-node-%d" i
+               } )
+       in
+       let faucet_aid =
+         Option.map faucet_account ~f:(fun pk ->
+             Public_key.Compressed.of_base58_check_exn pk
+             |> Public_key.decompress_exn |> Account_id.of_public_key )
+       in
+       let string_to_even_pc x =
+         Public_key.Compressed.of_base58_check_exn x
+         |> Zeko_types.Even_PC.create |> Or_error.ok
+       in
+       let da_keys =
+         String.split ~on:',' da_keys
+         |> List.map ~f:Public_key.Compressed.of_base58_check_exn
+       in
+       let pause_key =
+         string_to_even_pc pause_key
+         |> Option.value_exn ~message:"Pause key odd"
+       in
+       let sequencer_key =
+         string_to_even_pc sequencer_key
+         |> Option.value_exn ~message:"Sequencer key odd"
+       in
+       let account_creation_fee =
+         Currency.Fee.of_mina_string_exn account_creation_fee
+       in
+       let l1_uri = Uri.of_string l1_uri in
+       run ~l1_uri ~sk ~ledger_input ~faucet_aid ~da_nodes ~pause_key
+         ~sequencer_key ~da_keys ~da_quorum ~account_creation_fee ) )
+
+let deploy_token_owner =
+  ( "deploy-token-owner"
+  , Command.basic ~summary:"Deploy zeko token owner"
+      (let%map_open.Command l1_uri =
+         flag "--l1-uri" (required string) ~doc:"string L1 URI"
+       and account_creation_fee =
+         flag "--account-creation-fee" (required string)
+           ~doc:"float Account creation fee in mina"
+       in
+       fun () ->
+         let sk = Sys.getenv_exn "MINA_PRIVATE_KEY" in
+         let account_creation_fee =
+           Currency.Fee.of_mina_string_exn account_creation_fee
+         in
+         let l1_uri = Uri.of_string l1_uri in
+
+         let sender_keypair =
+           Keypair.of_private_key_exn @@ Private_key.of_base58_check_exn sk
+         in
+         let deploy_config =
+           Option.value_exn ~message:"ZEKO_DEPLOY_CONFIG is not set"
+             Zeko_circuits_config.deploy_config
+         in
+         let token_owner_kp =
+           Keypair.of_private_key_exn deploy_config.helper_token_owner_l1
+         in
+         let logger = Logger.create () in
+         Thread_safe.block_on_async_exn (fun () ->
+             let%bind nonce =
+               Gql_client.infer_nonce ~logger l1_uri
+                 (Public_key.compress sender_keypair.public_key)
+               >>| Or_error.ok_exn
+             in
+             let%bind command =
+               Sequencer_lib.Deploy.deploy_token_owner_exn
+                 ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+                 ~signer:sender_keypair ~token_owner_kp
+                 ~fee:(Currency.Fee.of_mina_int_exn 1)
+                 ~nonce ~account_creation_fee ()
+             in
+             match%bind
+               Gql_client.send_zkapp l1_uri
+                 (Zkapp_command.read_all_proofs_from_disk command)
+             with
+             | Ok _ ->
+                 Deferred.unit
+             | Error (`Failed_request err) ->
+                 eprintf "Failed request: %s\n%!" err ;
+                 Deferred.unit
+             | Error (`Graphql_error err) ->
+                 eprintf "Graphql error: %s\n%!" err ;
+                 Deferred.unit ) ) )
+
 let () =
-  Command_unix.run
-  @@ Command.basic ~summary:"Deploy zeko zkapp"
-       (let%map_open.Command l1_uri =
-          flag "--l1-uri" (required string) ~doc:"string L1 URI"
-        and ledger_input =
-          flag "--ledger-input" (optional string)
-            ~doc:"string Path to the json dump of the ledger"
-        and faucet_account =
-          flag "--faucet-account" (optional string)
-            ~doc:"string Faucet public key"
-        and da_nodes =
-          flag "--da-node" (listed string)
-            ~doc:"string Address of the DA node, can be supplied multiple times"
-        and pause_key =
-          flag "--pause-key" (required string) ~doc:"string Pause key"
-        and sequencer_key =
-          flag "--sequencer-key" (required string) ~doc:"string Sequencer key"
-        and da_keys =
-          flag "--da-keys" (required string)
-            ~doc:"string List of DA keys, separated by commas"
-        and da_quorum =
-          flag "--da-quorum" (required int)
-            ~doc:"int Quorum for the DA signature count"
-        and account_creation_fee =
-          flag "--account-creation-fee" (required string)
-            ~doc:"float Account creation fee in mina"
-        in
-        let sk = Sys.getenv_exn "MINA_PRIVATE_KEY" in
-        let da_nodes =
-          List.mapi da_nodes ~f:(fun i uri ->
-              Cli_lib.Flag.Types.
-                { value = Host_and_port.of_string uri
-                ; name = sprintf "da-node-%d" i
-                } )
-        in
-        let faucet_aid =
-          Option.map faucet_account ~f:(fun pk ->
-              Public_key.Compressed.of_base58_check_exn pk
-              |> Public_key.decompress_exn |> Account_id.of_public_key )
-        in
-        let string_to_even_pc x =
-          Public_key.Compressed.of_base58_check_exn x
-          |> Zeko_types.Even_PC.create |> Or_error.ok
-        in
-        let da_keys =
-          String.split ~on:',' da_keys
-          |> List.map ~f:Public_key.Compressed.of_base58_check_exn
-        in
-        let pause_key =
-          string_to_even_pc pause_key
-          |> Option.value_exn ~message:"Pause key odd"
-        in
-        let sequencer_key =
-          string_to_even_pc sequencer_key
-          |> Option.value_exn ~message:"Sequencer key odd"
-        in
-        let account_creation_fee =
-          Currency.Fee.of_mina_string_exn account_creation_fee
-        in
-        let l1_uri = Uri.of_string l1_uri in
-        run ~l1_uri ~sk ~ledger_input ~faucet_aid ~da_nodes ~pause_key
-          ~sequencer_key ~da_keys ~da_quorum ~account_creation_fee )
+  Command.group ~summary:"Sequencer CLI" [ deploy_all; deploy_token_owner ]
+  |> Command_unix.run

--- a/src/app/zeko/sequencer/gql_client/gql_client.ml
+++ b/src/app/zeko/sequencer/gql_client/gql_client.ml
@@ -379,6 +379,36 @@ let fetch_state_opt uri aid =
                |> List.map ~f:Field.of_string
                |> Zkapp_state.V.of_list_exn )) )
 
+let fetch_nonce_opt uri aid =
+  let q =
+    object
+      method query =
+        String.substr_replace_all ~pattern:"\n" ~with_:" "
+          {|
+            query ($pk: PublicKey!, $tokenId: TokenId!) {
+              account(publicKey: $pk, token: $tokenId){
+                nonce
+              }
+            }
+          |}
+
+      method variables =
+        `Assoc
+          [ ( "pk"
+            , `String
+                ( Account_id.public_key aid
+                |> Signature_lib.Public_key.Compressed.to_base58_check ) )
+          ; ("tokenId", `String (Account_id.token_id aid |> Token_id.to_string))
+          ]
+    end
+  in
+  query_with_retry ~label:"fetch nonce" q uri ~f:(fun result ->
+      Yojson.Safe.Util.(
+        result |> member "account"
+        |> to_option (fun json ->
+               member "nonce" json |> to_string |> Int.of_string
+               |> Unsigned.UInt32.of_int )) )
+
 let fetch_vk uri aid =
   let q =
     object

--- a/src/app/zeko/sequencer/gql_client/gql_client.ml
+++ b/src/app/zeko/sequencer/gql_client/gql_client.ml
@@ -440,6 +440,256 @@ let fetch_vk uri aid =
         |> member "verificationKey" |> to_string
         |> Side_loaded_verification_key.of_base64 |> Or_error.ok_exn) )
 
+let parse_auth_required = function
+  | "None" ->
+      Permissions.Auth_required.None
+  | "Either" ->
+      Either
+  | "Proof" ->
+      Proof
+  | "Signature" ->
+      Signature
+  | "Impossible" ->
+      Impossible
+  | s ->
+      failwithf "fetch_account: unknown AccountAuthRequired %s" s ()
+
+let parse_permissions json =
+  let open Yojson.Safe.Util in
+  let auth field = parse_auth_required (member field json |> to_string) in
+  let svk =
+    let svk = member "setVerificationKey" json in
+    ( parse_auth_required (member "auth" svk |> to_string)
+    , Mina_numbers.Txn_version.of_string (member "txnVersion" svk |> to_string)
+    )
+  in
+  Permissions.Poly.
+    { edit_state = auth "editState"
+    ; access = auth "access"
+    ; send = auth "send"
+    ; receive = auth "receive"
+    ; set_delegate = auth "setDelegate"
+    ; set_permissions = auth "setPermissions"
+    ; set_verification_key = svk
+    ; set_zkapp_uri = auth "setZkappUri"
+    ; edit_action_state = auth "editActionState"
+    ; set_token_symbol = auth "setTokenSymbol"
+    ; increment_nonce = auth "incrementNonce"
+    ; set_voting_for = auth "setVotingFor"
+    ; set_timing = auth "setTiming"
+    }
+
+(* GraphQL exposes the timing fields flatly. They are all null on an Untimed
+   account; on a Timed account they are all set. We use [cliffTime] as the
+   discriminator. *)
+let parse_timing json : Account_timing.t =
+  let open Yojson.Safe.Util in
+  match member "cliffTime" json with
+  | `Null ->
+      Untimed
+  | _ ->
+      (* Mina graphql's Balance/Amount scalars serialize via the type's
+         [to_string], which for [Currency.*] is [Unsigned.to_string] — raw
+         nanomina as a decimal string ("1000000000000"). Parse as such, not as
+         a mina-formatted decimal. *)
+      let initial_minimum_balance =
+        member "initialMinimumBalance" json
+        |> to_string |> Currency.Balance.of_string
+      in
+      let cliff_time =
+        member "cliffTime" json
+        |> to_string |> Mina_numbers.Global_slot_since_genesis.of_string
+      in
+      let cliff_amount =
+        member "cliffAmount" json |> to_string |> Currency.Amount.of_string
+      in
+      let vesting_period =
+        member "vestingPeriod" json
+        |> to_string |> Mina_numbers.Global_slot_span.of_string
+      in
+      let vesting_increment =
+        member "vestingIncrement" json |> to_string |> Currency.Amount.of_string
+      in
+      Timed
+        { initial_minimum_balance
+        ; cliff_time
+        ; cliff_amount
+        ; vesting_period
+        ; vesting_increment
+        }
+
+let parse_zkapp ~logger json : Zkapp_account.t option =
+  let open Yojson.Safe.Util in
+  match member "zkappUri" json with
+  | `Null ->
+      None
+  | _ ->
+      let app_state =
+        member "zkappState" json |> to_list |> List.map ~f:to_string
+        |> List.map ~f:Field.of_string
+        |> Zkapp_state.V.of_list_exn
+      in
+      let action_state =
+        match
+          member "actionState" json |> to_list |> List.map ~f:to_string
+          |> List.map ~f:Field.of_string
+        with
+        | [ a; b; c; d; e ] ->
+            Pickles_types.Vector.[ a; b; c; d; e ]
+        | _ ->
+            failwith "fetch_account: actionState must have 5 elements"
+      in
+      let verification_key =
+        match member "verificationKey" json with
+        | `Null ->
+            None
+        | vk ->
+            let data =
+              member "verificationKey" vk
+              |> to_string |> Side_loaded_verification_key.of_base64
+              |> Or_error.ok_exn
+            in
+            let hash =
+              member "hash" vk |> to_string |> Field.of_string
+            in
+            Some { With_hash.data; hash }
+      in
+      let proved_state = member "provedState" json |> to_bool in
+      let zkapp_uri = member "zkappUri" json |> to_string in
+      ignore logger ;
+      Some
+        { Zkapp_account.default with
+          app_state
+        ; verification_key
+        ; action_state
+        ; proved_state
+        ; zkapp_uri
+        }
+
+let fetch_account ~logger uri (aid : Account_id.t) :
+    Account.t option Deferred.Or_error.t =
+  let q =
+    object
+      method query =
+        String.substr_replace_all ~pattern:"\n" ~with_:" "
+          {|
+            query ($pk: PublicKey!, $tokenId: TokenId!) {
+              account(publicKey: $pk, token: $tokenId) {
+                publicKey
+                tokenId
+                tokenSymbol
+                balance { total }
+                nonce
+                receiptChainHash
+                delegate
+                votingFor
+                timing {
+                  initialMinimumBalance
+                  cliffTime
+                  cliffAmount
+                  vestingPeriod
+                  vestingIncrement
+                }
+                permissions {
+                  editState
+                  access
+                  send
+                  receive
+                  setDelegate
+                  setPermissions
+                  setVerificationKey { auth txnVersion }
+                  setZkappUri
+                  editActionState
+                  setTokenSymbol
+                  incrementNonce
+                  setVotingFor
+                  setTiming
+                }
+                zkappState
+                zkappUri
+                actionState
+                verificationKey { verificationKey hash }
+                provedState
+              }
+            }
+          |}
+
+      method variables =
+        `Assoc
+          [ ( "pk"
+            , `String
+                ( Account_id.public_key aid
+                |> Signature_lib.Public_key.Compressed.to_base58_check ) )
+          ; ("tokenId", `String (Account_id.token_id aid |> Token_id.to_string))
+          ]
+    end
+  in
+  query_with_retry ~label:"fetch account" ~logger q uri ~f:(fun result ->
+      let open Yojson.Safe.Util in
+      match member "account" result with
+      | `Null ->
+          None
+      | json ->
+          let public_key =
+            member "publicKey" json
+            |> to_string
+            |> Signature_lib.Public_key.Compressed.of_base58_check_exn
+          in
+          let token_id =
+            member "tokenId" json |> to_string |> Token_id.of_string
+          in
+          let token_symbol =
+            member "tokenSymbol" json |> to_string
+          in
+          let balance =
+            (* See note above on Balance/Amount scalar serialization. *)
+            member "balance" json |> member "total" |> to_string
+            |> Currency.Balance.of_string
+          in
+          let nonce =
+            member "nonce" json |> to_string |> Account.Nonce.of_string
+          in
+          let receipt_chain_hash =
+            member "receiptChainHash" json |> to_string
+            |> Receipt.Chain_hash.of_base58_check_exn
+          in
+          let delegate =
+            match member "delegate" json with
+            | `Null ->
+                None
+            | d ->
+                Some
+                  ( to_string d
+                  |> Signature_lib.Public_key.Compressed.of_base58_check_exn )
+          in
+          let voting_for =
+            (* Mina graphql declares both [receiptChainHash] and [votingFor]
+               as the [chain_hash] scalar (see [mina_graphql/types.ml]). The
+               encoding uses [Receipt.Chain_hash]'s version byte (0x0C), even
+               though [Account.t.voting_for] is a [State_hash.t]. Both share
+               the same underlying [Field.t], so we round-trip through it. *)
+            member "votingFor" json |> to_string
+            |> Receipt.Chain_hash.of_base58_check_exn
+            |> Receipt.Chain_hash.to_field |> State_hash.of_hash
+          in
+          let timing = parse_timing (member "timing" json) in
+          let permissions = parse_permissions (member "permissions" json) in
+          let zkapp = parse_zkapp ~logger json in
+          Some
+            (Account.of_poly
+               { public_key
+               ; token_id
+               ; token_symbol
+               ; balance
+               ; nonce
+               ; receipt_chain_hash
+               ; delegate
+               ; voting_for
+               ; timing
+               ; permissions
+               ; zkapp
+               } ) )
+
 let infer_state ~logger uri ~zkapp_pk ~signer_pk =
   let%map.Deferred.Result committed_state =
     fetch_state ~logger uri

--- a/src/app/zeko/sequencer/gql_client/gql_client.ml
+++ b/src/app/zeko/sequencer/gql_client/gql_client.ml
@@ -794,6 +794,27 @@ let fetch_best_chain ?(max_length = 10) uri =
         |> map (member "stateHash")
         |> to_list |> List.map ~f:to_string) )
 
+let fetch_account_creation_fee uri =
+  let q =
+    object
+      method query =
+        String.substr_replace_all ~pattern:"\n" ~with_:" "
+          {|
+            query {
+              genesisConstants {
+                accountCreationFee
+              }
+            }
+          |}
+
+      method variables = `Assoc []
+    end
+  in
+  query_with_retry ~label:"fetch account creation fee" q uri ~f:(fun result ->
+      Yojson.Safe.Util.(
+        result |> member "genesisConstants" |> member "accountCreationFee"
+        |> to_string |> Currency.Fee.of_string) )
+
 let fetch_genesis_timestamp uri =
   let q =
     object

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -204,12 +204,13 @@ module Deposit_request = struct
         ( Account_update.with_aux
             ~body:
               { Mina_base.Account_update.Body.dummy with
-                public_key = Zeko_circuits_config.Inputs.bridge_fee_recipient_l1
+                use_full_commitment = true
+              ; public_key = Zeko_circuits_config.Inputs.bridge_fee_recipient_l1
               ; balance_change =
                   Currency.Amount.Signed.of_unsigned
                     Zeko_circuits_config.Inputs.bridge_proof_fee
+              ; may_use_token = Parents_own_token
               ; authorization_kind = None_given
-              ; use_full_commitment = false
               }
             ~authorization:Control.Poly.None_given
         |> Account_update.read_all_proofs_from_disk )
@@ -220,7 +221,10 @@ module Deposit_request = struct
         { aux =
             Utils.value_to_hash ~init:Zeko_constants.deposit_salt
               Zeko_circuits.Bridge_state.Deposit_params_base.typ deposit_params
-        ; children = receive_forest @ fee_payout_forest
+        ; children =
+            Utils.rehash_forest
+              ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+              (receive_forest @ fee_payout_forest)
         ; slot_range = Slot_range.infinite
         }
     }

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -331,36 +331,16 @@ module Withdrawal_request = struct
     [@@deriving snarky]
   end
 
-  let make_witness t (withdrawal_params : Bridge_state.Withdrawal_params_base.t)
-      : Bridge.Inner_action_witness.serializable =
-    let inner_receive_witness =
-      Bridge.Inner_receive.of_serializable
-        ~vk_hash:t.verification_keys.bridge_mina_l2
-        { public_key = Zeko_circuits_config.Inputs.holder_account_l2
-        ; amount = withdrawal_params.amount
-        }
-    in
-    let _stmt, (inner_receive_body, _, inner_receive_calls) =
-      run_and_check_exn inner_receive_witness
-        Snark_params.Tick.Typ.(Mina_base.Zkapp_statement.typ * V.typ)
-        Bridge_inst_mina.Rule_bridge_inner_receive.main
-    in
-    let inner_receive_forest =
-      Zkapp_command.Call_forest.cons
-        ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
-        ~calls:inner_receive_calls
-        (Account_update.with_aux
-           ~body:
-             ( match Is_compile_simple_real.is_compile_simple_real with
-             | Some _ ->
-                 inner_receive_body
-             | None ->
-                 { inner_receive_body with authorization_kind = None_given } )
-           ~authorization:Control.Poly.None_given )
-        []
-      |> Zkapp_command.Call_forest.map
-           ~f:Account_update.read_all_proofs_from_disk
-    in
+  let make_inner_receive_witness t
+      (withdrawal_params : Bridge_state.Withdrawal_params_base.t) =
+    Bridge.Inner_receive.of_serializable
+      ~vk_hash:t.verification_keys.bridge_mina_l2
+      { public_key = Zeko_circuits_config.Inputs.holder_account_l2
+      ; amount = withdrawal_params.amount
+      }
+
+  let make_witness (withdrawal_params : Bridge_state.Withdrawal_params_base.t)
+      inner_receive_forest : Bridge.Inner_action_witness.serializable =
     let fee_payout_forest =
       Zkapp_command.Call_forest.cons
         ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
@@ -393,11 +373,35 @@ module Withdrawal_request = struct
     }
 
   let precompute_commitments t ({ withdrawal_params; transferrer } : t) =
+    let inner_receive_witness =
+      make_inner_receive_witness t withdrawal_params
+    in
+    let _stmt, (inner_receive_body, _, inner_receive_calls) =
+      run_and_check_exn inner_receive_witness
+        Snark_params.Tick.Typ.(Mina_base.Zkapp_statement.typ * V.typ)
+        Bridge_inst_mina.Rule_bridge_inner_receive.main
+    in
+    let inner_receive_forest =
+      Zkapp_command.Call_forest.cons
+        ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+        ~calls:inner_receive_calls
+        (Account_update.with_aux
+           ~body:
+             ( match Is_compile_simple_real.is_compile_simple_real with
+             | Some _ ->
+                 inner_receive_body
+             | None ->
+                 { inner_receive_body with authorization_kind = None_given } )
+           ~authorization:Control.Poly.None_given )
+        []
+      |> Zkapp_command.Call_forest.map
+           ~f:Account_update.read_all_proofs_from_disk
+    in
     let witness =
       Bridge.Inner_action_witness.of_serializable
         ~proof_cache_db:(Proof_cache_tag.create_identity_db ())
         ~vk_hash:t.verification_keys.inner_rules
-        (make_witness t withdrawal_params)
+        (make_witness withdrawal_params inner_receive_forest)
     in
     try
       let _stmt, (body, _, calls) =
@@ -464,7 +468,24 @@ module Withdrawal_request = struct
                   | Error e ->
                       Error.raise e
                 in
-                let witness = make_witness t withdrawal_params in
+                let%bind inner_receive_forest =
+                  match%map
+                    Zeko_prover.Client.inner_receive t.provers
+                      { public_key =
+                          Zeko_circuits_config.Inputs.holder_account_l2
+                      ; amount = withdrawal_params.amount
+                      }
+                  with
+                  | Error e ->
+                      Error.raise e
+                  | Ok ((body, _, calls), proof) ->
+                      Utils.attach_proof_to_forest
+                        ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+                        ~proof_cache_db:t.proof_cache_db ~body ~calls ~proof
+                in
+                let witness =
+                  make_witness withdrawal_params inner_receive_forest
+                in
                 match%map
                   Zeko_prover.Client.inner_action_witness t.provers witness
                 with

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -87,9 +87,40 @@ let transferrer_key ~signature_kind:_ transferrer =
   [%sexp_of: Account_update.Stable.Latest.t] transferrer |> Sexp.to_string
 
 let validate_transferrer ~expected_amount transferrer =
+  (* TODO *)
   let _ = expected_amount in
   let _ = transferrer in
   Ok ()
+
+let execute_request t ~logger ~(executor : Executor.t) (key, d) =
+  let%bind () = d in
+  Proofs_memory.get t.proofs_memory key
+  |> Option.value_exn |> snd
+  |> function
+  | `Pending ->
+      failwith "unreachable"
+  | `Done (Error e) ->
+      return (Error e)
+  | `Done (Ok forest) ->
+      let command : Zkapp_command.t =
+        { fee_payer =
+            Account_update.Fee_payer.make
+              ~body:
+                { public_key = Signer_service.Signer.public_key executor.signer
+                ; fee = Currency.Fee.zero
+                ; valid_until = None
+                ; nonce = Account.Nonce.zero
+                }
+              ~authorization:Signature.dummy
+        ; account_updates =
+            Zkapp_command.Call_forest.map forest
+              ~f:
+                (Account_update.write_all_proofs_to_disk
+                   ~proof_cache_db:(Proof_cache_tag.create_identity_db ()) )
+        ; memo = Signed_command_memo.empty
+        }
+      in
+      Executor.send_zkapp_command ~logger executor command
 
 module Deposit_request = struct
   type t =

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -178,10 +178,6 @@ module Deposit_request = struct
   let make_witness (deposit_params : Bridge_state.Deposit_params_base.t) :
       Bridge.Outer_action_witness.serializable =
     let receive_forest =
-      let user_children =
-        Zkapp_command.Call_forest.map deposit_params.children
-          ~f:Account_update.read_all_proofs_from_disk
-      in
       Zkapp_command.Call_forest.cons
         ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
         ( Account_update.with_aux
@@ -196,7 +192,7 @@ module Deposit_request = struct
               }
             ~authorization:Control.Poly.None_given
         |> Account_update.read_all_proofs_from_disk )
-        user_children
+        []
     in
     let fee_payout_forest =
       Zkapp_command.Call_forest.cons
@@ -371,20 +367,17 @@ module Withdrawal_request = struct
         ( Account_update.with_aux
             ~body:
               { Mina_base.Account_update.Body.dummy with
-                public_key = Zeko_circuits_config.Inputs.bridge_fee_recipient_l2
+                use_full_commitment = true
+              ; public_key = Zeko_circuits_config.Inputs.bridge_fee_recipient_l2
               ; balance_change =
                   Currency.Amount.Signed.of_unsigned
                     Zeko_circuits_config.Inputs.bridge_proof_fee
+              ; may_use_token = Parents_own_token
               ; authorization_kind = None_given
-              ; use_full_commitment = false
               }
             ~authorization:Control.Poly.None_given
         |> Account_update.read_all_proofs_from_disk )
         []
-    in
-    let user_children =
-      Zkapp_command.Call_forest.map withdrawal_params.children
-        ~f:Account_update.read_all_proofs_from_disk
     in
     { public_key = Zeko_circuits_config.Inputs.inner_public_key
     ; witness =
@@ -392,7 +385,10 @@ module Withdrawal_request = struct
             Utils.value_to_hash ~init:Zeko_constants.withdrawal_salt
               Zeko_circuits.Bridge_state.Withdrawal_params_base.typ
               withdrawal_params
-        ; children = inner_receive_forest @ fee_payout_forest @ user_children
+        ; children =
+            Utils.rehash_forest
+              ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+              (inner_receive_forest @ fee_payout_forest)
         }
     }
 

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -318,6 +318,7 @@ module Finalize_deposit = struct
     ; check_accepted_init : Bridge_inst_mina.Check_accepted.Definition.Init.t
     ; prev_next_deposit : Zeko_util.Checked32.t
     ; prev_nonce : Zeko_util.Checked32.t
+    ; helper_account_new : Zeko_util.Boolean.t
     }
   [@@deriving snarky]
 
@@ -326,6 +327,7 @@ module Finalize_deposit = struct
     ; check_accepted_init : Bridge_inst_mina.Check_accepted.Definition.Init.t
     ; prev_next_deposit : Zeko_util.Checked32.t
     ; prev_nonce : Zeko_util.Checked32.t
+    ; helper_account_new : Zeko_util.Boolean.t
     ; ase_elems : Field.t list
     ; check_accepted_elems :
         Bridge_inst_mina.Check_accepted.Definition.Elem.t list
@@ -336,6 +338,7 @@ module Finalize_deposit = struct
        ; check_accepted_init
        ; prev_next_deposit
        ; prev_nonce
+       ; helper_account_new
        ; ase_elems
        ; check_accepted_elems
        } :
@@ -346,7 +349,12 @@ module Finalize_deposit = struct
     in
     let t =
       typ.value_to_fields
-        { ase_source; check_accepted_init; prev_next_deposit; prev_nonce }
+        { ase_source
+        ; check_accepted_init
+        ; prev_next_deposit
+        ; prev_nonce
+        ; helper_account_new
+        }
       |> fst
     in
     let ase_elems = Array.of_list ase_elems in
@@ -368,6 +376,7 @@ module Finalize_deposit = struct
        ; check_accepted_elems
        ; prev_next_deposit
        ; prev_nonce
+       ; helper_account_new
        } as request :
         t_ ) =
     let key = key request in
@@ -395,7 +404,7 @@ module Finalize_deposit = struct
                     ~ase:(ase_source, ase_elems)
                     ~check_accepted:
                       (check_accepted_init, deposit_hash, check_accepted_elems)
-                    ~prev_next_deposit ~prev_nonce
+                    ~prev_next_deposit ~prev_nonce ~helper_account_new
                 with
                 | Error e ->
                     Error.raise e
@@ -611,6 +620,7 @@ module Finalize_withdrawal = struct
     ; prev_next_withdrawal : Zeko_util.Checked32.t
     ; withdrawal_params : Bridge_state.Withdrawal_params_base.t
     ; prev_nonce : Zeko_util.Checked32.t
+    ; helper_account_new : Zeko_util.Boolean.t
     }
   [@@deriving snarky]
 
@@ -624,6 +634,7 @@ module Finalize_withdrawal = struct
     ; prev_next_withdrawal : Zeko_util.Checked32.t
     ; withdrawal_params : Bridge_state.Withdrawal_params_base.t
     ; prev_nonce : Zeko_util.Checked32.t
+    ; helper_account_new : Zeko_util.Boolean.t
     ; commit_ase_elems : Field.t list
     ; withdrawal_ase_elems : Field.t list
     }
@@ -638,6 +649,7 @@ module Finalize_withdrawal = struct
        ; prev_next_withdrawal
        ; withdrawal_params
        ; prev_nonce
+       ; helper_account_new
        ; commit_ase_elems
        ; withdrawal_ase_elems
        } :
@@ -654,6 +666,7 @@ module Finalize_withdrawal = struct
         ; prev_next_withdrawal
         ; withdrawal_params
         ; prev_nonce
+        ; helper_account_new
         }
       |> fst
     in
@@ -677,6 +690,7 @@ module Finalize_withdrawal = struct
        ; prev_next_withdrawal
        ; withdrawal_params
        ; prev_nonce
+       ; helper_account_new
        } as request :
         t_ ) =
     let key = key request in
@@ -698,7 +712,7 @@ module Finalize_withdrawal = struct
                       ~before_withdrawal
                       ~withdrawal_ase:
                         (withdrawal_ase_source, withdrawal_ase_elems)
-                      ~prev_next_withdrawal ~prev_nonce
+                      ~prev_next_withdrawal ~prev_nonce ~helper_account_new
                       ~withdrawal_params:
                         (Bridge.Finalize_withdrawal.Withdrawal_params_base
                          .to_serializable withdrawal_params )

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -70,14 +70,19 @@ type t =
   ; proof_cache_db : Proof_cache_tag.cache_db
   ; fee_recipient_l1 : Public_key.Compressed.t
   ; fee_recipient_l2 : Public_key.Compressed.t
+  ; verification_keys : Zeko_prover.Prover.Verification_key_hashes.t
   }
 
 let create ~provers ~proof_cache_db ~fee_recipient_l1 ~fee_recipient_l2 =
+  let%map verification_keys =
+    Zeko_prover.Client.verification_keys provers >>| Or_error.ok_exn
+  in
   { proofs_memory = Proofs_memory.create ~lifetime:Float.(60. * 20.)
   ; provers
   ; proof_cache_db
   ; fee_recipient_l1
   ; fee_recipient_l2
+  ; verification_keys
   }
 
 let wrap_with_transferrer ~signature_kind transferrer calls =
@@ -91,6 +96,34 @@ let validate_transferrer ~expected_amount transferrer =
   let _ = expected_amount in
   let _ = transferrer in
   Ok ()
+
+let run_and_check_exn (input : 'input) out_typ
+    (main :
+         'input V.t
+      -> ('a, _) Compile_simple.main_return Snark_params.Tick.Checked.t ) =
+  Snark_params.Tick.run_and_check_exn
+    (let%bind.Checked () = exists Typ.unit ~compute:(fun _ -> ()) in
+     let%map.Checked { out; _ } = main (V.return input) in
+     As_prover.read out_typ out )
+
+let fold ~(init_fn : 'init_var -> 'stmt_var Checked.t)
+    ~(step_fn : 'elm_var -> 'stmt_var -> 'stmt_var Checked.t)
+    ~(init_typ : ('init_var, 'init_val) Typ.typ)
+    ~(stmt_typ : ('stmt_var, 'stmt_val) Typ.typ)
+    ~(elm_typ : ('elm_var, 'elm_val) Typ.typ) (init : 'init_val)
+    (elms : 'elm_val list) =
+  Snark_params.Tick.run_and_check_exn
+    (let%bind.Checked init = exists init_typ ~compute:(fun _ -> init) in
+     let%bind.Checked stmt = init_fn init in
+     let%bind.Checked elms =
+       exists
+         (Typ.list ~length:(List.length elms) elm_typ)
+         ~compute:(fun _ -> elms)
+     in
+     let%map.Checked stmt =
+       Zeko_util.foldl elms ~init:stmt ~f:(fun acc elm -> step_fn elm acc)
+     in
+     As_prover.read stmt_typ stmt )
 
 let execute_request t ~logger ~(executor : Executor.t) (key, d) =
   let%bind () = d in
@@ -107,7 +140,7 @@ let execute_request t ~logger ~(executor : Executor.t) (key, d) =
             Account_update.Fee_payer.make
               ~body:
                 { public_key = Signer_service.Signer.public_key executor.signer
-                ; fee = Currency.Fee.zero
+                ; fee = Currency.Fee.of_mina_string_exn "0.1"
                 ; valid_until = None
                 ; nonce = Account.Nonce.zero
                 }
@@ -133,6 +166,98 @@ module Deposit_request = struct
     [@@deriving snarky]
   end
 
+  let make_witness t (deposit_params : Bridge_state.Deposit_params_base.t) :
+      Bridge.Outer_action_witness.serializable =
+    let receive_forest =
+      let user_children =
+        Zkapp_command.Call_forest.map deposit_params.children
+          ~f:Account_update.read_all_proofs_from_disk
+      in
+      Zkapp_command.Call_forest.cons
+        ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+        ( Account_update.with_aux
+            ~body:
+              { Mina_base.Account_update.Body.dummy with
+                use_full_commitment = true
+              ; public_key = deposit_params.holder_account_l1
+              ; balance_change =
+                  Currency.Amount.Signed.(of_unsigned deposit_params.amount)
+              ; may_use_token = Parents_own_token
+              ; authorization_kind = None_given
+              }
+            ~authorization:Control.Poly.None_given
+        |> Account_update.read_all_proofs_from_disk )
+        user_children
+    in
+    let fee_payout_forest =
+      Zkapp_command.Call_forest.cons
+        ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+        ( Account_update.with_aux
+            ~body:
+              { Mina_base.Account_update.Body.dummy with
+                public_key = t.fee_recipient_l1
+              ; balance_change =
+                  Currency.Amount.Signed.of_unsigned
+                    Zeko_circuits_config.Inputs.bridge_proof_fee
+              ; authorization_kind = None_given
+              ; use_full_commitment = false
+              }
+            ~authorization:Control.Poly.None_given
+        |> Account_update.read_all_proofs_from_disk )
+        []
+    in
+    { public_key = Zeko_circuits_config.Inputs.zeko_l1
+    ; witness =
+        { aux =
+            Utils.value_to_hash ~init:Zeko_constants.deposit_salt
+              Zeko_circuits.Bridge_state.Deposit_params_base.typ deposit_params
+        ; children = receive_forest @ fee_payout_forest
+        ; slot_range = Slot_range.infinite
+        }
+    }
+
+  let precompute_commitments t ({ deposit_params; transferrer } : t) =
+    let witness =
+      Bridge.Outer_action_witness.of_serializable
+        ~proof_cache_db:(Proof_cache_tag.create_identity_db ())
+        ~vk_hash:t.verification_keys.outer_rules
+        (make_witness t deposit_params)
+    in
+    try
+      let _stmt, (body, _, calls) =
+        run_and_check_exn witness
+          Snark_params.Tick.Typ.(Mina_base.Zkapp_statement.typ * V.typ)
+          Outer_rules_inst.Rule_action_witness_inst.main
+      in
+      let account_update =
+        Account_update.with_aux
+          ~body:
+            ( match Is_compile_simple_real.is_compile_simple_real with
+            | Some _ ->
+                body
+            | None ->
+                (* To make the fake tests work *)
+                { body with authorization_kind = None_given } )
+          ~authorization:Control.Poly.None_given
+      in
+      let forest =
+        Zkapp_command.Call_forest.cons
+          ~signature_kind:Zeko_circuits_config.Inputs.chain_l1 ~calls
+          account_update []
+        |> Zkapp_command.Call_forest.map
+             ~f:Account_update.read_all_proofs_from_disk
+        |> wrap_with_transferrer
+             ~signature_kind:Zeko_circuits_config.Inputs.chain_l1 transferrer
+        |> Utils.rehash_forest
+             ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+      in
+      let tx_commitment =
+        Zkapp_command.Transaction_commitment.create
+          ~account_updates_hash:(Zkapp_command.Call_forest.hash forest)
+      in
+      Ok (forest, `Commitment tx_commitment)
+    with exn -> Error (Error.of_exn exn)
+
   let key t =
     let (Typ typ) = Key.typ in
     typ.value_to_fields t |> fst
@@ -141,10 +266,6 @@ module Deposit_request = struct
     |> Field.to_string
 
   let f ~t ~logger ({ deposit_params; transferrer } : t) =
-    let bridge_fee = Zeko_circuits_config.Inputs.bridge_proof_fee in
-    let expected_amount =
-      Currency.Amount.add deposit_params.amount bridge_fee |> Option.value_exn
-    in
     let key =
       key { deposit_params }
       ^ ":"
@@ -155,6 +276,11 @@ module Deposit_request = struct
     , Proofs_memory.prove t.proofs_memory key ~f:(fun () ->
           let%map result =
             try_with (fun () ->
+                let expected_amount =
+                  Currency.Amount.add deposit_params.amount
+                    Zeko_circuits_config.Inputs.bridge_proof_fee
+                  |> Option.value_exn
+                in
                 let%bind () =
                   match validate_transferrer ~expected_amount transferrer with
                   | Ok () ->
@@ -162,57 +288,9 @@ module Deposit_request = struct
                   | Error e ->
                       Error.raise e
                 in
-                let receive_forest =
-                  let user_children =
-                    Zkapp_command.Call_forest.map deposit_params.children
-                      ~f:Account_update.read_all_proofs_from_disk
-                  in
-                  Zkapp_command.Call_forest.cons
-                    ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
-                    ( Account_update.with_aux
-                        ~body:
-                          { Mina_base.Account_update.Body.dummy with
-                            use_full_commitment = true
-                          ; public_key = deposit_params.holder_account_l1
-                          ; balance_change =
-                              Currency.Amount.Signed.(
-                                of_unsigned deposit_params.amount)
-                          ; may_use_token = Parents_own_token
-                          ; authorization_kind = None_given
-                          }
-                        ~authorization:Control.Poly.None_given
-                    |> Account_update.read_all_proofs_from_disk )
-                    user_children
-                in
-                let fee_payout_forest =
-                  Zkapp_command.Call_forest.cons
-                    ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
-                    ( Account_update.with_aux
-                        ~body:
-                          { Mina_base.Account_update.Body.dummy with
-                            public_key = t.fee_recipient_l1
-                          ; balance_change =
-                              Currency.Amount.Signed.of_unsigned bridge_fee
-                          ; authorization_kind = None_given
-                          ; use_full_commitment = false
-                          }
-                        ~authorization:Control.Poly.None_given
-                    |> Account_update.read_all_proofs_from_disk )
-                    []
-                in
+                let witness = make_witness t deposit_params in
                 match%map
-                  Zeko_prover.Client.outer_action_witness t.provers
-                    { public_key = Zeko_circuits_config.Inputs.zeko_l1
-                    ; witness =
-                        { aux =
-                            Utils.value_to_hash
-                              ~init:Zeko_constants.deposit_salt
-                              Zeko_circuits.Bridge_state.Deposit_params_base.typ
-                              deposit_params
-                        ; children = receive_forest @ fee_payout_forest
-                        ; slot_range = Slot_range.infinite
-                        }
-                    }
+                  Zeko_prover.Client.outer_action_witness t.provers witness
                 with
                 | Error e ->
                     Error.raise e
@@ -364,6 +442,113 @@ module Finalize_deposit = struct
         Bridge_inst_mina.Check_accepted.Definition.Elem.t list
     }
 
+  let precompute_commitments t
+      ({ ase_source
+       ; ase_elems
+       ; check_accepted_init
+       ; check_accepted_elems
+       ; prev_next_deposit
+       ; prev_nonce
+       ; helper_account_new
+       } :
+        t_ ) =
+    let deposit, check_accepted_elems =
+      (List.hd_exn check_accepted_elems, List.tl_exn check_accepted_elems)
+    in
+    let deposit_hash =
+      Zkapp_account.Actions_impl.hash [ Utils.actions_of_outer_action deposit ]
+    in
+    let ase =
+      let target =
+        fold
+          ~init_fn:(Ase.M_with_length.init ~check:None)
+          ~step_fn:Ase.M_with_length.step ~init_typ:Ase.M_with_length.Init.typ
+          ~stmt_typ:Ase.M_with_length.Stmt.typ ~elm_typ:F.typ ase_source
+          ase_elems
+      in
+      Bridge_inst_mina.Rule_bridge_finalize_deposit.Ase_inst.make
+        ~proof:
+          (Compile_simple.Proof.of_pickles
+             Pickles_types.Nat.(Pickles.Proof.dummy N2.n N2.n ~domain_log2:14) )
+        ~proof_source:ase_source ~proof_target:target ase_source []
+    in
+    let check_accepted =
+      let source : Bridge.Check_accepted_mina.Stmt.t =
+        { params = check_accepted_init.params
+        ; action_state =
+            Zkapp_account.Actions_impl.push_hash
+              (Rollup_state.Outer_action_state.raw
+                 check_accepted_init.original_action_state )
+              deposit_hash
+            |> Rollup_state.Outer_action_state.unsafe_value_of_field
+        ; deposit_index = check_accepted_init.deposit_index
+        ; n_steps = Zeko_util.Checked32.zero
+        ; is_rejected = false
+        ; is_accepted = false
+        }
+      in
+      let target =
+        fold
+          ~init_fn:(Bridge_inst_mina.Check_accepted.Definition.init ~check:None)
+          ~step_fn:Bridge_inst_mina.Check_accepted.Definition.step
+          ~init_typ:Bridge_inst_mina.Check_accepted.Definition.Init.typ
+          ~stmt_typ:Bridge_inst_mina.Check_accepted.Definition.Stmt.typ
+          ~elm_typ:Bridge_inst_mina.Check_accepted.Definition.Elem.typ
+          check_accepted_init check_accepted_elems
+      in
+      Bridge_inst_mina.Rule_bridge_finalize_deposit.Check_accepted_inst.make
+        ~proof:
+          (Compile_simple.Proof.of_pickles
+             Pickles_types.Nat.(Pickles.Proof.dummy N2.n N2.n ~domain_log2:14) )
+        ~proof_source:source ~proof_target:target check_accepted_init []
+    in
+    let witness : Bridge.Finalize_deposit.t =
+      { vk_hash = t.verification_keys.bridge_mina_l2
+      ; public_key = Zeko_circuits_config.Inputs.holder_account_l2
+      ; may_use_token =
+          Bridge_inst_mina.Rule_bridge_finalize_deposit.May_use_token.No
+      ; inner_authorization_kind =
+          Zeko_circuits.Rule_bridge_finalize_deposit.A.None_given
+      ; ase
+      ; check_accepted
+      ; prev_next_deposit
+      ; prev_nonce
+      ; helper_account_new
+      }
+    in
+    try
+      let _stmt, (body, _, calls) =
+        run_and_check_exn witness
+          Snark_params.Tick.Typ.(Mina_base.Zkapp_statement.typ * V.typ)
+          Bridge_inst_mina.Rule_bridge_finalize_deposit.main
+      in
+      let account_update =
+        Account_update.with_aux
+          ~body:
+            ( match Is_compile_simple_real.is_compile_simple_real with
+            | Some _ ->
+                body
+            | None ->
+                (* To make the fake tests work *)
+                { body with authorization_kind = None_given } )
+          ~authorization:Control.Poly.None_given
+      in
+      let forest =
+        Zkapp_command.Call_forest.cons
+          ~signature_kind:Zeko_circuits_config.Inputs.chain_l1 ~calls
+          account_update []
+        |> Zkapp_command.Call_forest.map
+             ~f:Account_update.read_all_proofs_from_disk
+        |> Utils.rehash_forest
+             ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+      in
+      let tx_commitment =
+        Zkapp_command.Transaction_commitment.create
+          ~account_updates_hash:(Zkapp_command.Call_forest.hash forest)
+      in
+      Ok (forest, `Commitment tx_commitment)
+    with exn -> Error (Error.of_exn exn)
+
   let key
       ({ ase_source
        ; check_accepted_init
@@ -409,7 +594,7 @@ module Finalize_deposit = struct
        ; prev_nonce
        ; helper_account_new
        } as request :
-        t_ ) =
+        t_ ) (helper_account_signature : Signature.t) =
     let key = key request in
     ( key
     , Proofs_memory.prove t.proofs_memory key ~f:(fun () ->
@@ -440,6 +625,21 @@ module Finalize_deposit = struct
                 | Error e ->
                     Error.raise e
                 | Ok ((body, _, calls), proof) ->
+                    (* Attach helper account signature *)
+                    let calls =
+                      match calls with
+                      | helper_account :: remaining_calls ->
+                          Zkapp_command.Call_forest.cons
+                            ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+                            ~calls:helper_account.elt.calls
+                            { helper_account.elt.account_update with
+                              authorization =
+                                Control.Poly.Signature helper_account_signature
+                            }
+                            remaining_calls
+                      | _ ->
+                          failwith "shouldn't be reachable"
+                    in
                     Utils.attach_proof_to_forest
                       ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
                       ~proof_cache_db:t.proof_cache_db ~body ~calls ~proof

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -70,9 +70,15 @@ type t =
   ; provers : Zeko_prover.Client.t
   ; proof_cache_db : Proof_cache_tag.cache_db
   ; verification_keys : Zeko_prover.Prover.Verification_key_hashes.t
+  ; preverify_l2 :
+         ( Account_update.Stable.V1.t
+         , Zkapp_command.Digest.Account_update.t
+         , Zkapp_command.Digest.Forest.t )
+         Zkapp_command.Call_forest.t
+      -> unit Deferred.Or_error.t
   }
 
-let create ~provers ~proof_cache_db =
+let create ~provers ~proof_cache_db ~preverify_l2 =
   let%map verification_keys =
     Zeko_prover.Client.verification_keys provers >>| Or_error.ok_exn
   in
@@ -80,7 +86,24 @@ let create ~provers ~proof_cache_db =
   ; provers
   ; proof_cache_db
   ; verification_keys
+  ; preverify_l2
   }
+
+(** Verify a Schnorr signature against the partial transaction commitment. The
+    signing public key is taken to be that of the supplied account update. Used
+    to check the [transferrer] signature on submitDeposit/submitWithdrawal and
+    the [helper_account_signature] on the finalize* actions. *)
+let verify_signature ~signature_kind ~tx_commitment ~public_key signature =
+  match Signature_lib.Public_key.decompress public_key with
+  | None ->
+      Or_error.error_string "verify_signature: invalid public key"
+  | Some pk ->
+      if
+        Signature_lib.Schnorr.Chunked.verify ~signature_kind signature
+          (Snark_params.Tick.Inner_curve.of_affine pk)
+          (Random_oracle_input.Chunked.field tx_commitment)
+      then Ok ()
+      else Or_error.error_string "verify_signature: signature does not verify"
 
 let wrap_with_transferrer ~signature_kind transferrer calls =
   Zkapp_command.Call_forest.cons ~signature_kind transferrer calls
@@ -303,6 +326,23 @@ module Deposit_request = struct
                   | Error e ->
                       Error.raise e
                 in
+                (* Verify the transferrer signature against the precomputed
+                   commitment before spending compute on the proof. *)
+                let _forest, `Commitment commitment =
+                  precompute_commitments t { deposit_params; transferrer }
+                  |> Or_error.ok_exn
+                in
+                let () =
+                  match Account_update.Poly.authorization transferrer with
+                  | Control.Poly.Signature signature ->
+                      verify_signature
+                        ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+                        ~tx_commitment:commitment
+                        ~public_key:transferrer.body.public_key signature
+                      |> Or_error.ok_exn
+                  | _ ->
+                      failwith "Deposit_request: transferrer must be signed"
+                in
                 let witness = make_witness deposit_params in
                 match%map
                   Zeko_prover.Client.outer_action_witness t.provers witness
@@ -483,6 +523,24 @@ module Withdrawal_request = struct
                   | Error e ->
                       Error.raise e
                 in
+                (* Verify the transferrer signature and preverify the command
+                   on L2 before spending compute on the proof. *)
+                let forest, `Commitment commitment =
+                  precompute_commitments t { withdrawal_params; transferrer }
+                  |> Or_error.ok_exn
+                in
+                let () =
+                  match Account_update.Poly.authorization transferrer with
+                  | Control.Poly.Signature signature ->
+                      verify_signature
+                        ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+                        ~tx_commitment:commitment
+                        ~public_key:transferrer.body.public_key signature
+                      |> Or_error.ok_exn
+                  | _ ->
+                      failwith "Withdrawal_request: transferrer must be signed"
+                in
+                let%bind () = t.preverify_l2 forest >>| Or_error.ok_exn in
                 let%bind inner_receive_forest =
                   match%map
                     Zeko_prover.Client.inner_receive t.provers
@@ -704,6 +762,50 @@ module Finalize_deposit = struct
     , Proofs_memory.prove t.proofs_memory key ~f:(fun () ->
           let%map result =
             try_with (fun () ->
+                (* Verify the helper-account signature and preverify the
+                   command on L2 before spending compute on the proof. *)
+                let forest, `Commitment commitment =
+                  precompute_commitments t request |> Or_error.ok_exn
+                in
+                let top_tree, helper, rest_calls =
+                  match forest with
+                  | [ ({ elt = { calls = helper :: rest; _ }; _ } as top) ] ->
+                      (top, helper, rest)
+                  | _ ->
+                      failwith
+                        "Finalize_deposit: unexpected precomputed forest layout"
+                in
+                let helper_pk = helper.elt.account_update.body.public_key in
+                let () =
+                  verify_signature
+                    ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+                    ~tx_commitment:commitment ~public_key:helper_pk
+                    helper_account_signature
+                  |> Or_error.ok_exn
+                in
+                (* Attach the helper signature in place before preverify so
+                   [body.authorization_kind = Signature] matches the actual
+                   authorization (otherwise the unchecked apply path's
+                   is_signed/signature_verifies assertion fires). *)
+                let forest =
+                  let new_calls =
+                    Zkapp_command.Call_forest.cons
+                      ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+                      ~calls:helper.elt.calls
+                      { helper.elt.account_update with
+                        authorization =
+                          Control.Poly.Signature helper_account_signature
+                      }
+                      rest_calls
+                  in
+                  [ { top_tree with
+                      elt = { top_tree.elt with calls = new_calls }
+                    }
+                  ]
+                  |> Utils.rehash_forest
+                       ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+                in
+                let%bind () = t.preverify_l2 forest >>| Or_error.ok_exn in
                 let deposit, check_accepted_elems =
                   ( List.hd_exn check_accepted_elems
                   , List.tl_exn check_accepted_elems )
@@ -1104,6 +1206,46 @@ module Finalize_cancelled_deposit = struct
     , Proofs_memory.prove t.proofs_memory key ~f:(fun () ->
           let%map result =
             try_with (fun () ->
+                (* Verify the helper-account signature against the precomputed
+                   commitment before spending compute on the proof. This action
+                   targets L1, so we don't preverify here. *)
+                let forest, `Commitment commitment =
+                  precompute_commitments t request |> Or_error.ok_exn
+                in
+                let helper_pk =
+                  match forest with
+                  | [ { elt =
+                          { calls =
+                              { elt =
+                                  { calls =
+                                      [ { elt =
+                                            { account_update = helper_au; _ }
+                                        ; _
+                                        }
+                                      ]
+                                  ; _
+                                  }
+                              ; _
+                              }
+                              :: _
+                          ; _
+                          }
+                      ; _
+                      }
+                    ] ->
+                      helper_au.body.public_key
+                  | _ ->
+                      failwith
+                        "Finalize_cancelled_deposit: unexpected precomputed \
+                         forest layout"
+                in
+                let () =
+                  verify_signature
+                    ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+                    ~tx_commitment:commitment ~public_key:helper_pk
+                    helper_account_signature
+                  |> Or_error.ok_exn
+                in
                 let%bind ( (cancelled_deposit_body, _, calls)
                          , cancelled_deposit_proof ) =
                   let deposit, check_accepted_elems =
@@ -1464,6 +1606,46 @@ module Finalize_withdrawal = struct
     , Proofs_memory.prove t.proofs_memory key ~f:(fun () ->
           let%map result =
             try_with (fun () ->
+                (* Verify the helper-account signature against the precomputed
+                   commitment before spending compute on the proof. This action
+                   targets L1, so we don't preverify here. *)
+                let forest, `Commitment commitment =
+                  precompute_commitments t request |> Or_error.ok_exn
+                in
+                let helper_pk =
+                  match forest with
+                  | [ { elt =
+                          { calls =
+                              { elt =
+                                  { calls =
+                                      [ { elt =
+                                            { account_update = helper_au; _ }
+                                        ; _
+                                        }
+                                      ]
+                                  ; _
+                                  }
+                              ; _
+                              }
+                              :: _
+                          ; _
+                          }
+                      ; _
+                      }
+                    ] ->
+                      helper_au.body.public_key
+                  | _ ->
+                      failwith
+                        "Finalize_withdrawal: unexpected precomputed forest \
+                         layout"
+                in
+                let () =
+                  verify_signature
+                    ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+                    ~tx_commitment:commitment ~public_key:helper_pk
+                    helper_account_signature
+                  |> Or_error.ok_exn
+                in
                 let%bind (withdrawal_body, _, calls), withdrawal_proof =
                   match%map
                     Zeko_prover.Client.finalize_withdrawal t.provers ~public_key

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -68,35 +68,81 @@ type t =
   { proofs_memory : Proofs_memory.t
   ; provers : Zeko_prover.Client.t
   ; proof_cache_db : Proof_cache_tag.cache_db
+  ; fee_recipient_l1 : Public_key.Compressed.t
+  ; fee_recipient_l2 : Public_key.Compressed.t
   }
 
-let create ~provers ~proof_cache_db =
+let create ~provers ~proof_cache_db ~fee_recipient_l1 ~fee_recipient_l2 =
   { proofs_memory = Proofs_memory.create ~lifetime:Float.(60. * 20.)
   ; provers
   ; proof_cache_db
+  ; fee_recipient_l1
+  ; fee_recipient_l2
   }
 
+let wrap_with_transferrer ~signature_kind transferrer calls =
+  Zkapp_command.Call_forest.cons ~signature_kind
+    transferrer
+    calls
+
+let transferrer_key ~signature_kind:_ transferrer =
+  [%sexp_of: Account_update.Stable.Latest.t] transferrer
+  |> Sexp.to_string
+
+let validate_transferrer ~expected_amount transferrer =
+  let _ = expected_amount in
+  let _ = transferrer in
+  Ok ()
+
 module Deposit_request = struct
-  type t = { deposit_params : Bridge_state.Deposit_params_base.t }
-  [@@deriving snarky]
+  type t =
+    { deposit_params : Bridge_state.Deposit_params_base.t
+    ; transferrer : Account_update.Stable.Latest.t
+    }
+
+  module Key = struct
+    type t = { deposit_params : Bridge_state.Deposit_params_base.t }
+    [@@deriving snarky]
+  end
 
   let key t =
-    let (Typ typ) = typ in
+    let (Typ typ) = Key.typ in
     typ.value_to_fields t |> fst
     |> Random_oracle.hash
          ~init:(Hash_prefix_create.salt Zeko_constants.bridge_prover_cache)
     |> Field.to_string
 
-  let f ~t ~logger ({ deposit_params } as request : t) =
-    let key = key request in
+  let f ~t ~logger ({ deposit_params; transferrer } : t) =
+    let bridge_fee = Zeko_circuits_config.Inputs.bridge_proof_fee in
+    let expected_amount =
+      Currency.Amount.add deposit_params.amount bridge_fee |> Option.value_exn
+    in
+    let key =
+      key { deposit_params }
+      ^ ":"
+      ^ transferrer_key
+          ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+          transferrer
+    in
     ( key
     , Proofs_memory.prove t.proofs_memory key ~f:(fun () ->
           let%map result =
             try_with (fun () ->
+                let%bind () =
+                  match validate_transferrer ~expected_amount transferrer with
+                  | Ok () ->
+                      return ()
+                  | Error e ->
+                      Error.raise e
+                in
                 let receive_forest =
+                  let user_children =
+                    Zkapp_command.Call_forest.map deposit_params.children
+                      ~f:Account_update.read_all_proofs_from_disk
+                  in
                   Zkapp_command.Call_forest.cons
                     ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
-                    (Account_update.with_no_aux
+                    (Account_update.with_aux
                        ~body:
                          { Mina_base.Account_update.Body.dummy with
                            use_full_commitment = true
@@ -107,9 +153,24 @@ module Deposit_request = struct
                          ; may_use_token = Parents_own_token
                          ; authorization_kind = None_given
                          }
-                       ~authorization:
-                         (* Account_update.Checked.t == Account_update.Body.Checked.t so authorization is dropped anyways *)
-                         Control.Poly.None_given )
+                       ~authorization:Control.Poly.None_given
+                    |> Account_update.read_all_proofs_from_disk )
+                    user_children
+                in
+                let fee_payout_forest =
+                  Zkapp_command.Call_forest.cons
+                    ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+                    (Account_update.with_aux
+                       ~body:
+                         { Mina_base.Account_update.Body.dummy with
+                           public_key = t.fee_recipient_l1
+                         ; balance_change =
+                             Currency.Amount.Signed.of_unsigned bridge_fee
+                         ; authorization_kind = None_given
+                         ; use_full_commitment = false
+                         }
+                       ~authorization:Control.Poly.None_given
+                    |> Account_update.read_all_proofs_from_disk )
                     []
                 in
                 match%map
@@ -121,7 +182,7 @@ module Deposit_request = struct
                               ~init:Zeko_constants.deposit_salt
                               Zeko_circuits.Bridge_state.Deposit_params_base.typ
                               deposit_params
-                        ; children = receive_forest
+                        ; children = receive_forest @ fee_payout_forest
                         ; slot_range = Slot_range.infinite
                         }
                     }
@@ -131,7 +192,10 @@ module Deposit_request = struct
                 | Ok ((body, _, calls), proof) ->
                     Utils.attach_proof_to_forest
                       ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
-                      ~proof_cache_db:t.proof_cache_db ~body ~calls ~proof )
+                      ~proof_cache_db:t.proof_cache_db ~body ~calls ~proof
+                    |> wrap_with_transferrer
+                         ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+                         transferrer )
             >>| Result.map_error ~f:(fun e -> Exn.to_string e)
           in
           match result with
@@ -143,22 +207,47 @@ module Deposit_request = struct
 end
 
 module Withdrawal_request = struct
-  type t = { withdrawal_params : Bridge_state.Withdrawal_params_base.t }
-  [@@deriving snarky]
+  type t =
+    { withdrawal_params : Bridge_state.Withdrawal_params_base.t
+    ; transferrer : Account_update.Stable.Latest.t
+    }
+
+  module Key = struct
+    type t = { withdrawal_params : Bridge_state.Withdrawal_params_base.t }
+    [@@deriving snarky]
+  end
 
   let key t =
-    let (Typ typ) = typ in
+    let (Typ typ) = Key.typ in
     typ.value_to_fields t |> fst
     |> Random_oracle.hash
          ~init:(Hash_prefix_create.salt Zeko_constants.bridge_prover_cache)
     |> Field.to_string
 
-  let f ~t ~logger ({ withdrawal_params } as request : t) =
-    let key = key request in
+  let f ~t ~logger ({ withdrawal_params; transferrer } : t) =
+    let bridge_fee = Zeko_circuits_config.Inputs.bridge_proof_fee in
+    let expected_amount =
+      Currency.Amount.add withdrawal_params.amount bridge_fee
+      |> Option.value_exn
+    in
+    let key =
+      key { withdrawal_params }
+      ^ ":"
+      ^ transferrer_key
+          ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+          transferrer
+    in
     ( key
     , Proofs_memory.prove t.proofs_memory key ~f:(fun () ->
           let%map result =
             try_with (fun () ->
+                let%bind () =
+                  match validate_transferrer ~expected_amount transferrer with
+                  | Ok () ->
+                      return ()
+                  | Error e ->
+                      Error.raise e
+                in
                 let%bind inner_receive_forest =
                   match%map
                     Zeko_prover.Client.inner_receive t.provers
@@ -174,6 +263,26 @@ module Withdrawal_request = struct
                         ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
                         ~proof_cache_db:t.proof_cache_db ~body ~calls ~proof
                 in
+                let user_children =
+                  Zkapp_command.Call_forest.map withdrawal_params.children
+                    ~f:Account_update.read_all_proofs_from_disk
+                in
+                let fee_payout_forest =
+                  Zkapp_command.Call_forest.cons
+                    ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+                    (Account_update.with_aux
+                       ~body:
+                         { Mina_base.Account_update.Body.dummy with
+                           public_key = t.fee_recipient_l2
+                         ; balance_change =
+                             Currency.Amount.Signed.of_unsigned bridge_fee
+                         ; authorization_kind = None_given
+                         ; use_full_commitment = false
+                         }
+                       ~authorization:Control.Poly.None_given
+                    |> Account_update.read_all_proofs_from_disk )
+                    []
+                in
                 match%map
                   Zeko_prover.Client.inner_action_witness t.provers
                     { public_key = Zeko_circuits_config.Inputs.inner_public_key
@@ -183,7 +292,9 @@ module Withdrawal_request = struct
                               ~init:Zeko_constants.withdrawal_salt
                               Zeko_circuits.Bridge_state.Withdrawal_params_base
                               .typ withdrawal_params
-                        ; children = inner_receive_forest
+                        ; children =
+                            inner_receive_forest @ fee_payout_forest
+                            @ user_children
                         }
                     }
                 with
@@ -192,7 +303,10 @@ module Withdrawal_request = struct
                 | Ok ((body, _, calls), proof) ->
                     Utils.attach_proof_to_forest
                       ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
-                      ~proof_cache_db:t.proof_cache_db ~body ~calls ~proof )
+                      ~proof_cache_db:t.proof_cache_db ~body ~calls ~proof
+                    |> wrap_with_transferrer
+                         ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+                         transferrer )
             >>| Result.map_error ~f:(fun e -> Exn.to_string e)
           in
           match result with
@@ -589,32 +703,31 @@ module Finalize_withdrawal = struct
                   | Ok x ->
                       x
                 in
-                let (_, helper_account), witness_outer =
+                let helper_account, witness_outer, remaining_calls =
                   match calls with
-                  | [ { elt =
-                          { account_update = helper_token_owner
-                          ; calls =
-                              [ { elt =
-                                    { account_update = helper_account
-                                    ; calls = []
-                                    ; _
-                                    }
-                                ; _
-                                }
-                              ]
-                          ; _
-                          }
-                      ; _
-                      }
-                    ; { elt = { account_update = witness_outer; calls = []; _ }
-                      ; _
-                      }
-                    ] ->
-                      ((helper_token_owner, helper_account), witness_outer)
+                  | { elt =
+                        { account_update = _helper_token_owner
+                        ; calls =
+                            [ { elt =
+                                  { account_update = helper_account
+                                  ; calls = []
+                                  ; _
+                                  }
+                              ; _
+                              }
+                            ]
+                        ; _
+                        }
+                    ; _
+                    }
+                    :: { elt = { account_update = witness_outer; calls = []; _ }
+                       ; _
+                       }
+                       :: remaining_calls ->
+                      (helper_account, witness_outer, remaining_calls)
                   | _ ->
                       failwith
-                        "finalize_withdrawal calls: no helper token owner or \
-                         witness outer"
+                        "finalize_withdrawal calls: invalid helper/witness layout"
                 in
                 let witness_forest =
                   Zkapp_command.Call_forest.cons
@@ -636,7 +749,7 @@ module Finalize_withdrawal = struct
                         ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
                         ~proof_cache_db:t.proof_cache_db ~body ~calls ~proof
                 in
-                let children = helper_forest @ witness_forest in
+                let children = helper_forest @ witness_forest @ remaining_calls in
                 Utils.attach_proof_to_forest
                   ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
                   ~proof_cache_db:t.proof_cache_db ~body:withdrawal_body

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -322,6 +322,109 @@ module Withdrawal_request = struct
     [@@deriving snarky]
   end
 
+  let make_witness t (withdrawal_params : Bridge_state.Withdrawal_params_base.t)
+      : Bridge.Inner_action_witness.serializable =
+    let inner_receive_witness =
+      Bridge.Inner_receive.of_serializable
+        ~vk_hash:t.verification_keys.bridge_mina_l2
+        { public_key = Zeko_circuits_config.Inputs.holder_account_l2
+        ; amount = withdrawal_params.amount
+        }
+    in
+    let _stmt, (inner_receive_body, _, inner_receive_calls) =
+      run_and_check_exn inner_receive_witness
+        Snark_params.Tick.Typ.(Mina_base.Zkapp_statement.typ * V.typ)
+        Bridge_inst_mina.Rule_bridge_inner_receive.main
+    in
+    let inner_receive_forest =
+      Zkapp_command.Call_forest.cons
+        ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+        ~calls:inner_receive_calls
+        (Account_update.with_aux
+           ~body:
+             ( match Is_compile_simple_real.is_compile_simple_real with
+             | Some _ ->
+                 inner_receive_body
+             | None ->
+                 { inner_receive_body with authorization_kind = None_given } )
+           ~authorization:Control.Poly.None_given )
+        []
+      |> Zkapp_command.Call_forest.map
+           ~f:Account_update.read_all_proofs_from_disk
+    in
+    let fee_payout_forest =
+      Zkapp_command.Call_forest.cons
+        ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+        ( Account_update.with_aux
+            ~body:
+              { Mina_base.Account_update.Body.dummy with
+                public_key = t.fee_recipient_l2
+              ; balance_change =
+                  Currency.Amount.Signed.of_unsigned
+                    Zeko_circuits_config.Inputs.bridge_proof_fee
+              ; authorization_kind = None_given
+              ; use_full_commitment = false
+              }
+            ~authorization:Control.Poly.None_given
+        |> Account_update.read_all_proofs_from_disk )
+        []
+    in
+    let user_children =
+      Zkapp_command.Call_forest.map withdrawal_params.children
+        ~f:Account_update.read_all_proofs_from_disk
+    in
+    { public_key = Zeko_circuits_config.Inputs.inner_public_key
+    ; witness =
+        { aux =
+            Utils.value_to_hash ~init:Zeko_constants.withdrawal_salt
+              Zeko_circuits.Bridge_state.Withdrawal_params_base.typ
+              withdrawal_params
+        ; children = inner_receive_forest @ fee_payout_forest @ user_children
+        }
+    }
+
+  let precompute_commitments t ({ withdrawal_params; transferrer } : t) =
+    let witness =
+      Bridge.Inner_action_witness.of_serializable
+        ~proof_cache_db:(Proof_cache_tag.create_identity_db ())
+        ~vk_hash:t.verification_keys.inner_rules
+        (make_witness t withdrawal_params)
+    in
+    try
+      let _stmt, (body, _, calls) =
+        run_and_check_exn witness
+          Snark_params.Tick.Typ.(Mina_base.Zkapp_statement.typ * V.typ)
+          Inner_rules_inst.Rule_inner_action_witness_inst.main
+      in
+      let account_update =
+        Account_update.with_aux
+          ~body:
+            ( match Is_compile_simple_real.is_compile_simple_real with
+            | Some _ ->
+                body
+            | None ->
+                (* To make the fake tests work *)
+                { body with authorization_kind = None_given } )
+          ~authorization:Control.Poly.None_given
+      in
+      let forest =
+        Zkapp_command.Call_forest.cons
+          ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 ~calls
+          account_update []
+        |> Zkapp_command.Call_forest.map
+             ~f:Account_update.read_all_proofs_from_disk
+        |> wrap_with_transferrer
+             ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 transferrer
+        |> Utils.rehash_forest
+             ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+      in
+      let tx_commitment =
+        Zkapp_command.Transaction_commitment.create
+          ~account_updates_hash:(Zkapp_command.Call_forest.hash forest)
+      in
+      Ok (forest, `Commitment tx_commitment)
+    with exn -> Error (Error.of_exn exn)
+
   let key t =
     let (Typ typ) = Key.typ in
     typ.value_to_fields t |> fst
@@ -352,55 +455,9 @@ module Withdrawal_request = struct
                   | Error e ->
                       Error.raise e
                 in
-                let%bind inner_receive_forest =
-                  match%map
-                    Zeko_prover.Client.inner_receive t.provers
-                      { public_key =
-                          Zeko_circuits_config.Inputs.holder_account_l2
-                      ; amount = withdrawal_params.amount
-                      }
-                  with
-                  | Error e ->
-                      Error.raise e
-                  | Ok ((body, _, calls), proof) ->
-                      Utils.attach_proof_to_forest
-                        ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
-                        ~proof_cache_db:t.proof_cache_db ~body ~calls ~proof
-                in
-                let user_children =
-                  Zkapp_command.Call_forest.map withdrawal_params.children
-                    ~f:Account_update.read_all_proofs_from_disk
-                in
-                let fee_payout_forest =
-                  Zkapp_command.Call_forest.cons
-                    ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
-                    ( Account_update.with_aux
-                        ~body:
-                          { Mina_base.Account_update.Body.dummy with
-                            public_key = t.fee_recipient_l2
-                          ; balance_change =
-                              Currency.Amount.Signed.of_unsigned bridge_fee
-                          ; authorization_kind = None_given
-                          ; use_full_commitment = false
-                          }
-                        ~authorization:Control.Poly.None_given
-                    |> Account_update.read_all_proofs_from_disk )
-                    []
-                in
+                let witness = make_witness t withdrawal_params in
                 match%map
-                  Zeko_prover.Client.inner_action_witness t.provers
-                    { public_key = Zeko_circuits_config.Inputs.inner_public_key
-                    ; witness =
-                        { aux =
-                            Utils.value_to_hash
-                              ~init:Zeko_constants.withdrawal_salt
-                              Zeko_circuits.Bridge_state.Withdrawal_params_base
-                              .typ withdrawal_params
-                        ; children =
-                            inner_receive_forest @ fee_payout_forest
-                            @ user_children
-                        }
-                    }
+                  Zeko_prover.Client.inner_action_witness t.provers witness
                 with
                 | Error e ->
                     Error.raise e
@@ -870,6 +927,158 @@ module Finalize_withdrawal = struct
     ; withdrawal_ase_elems : Field.t list
     }
 
+  let precompute_commitments t
+      ({ public_key
+       ; commit
+       ; before_commit
+       ; commit_ase_source
+       ; commit_ase_elems
+       ; before_withdrawal
+       ; withdrawal_ase_source
+       ; withdrawal_ase_elems
+       ; prev_next_withdrawal
+       ; withdrawal_params
+       ; prev_nonce
+       ; helper_account_new
+       } :
+        t_ ) =
+    let commit_ase =
+      let target =
+        fold
+          ~init_fn:(Ase.M_without_length.init ~check:None)
+          ~step_fn:Ase.M_without_length.step
+          ~init_typ:Ase.M_without_length.Init.typ
+          ~stmt_typ:Ase.M_without_length.Stmt.typ ~elm_typ:F.typ
+          commit_ase_source commit_ase_elems
+      in
+      Bridge_inst_mina.Rule_bridge_finalize_withdrawal.Ase_outer_inst.make
+        ~proof:
+          (Compile_simple.Proof.of_pickles
+             Pickles_types.Nat.(Pickles.Proof.dummy N2.n N2.n ~domain_log2:14) )
+        ~proof_source:commit_ase_source ~proof_target:target commit_ase_source
+        []
+    in
+    let withdrawal_ase =
+      let target =
+        fold
+          ~init_fn:(Ase.M_with_length.init ~check:None)
+          ~step_fn:Ase.M_with_length.step ~init_typ:Ase.M_with_length.Init.typ
+          ~stmt_typ:Ase.M_with_length.Stmt.typ ~elm_typ:F.typ
+          withdrawal_ase_source withdrawal_ase_elems
+      in
+      Bridge_inst_mina.Rule_bridge_finalize_withdrawal.Ase_inner_inst.make
+        ~proof:
+          (Compile_simple.Proof.of_pickles
+             Pickles_types.Nat.(Pickles.Proof.dummy N2.n N2.n ~domain_log2:14) )
+        ~proof_source:withdrawal_ase_source ~proof_target:target
+        withdrawal_ase_source []
+    in
+    let witness : Bridge.Finalize_withdrawal.t =
+      { vk_hash = t.verification_keys.bridge_mina_l1
+      ; public_key
+      ; may_use_token =
+          Bridge_inst_mina.Rule_bridge_finalize_withdrawal.May_use_token.No
+      ; outer_authorization_kind =
+          Zeko_circuits.Rule_bridge_finalize_withdrawal.A.None_given
+      ; commit
+      ; before_commit
+      ; commit_ase
+      ; before_withdrawal
+      ; withdrawal_ase
+      ; prev_next_withdrawal
+      ; withdrawal_params
+      ; helper_token_owner_l1_vk_hash =
+          t.verification_keys.bridge_mina_token_owner
+      ; l2_holder_vk_hash = t.verification_keys.bridge_mina_l2
+      ; prev_nonce
+      ; helper_account_new
+      }
+    in
+    try
+      let _stmt, (body, _, calls) =
+        run_and_check_exn witness
+          Snark_params.Tick.Typ.(Mina_base.Zkapp_statement.typ * V.typ)
+          Bridge_inst_mina.Rule_bridge_finalize_withdrawal.main
+      in
+      let helper_account, witness_outer, remaining_calls =
+        match calls with
+        | { elt =
+              { account_update = _helper_token_owner
+              ; calls =
+                  [ { elt = { account_update = helper_account; calls = []; _ }
+                    ; _
+                    }
+                  ]
+              ; _
+              }
+          ; _
+          }
+          :: { elt = { account_update = witness_outer; calls = []; _ }; _ }
+             :: remaining_calls ->
+            (helper_account, witness_outer, remaining_calls)
+        | _ ->
+            failwith
+              "finalize_withdrawal precompute: invalid helper/witness layout"
+      in
+      let helper_witness =
+        Bridge.Outer_token_owner.of_serializable
+          ~vk_hash:t.verification_keys.bridge_mina_token_owner
+          { public_key = Zeko_circuits_config.Inputs.helper_token_owner_l1
+          ; a = helper_account.body
+          }
+      in
+      let _helper_stmt, (helper_body, _, helper_calls) =
+        run_and_check_exn helper_witness
+          Snark_params.Tick.Typ.(Mina_base.Zkapp_statement.typ * V.typ)
+          Bridge_inst_mina.Rule_bridge_outer_token_owner.main
+      in
+      let helper_account_update =
+        Account_update.with_aux
+          ~body:
+            ( match Is_compile_simple_real.is_compile_simple_real with
+            | Some _ ->
+                helper_body
+            | None ->
+                { helper_body with authorization_kind = None_given } )
+          ~authorization:Control.Poly.None_given
+      in
+      let helper_forest =
+        Zkapp_command.Call_forest.cons
+          ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+          ~calls:helper_calls helper_account_update []
+      in
+      let witness_forest =
+        Zkapp_command.Call_forest.cons
+          ~signature_kind:Zeko_circuits_config.Inputs.chain_l1 witness_outer []
+      in
+      let account_update =
+        Account_update.with_aux
+          ~body:
+            ( match Is_compile_simple_real.is_compile_simple_real with
+            | Some _ ->
+                body
+            | None ->
+                (* To make the fake tests work *)
+                { body with authorization_kind = None_given } )
+          ~authorization:Control.Poly.None_given
+      in
+      let forest =
+        Zkapp_command.Call_forest.cons
+          ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+          ~calls:(helper_forest @ witness_forest @ remaining_calls)
+          account_update []
+        |> Zkapp_command.Call_forest.map
+             ~f:Account_update.read_all_proofs_from_disk
+        |> Utils.rehash_forest
+             ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+      in
+      let tx_commitment =
+        Zkapp_command.Transaction_commitment.create
+          ~account_updates_hash:(Zkapp_command.Call_forest.hash forest)
+      in
+      Ok (forest, `Commitment tx_commitment)
+    with exn -> Error (Error.of_exn exn)
+
   let key
       ({ public_key
        ; commit
@@ -923,7 +1132,7 @@ module Finalize_withdrawal = struct
        ; prev_nonce
        ; helper_account_new
        } as request :
-        t_ ) =
+        t_ ) (helper_account_signature : Signature.t) =
     let key = key request in
     ( key
     , Proofs_memory.prove t.proofs_memory key ~f:(fun () ->
@@ -996,6 +1205,23 @@ module Finalize_withdrawal = struct
                   | Error e ->
                       Error.raise e
                   | Ok ((body, _, calls), proof) ->
+                      (* Attach helper account signature *)
+                      let calls =
+                        match calls with
+                        | helper_account :: remaining_calls ->
+                            Zkapp_command.Call_forest.cons
+                              ~signature_kind:
+                                Zeko_circuits_config.Inputs.chain_l1
+                              ~calls:helper_account.elt.calls
+                              { helper_account.elt.account_update with
+                                authorization =
+                                  Control.Poly.Signature
+                                    helper_account_signature
+                              }
+                              remaining_calls
+                        | _ ->
+                            failwith "shouldn't be reachable"
+                      in
                       Utils.attach_proof_to_forest
                         ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
                         ~proof_cache_db:t.proof_cache_db ~body ~calls ~proof

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -81,13 +81,10 @@ let create ~provers ~proof_cache_db ~fee_recipient_l1 ~fee_recipient_l2 =
   }
 
 let wrap_with_transferrer ~signature_kind transferrer calls =
-  Zkapp_command.Call_forest.cons ~signature_kind
-    transferrer
-    calls
+  Zkapp_command.Call_forest.cons ~signature_kind transferrer calls
 
 let transferrer_key ~signature_kind:_ transferrer =
-  [%sexp_of: Account_update.Stable.Latest.t] transferrer
-  |> Sexp.to_string
+  [%sexp_of: Account_update.Stable.Latest.t] transferrer |> Sexp.to_string
 
 let validate_transferrer ~expected_amount transferrer =
   let _ = expected_amount in
@@ -120,8 +117,7 @@ module Deposit_request = struct
     let key =
       key { deposit_params }
       ^ ":"
-      ^ transferrer_key
-          ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+      ^ transferrer_key ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
           transferrer
     in
     ( key
@@ -142,34 +138,34 @@ module Deposit_request = struct
                   in
                   Zkapp_command.Call_forest.cons
                     ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
-                    (Account_update.with_aux
-                       ~body:
-                         { Mina_base.Account_update.Body.dummy with
-                           use_full_commitment = true
-                         ; public_key = deposit_params.holder_account_l1
-                         ; balance_change =
-                             Currency.Amount.Signed.(
-                               of_unsigned deposit_params.amount)
-                         ; may_use_token = Parents_own_token
-                         ; authorization_kind = None_given
-                         }
-                       ~authorization:Control.Poly.None_given
+                    ( Account_update.with_aux
+                        ~body:
+                          { Mina_base.Account_update.Body.dummy with
+                            use_full_commitment = true
+                          ; public_key = deposit_params.holder_account_l1
+                          ; balance_change =
+                              Currency.Amount.Signed.(
+                                of_unsigned deposit_params.amount)
+                          ; may_use_token = Parents_own_token
+                          ; authorization_kind = None_given
+                          }
+                        ~authorization:Control.Poly.None_given
                     |> Account_update.read_all_proofs_from_disk )
                     user_children
                 in
                 let fee_payout_forest =
                   Zkapp_command.Call_forest.cons
                     ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
-                    (Account_update.with_aux
-                       ~body:
-                         { Mina_base.Account_update.Body.dummy with
-                           public_key = t.fee_recipient_l1
-                         ; balance_change =
-                             Currency.Amount.Signed.of_unsigned bridge_fee
-                         ; authorization_kind = None_given
-                         ; use_full_commitment = false
-                         }
-                       ~authorization:Control.Poly.None_given
+                    ( Account_update.with_aux
+                        ~body:
+                          { Mina_base.Account_update.Body.dummy with
+                            public_key = t.fee_recipient_l1
+                          ; balance_change =
+                              Currency.Amount.Signed.of_unsigned bridge_fee
+                          ; authorization_kind = None_given
+                          ; use_full_commitment = false
+                          }
+                        ~authorization:Control.Poly.None_given
                     |> Account_update.read_all_proofs_from_disk )
                     []
                 in
@@ -233,8 +229,7 @@ module Withdrawal_request = struct
     let key =
       key { withdrawal_params }
       ^ ":"
-      ^ transferrer_key
-          ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+      ^ transferrer_key ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
           transferrer
     in
     ( key
@@ -270,16 +265,16 @@ module Withdrawal_request = struct
                 let fee_payout_forest =
                   Zkapp_command.Call_forest.cons
                     ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
-                    (Account_update.with_aux
-                       ~body:
-                         { Mina_base.Account_update.Body.dummy with
-                           public_key = t.fee_recipient_l2
-                         ; balance_change =
-                             Currency.Amount.Signed.of_unsigned bridge_fee
-                         ; authorization_kind = None_given
-                         ; use_full_commitment = false
-                         }
-                       ~authorization:Control.Poly.None_given
+                    ( Account_update.with_aux
+                        ~body:
+                          { Mina_base.Account_update.Body.dummy with
+                            public_key = t.fee_recipient_l2
+                          ; balance_change =
+                              Currency.Amount.Signed.of_unsigned bridge_fee
+                          ; authorization_kind = None_given
+                          ; use_full_commitment = false
+                          }
+                        ~authorization:Control.Poly.None_given
                     |> Account_update.read_all_proofs_from_disk )
                     []
                 in
@@ -322,6 +317,7 @@ module Finalize_deposit = struct
     { ase_source : Ase.With_length.Stmt.t
     ; check_accepted_init : Bridge_inst_mina.Check_accepted.Definition.Init.t
     ; prev_next_deposit : Zeko_util.Checked32.t
+    ; prev_nonce : Zeko_util.Checked32.t
     }
   [@@deriving snarky]
 
@@ -329,6 +325,7 @@ module Finalize_deposit = struct
     { ase_source : Ase.With_length.Stmt.t
     ; check_accepted_init : Bridge_inst_mina.Check_accepted.Definition.Init.t
     ; prev_next_deposit : Zeko_util.Checked32.t
+    ; prev_nonce : Zeko_util.Checked32.t
     ; ase_elems : Field.t list
     ; check_accepted_elems :
         Bridge_inst_mina.Check_accepted.Definition.Elem.t list
@@ -338,6 +335,7 @@ module Finalize_deposit = struct
       ({ ase_source
        ; check_accepted_init
        ; prev_next_deposit
+       ; prev_nonce
        ; ase_elems
        ; check_accepted_elems
        } :
@@ -347,7 +345,8 @@ module Finalize_deposit = struct
       Bridge_inst_mina.Check_accepted.Definition.Elem.typ
     in
     let t =
-      typ.value_to_fields { ase_source; check_accepted_init; prev_next_deposit }
+      typ.value_to_fields
+        { ase_source; check_accepted_init; prev_next_deposit; prev_nonce }
       |> fst
     in
     let ase_elems = Array.of_list ase_elems in
@@ -368,6 +367,7 @@ module Finalize_deposit = struct
        ; check_accepted_init
        ; check_accepted_elems
        ; prev_next_deposit
+       ; prev_nonce
        } as request :
         t_ ) =
     let key = key request in
@@ -395,7 +395,7 @@ module Finalize_deposit = struct
                     ~ase:(ase_source, ase_elems)
                     ~check_accepted:
                       (check_accepted_init, deposit_hash, check_accepted_elems)
-                    ~prev_next_deposit
+                    ~prev_next_deposit ~prev_nonce
                 with
                 | Error e ->
                     Error.raise e
@@ -610,6 +610,7 @@ module Finalize_withdrawal = struct
     ; withdrawal_ase_source : Ase.With_length.Stmt.t
     ; prev_next_withdrawal : Zeko_util.Checked32.t
     ; withdrawal_params : Bridge_state.Withdrawal_params_base.t
+    ; prev_nonce : Zeko_util.Checked32.t
     }
   [@@deriving snarky]
 
@@ -622,6 +623,7 @@ module Finalize_withdrawal = struct
     ; withdrawal_ase_source : Ase.With_length.Stmt.t
     ; prev_next_withdrawal : Zeko_util.Checked32.t
     ; withdrawal_params : Bridge_state.Withdrawal_params_base.t
+    ; prev_nonce : Zeko_util.Checked32.t
     ; commit_ase_elems : Field.t list
     ; withdrawal_ase_elems : Field.t list
     }
@@ -635,6 +637,7 @@ module Finalize_withdrawal = struct
        ; withdrawal_ase_source
        ; prev_next_withdrawal
        ; withdrawal_params
+       ; prev_nonce
        ; commit_ase_elems
        ; withdrawal_ase_elems
        } :
@@ -650,6 +653,7 @@ module Finalize_withdrawal = struct
         ; withdrawal_ase_source
         ; prev_next_withdrawal
         ; withdrawal_params
+        ; prev_nonce
         }
       |> fst
     in
@@ -672,6 +676,7 @@ module Finalize_withdrawal = struct
        ; withdrawal_ase_elems
        ; prev_next_withdrawal
        ; withdrawal_params
+       ; prev_nonce
        } as request :
         t_ ) =
     let key = key request in
@@ -693,7 +698,7 @@ module Finalize_withdrawal = struct
                       ~before_withdrawal
                       ~withdrawal_ase:
                         (withdrawal_ase_source, withdrawal_ase_elems)
-                      ~prev_next_withdrawal
+                      ~prev_next_withdrawal ~prev_nonce
                       ~withdrawal_params:
                         (Bridge.Finalize_withdrawal.Withdrawal_params_base
                          .to_serializable withdrawal_params )
@@ -727,7 +732,8 @@ module Finalize_withdrawal = struct
                       (helper_account, witness_outer, remaining_calls)
                   | _ ->
                       failwith
-                        "finalize_withdrawal calls: invalid helper/witness layout"
+                        "finalize_withdrawal calls: invalid helper/witness \
+                         layout"
                 in
                 let witness_forest =
                   Zkapp_command.Call_forest.cons
@@ -749,7 +755,9 @@ module Finalize_withdrawal = struct
                         ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
                         ~proof_cache_db:t.proof_cache_db ~body ~calls ~proof
                 in
-                let children = helper_forest @ witness_forest @ remaining_calls in
+                let children =
+                  helper_forest @ witness_forest @ remaining_calls
+                in
                 Utils.attach_proof_to_forest
                   ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
                   ~proof_cache_db:t.proof_cache_db ~body:withdrawal_body

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -853,7 +853,7 @@ module Finalize_deposit = struct
                 let helper_pk = helper.elt.account_update.body.public_key in
                 let () =
                   verify_signature
-                    ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+                    ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
                     ~tx_commitment:commitment ~public_key:helper_pk
                     helper_account_signature
                   |> Or_error.ok_exn

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -769,6 +769,8 @@ module Finalize_cancelled_deposit = struct
     ; check_accepted_init : Bridge_inst_mina.Check_accepted.Definition.Init.t
     ; check_accepted_ase_source : Ase.With_length.Stmt.t
     ; prev_next_cancelled_deposit : Zeko_util.Checked32.t
+    ; prev_nonce : Zeko_util.Checked32.t
+    ; helper_account_new : Zeko_util.Boolean.t
     }
   [@@deriving snarky]
 
@@ -781,12 +783,259 @@ module Finalize_cancelled_deposit = struct
     ; check_accepted_init : Bridge_inst_mina.Check_accepted.Definition.Init.t
     ; check_accepted_ase_source : Ase.With_length.Stmt.t
     ; prev_next_cancelled_deposit : Zeko_util.Checked32.t
+    ; prev_nonce : Zeko_util.Checked32.t
+    ; helper_account_new : Zeko_util.Boolean.t
     ; commit_ase_elems : Field.t list
     ; sync_ase_elems : Field.t list
     ; check_accepted_elems :
         Bridge_inst_mina.Check_accepted.Definition.Elem.t list
     ; check_accepted_ase_elems : Field.t list
     }
+
+  let precompute_commitments t
+      ({ public_key
+       ; commit
+       ; before_commit
+       ; commit_ase_source
+       ; sync_ase_source
+       ; check_accepted_init
+       ; check_accepted_ase_source
+       ; prev_next_cancelled_deposit
+       ; commit_ase_elems
+       ; sync_ase_elems
+       ; check_accepted_elems
+       ; check_accepted_ase_elems
+       ; prev_nonce
+       ; helper_account_new
+       } :
+        t_ ) =
+    let deposit, check_accepted_elems =
+      (List.hd_exn check_accepted_elems, List.tl_exn check_accepted_elems)
+    in
+    let deposit_hash =
+      Zkapp_account.Actions_impl.hash [ Utils.actions_of_outer_action deposit ]
+    in
+    let commit_ase =
+      let target =
+        fold
+          ~init_fn:(Ase.M_without_length.init ~check:None)
+          ~step_fn:Ase.M_without_length.step
+          ~init_typ:Ase.M_without_length.Init.typ
+          ~stmt_typ:Ase.M_without_length.Stmt.typ ~elm_typ:F.typ
+          commit_ase_source commit_ase_elems
+      in
+      Bridge_inst_mina.Rule_bridge_finalize_cancelled_deposit.Ase_outer_inst
+      .make
+        ~proof:
+          (Compile_simple.Proof.of_pickles
+             Pickles_types.Nat.(Pickles.Proof.dummy N2.n N2.n ~domain_log2:14) )
+        ~proof_source:commit_ase_source ~proof_target:target commit_ase_source
+        []
+    in
+    let sync_ase =
+      let target =
+        fold
+          ~init_fn:(Ase.M_with_length.init ~check:None)
+          ~step_fn:Ase.M_with_length.step ~init_typ:Ase.M_with_length.Init.typ
+          ~stmt_typ:Ase.M_with_length.Stmt.typ ~elm_typ:F.typ sync_ase_source
+          sync_ase_elems
+      in
+      Bridge.Finalize_cancelled_deposit.Ase_outer_with_length_inst.make
+        ~proof:
+          (Compile_simple.Proof.of_pickles
+             Pickles_types.Nat.(Pickles.Proof.dummy N2.n N2.n ~domain_log2:14) )
+        ~proof_source:sync_ase_source ~proof_target:target sync_ase_source []
+    in
+    let check_accepted =
+      let source : Bridge.Check_accepted_mina.Stmt.t =
+        { params = check_accepted_init.params
+        ; action_state =
+            Zkapp_account.Actions_impl.push_hash
+              (Rollup_state.Outer_action_state.raw
+                 check_accepted_init.original_action_state )
+              deposit_hash
+            |> Rollup_state.Outer_action_state.unsafe_value_of_field
+        ; deposit_index = check_accepted_init.deposit_index
+        ; n_steps = Zeko_util.Checked32.zero
+        ; is_rejected = false
+        ; is_accepted = false
+        }
+      in
+      let target =
+        fold
+          ~init_fn:(Bridge_inst_mina.Check_accepted.Definition.init ~check:None)
+          ~step_fn:Bridge_inst_mina.Check_accepted.Definition.step
+          ~init_typ:Bridge_inst_mina.Check_accepted.Definition.Init.typ
+          ~stmt_typ:Bridge_inst_mina.Check_accepted.Definition.Stmt.typ
+          ~elm_typ:Bridge_inst_mina.Check_accepted.Definition.Elem.typ
+          check_accepted_init check_accepted_elems
+      in
+      Bridge_inst_mina.Rule_bridge_finalize_cancelled_deposit
+      .Check_accepted_inst
+      .make
+        ~proof:
+          (Compile_simple.Proof.of_pickles
+             Pickles_types.Nat.(Pickles.Proof.dummy N2.n N2.n ~domain_log2:14) )
+        ~proof_source:source ~proof_target:target check_accepted_init []
+    in
+    let check_accepted_ase =
+      let target =
+        fold
+          ~init_fn:(Ase.M_with_length.init ~check:None)
+          ~step_fn:Ase.M_with_length.step ~init_typ:Ase.M_with_length.Init.typ
+          ~stmt_typ:Ase.M_with_length.Stmt.typ ~elm_typ:F.typ
+          check_accepted_ase_source check_accepted_ase_elems
+      in
+      Bridge.Finalize_cancelled_deposit.Ase_outer_with_length_inst.make
+        ~proof:
+          (Compile_simple.Proof.of_pickles
+             Pickles_types.Nat.(Pickles.Proof.dummy N2.n N2.n ~domain_log2:14) )
+        ~proof_source:check_accepted_ase_source ~proof_target:target
+        check_accepted_ase_source []
+    in
+    let verify_two_outer_ases =
+      run_and_check_exn (commit_ase, sync_ase)
+        Typ.(
+          Bridge_inst_mina.Rule_bridge_finalize_cancelled_deposit.Ase_outer_inst
+          .Stmt
+          .typ
+          * Bridge_inst_mina.Rule_bridge_finalize_cancelled_deposit
+            .Ase_outer_with_length_inst
+            .Stmt
+            .typ)
+        Bridge_inst_mina.Rule_bridge_finalize_cancelled_deposit
+        .Verify_two_outer_ases
+        .main
+      |> Bridge_inst_mina.Rule_bridge_finalize_cancelled_deposit
+         .Verify_two_outer_ases
+         .make_unchecked
+           ~proof:
+             (Compile_simple.Proof.of_pickles
+                Pickles_types.Nat.(
+                  Pickles.Proof.dummy N2.n N2.n ~domain_log2:14) )
+    in
+    let verify_check_accepted_and_ase =
+      run_and_check_exn
+        (check_accepted, check_accepted_ase)
+        Typ.(
+          Bridge_inst_mina.Check_accepted.Definition.Stmt.typ
+          * Bridge_inst_mina.Rule_bridge_finalize_cancelled_deposit
+            .Ase_outer_with_length_inst
+            .Stmt
+            .typ)
+        Bridge_inst_mina.Rule_bridge_finalize_cancelled_deposit
+        .Verify_check_accepted_and_ase
+        .main
+      |> Bridge_inst_mina.Rule_bridge_finalize_cancelled_deposit
+         .Verify_check_accepted_and_ase
+         .make_unchecked
+           ~proof:
+             (Compile_simple.Proof.of_pickles
+                Pickles_types.Nat.(
+                  Pickles.Proof.dummy N2.n N2.n ~domain_log2:14) )
+    in
+    let witness : Bridge.Finalize_cancelled_deposit.t =
+      { vk_hash = t.verification_keys.bridge_mina_l1
+      ; helper_token_owner_l1_vk_hash =
+          t.verification_keys.bridge_mina_token_owner
+      ; public_key
+      ; may_use_token =
+          Bridge_inst_mina.Rule_bridge_finalize_withdrawal.May_use_token.No
+      ; outer_authorization_kind =
+          Zeko_circuits.Rule_bridge_finalize_withdrawal.A.None_given
+      ; commit
+      ; before_commit_ase = before_commit
+      ; verify_two_outer_ases
+      ; verify_check_accepted_and_ase
+      ; prev_next_cancelled_deposit
+      ; prev_nonce
+      ; helper_account_new
+      }
+    in
+    try
+      let _stmt, (body, _, calls) =
+        run_and_check_exn witness
+          Snark_params.Tick.Typ.(Mina_base.Zkapp_statement.typ * V.typ)
+          Bridge_inst_mina.Rule_bridge_finalize_cancelled_deposit.main
+      in
+      let helper_account, witness_outer, remaining_calls =
+        match calls with
+        | { elt =
+              { account_update = _helper_token_owner
+              ; calls =
+                  [ { elt = { account_update = helper_account; calls = []; _ }
+                    ; _
+                    }
+                  ]
+              ; _
+              }
+          ; _
+          }
+          :: { elt = { account_update = witness_outer; calls = []; _ }; _ }
+             :: remaining_calls ->
+            (helper_account, witness_outer, remaining_calls)
+        | _ ->
+            failwith
+              "finalize_withdrawal precompute: invalid helper/witness layout"
+      in
+      let helper_witness =
+        Bridge.Outer_token_owner.of_serializable
+          ~vk_hash:t.verification_keys.bridge_mina_token_owner
+          { public_key = Zeko_circuits_config.Inputs.helper_token_owner_l1
+          ; a = helper_account.body
+          }
+      in
+      let _helper_stmt, (helper_body, _, helper_calls) =
+        run_and_check_exn helper_witness
+          Snark_params.Tick.Typ.(Mina_base.Zkapp_statement.typ * V.typ)
+          Bridge_inst_mina.Rule_bridge_outer_token_owner.main
+      in
+      let helper_account_update =
+        Account_update.with_aux
+          ~body:
+            ( match Is_compile_simple_real.is_compile_simple_real with
+            | Some _ ->
+                helper_body
+            | None ->
+                { helper_body with authorization_kind = None_given } )
+          ~authorization:Control.Poly.None_given
+      in
+      let helper_forest =
+        Zkapp_command.Call_forest.cons
+          ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+          ~calls:helper_calls helper_account_update []
+      in
+      let witness_forest =
+        Zkapp_command.Call_forest.cons
+          ~signature_kind:Zeko_circuits_config.Inputs.chain_l1 witness_outer []
+      in
+      let account_update =
+        Account_update.with_aux
+          ~body:
+            ( match Is_compile_simple_real.is_compile_simple_real with
+            | Some _ ->
+                body
+            | None ->
+                (* To make the fake tests work *)
+                { body with authorization_kind = None_given } )
+          ~authorization:Control.Poly.None_given
+      in
+      let forest =
+        Zkapp_command.Call_forest.cons
+          ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+          ~calls:(helper_forest @ witness_forest @ remaining_calls)
+          account_update []
+        |> Zkapp_command.Call_forest.map
+             ~f:Account_update.read_all_proofs_from_disk
+        |> Utils.rehash_forest
+             ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+      in
+      let tx_commitment =
+        Zkapp_command.Transaction_commitment.create
+          ~account_updates_hash:(Zkapp_command.Call_forest.hash forest)
+      in
+      Ok (forest, `Commitment tx_commitment)
+    with exn -> Error (Error.of_exn exn)
 
   let key
       ({ public_key
@@ -801,8 +1050,10 @@ module Finalize_cancelled_deposit = struct
        ; sync_ase_elems
        ; check_accepted_elems = _
        ; check_accepted_ase_elems
+       ; prev_nonce
+       ; helper_account_new
        } :
-        t_ ) =
+        t_ ) (helper_account_signature : Signature.t) =
     let (Typ typ) = typ in
     let t =
       typ.value_to_fields
@@ -814,15 +1065,19 @@ module Finalize_cancelled_deposit = struct
         ; check_accepted_init
         ; check_accepted_ase_source
         ; prev_next_cancelled_deposit
+        ; prev_nonce
+        ; helper_account_new
         }
       |> fst
     in
     let commit_ase_elems = Array.of_list commit_ase_elems in
     let sync_ase_elems = Array.of_list sync_ase_elems in
     let check_accepted_ase_elems = Array.of_list check_accepted_ase_elems in
+    let r, _s = helper_account_signature in
     Array.append t commit_ase_elems
     |> Array.append sync_ase_elems
     |> Array.append check_accepted_ase_elems
+    |> Array.append [| r |]
     |> Random_oracle.hash
          ~init:(Hash_prefix_create.salt Zeko_constants.bridge_prover_cache)
     |> Field.to_string
@@ -840,9 +1095,11 @@ module Finalize_cancelled_deposit = struct
        ; sync_ase_elems
        ; check_accepted_elems
        ; check_accepted_ase_elems
+       ; prev_nonce
+       ; helper_account_new
        } as request :
-        t_ ) =
-    let key = key request in
+        t_ ) (helper_account_signature : Signature.t) =
+    let key = key request helper_account_signature in
     ( key
     , Proofs_memory.prove t.proofs_memory key ~f:(fun () ->
           let%map result =
@@ -873,35 +1130,36 @@ module Finalize_cancelled_deposit = struct
                         (check_accepted_init, deposit_hash, check_accepted_elems)
                       ~check_accepted_ase:
                         (check_accepted_ase_source, check_accepted_ase_elems)
-                      ~prev_next_cancelled_deposit
+                      ~prev_next_cancelled_deposit ~prev_nonce
+                      ~helper_account_new
                   with
                   | Error e ->
                       Error.raise e
                   | Ok x ->
                       x
                 in
-                let (_, helper_account), witness_outer =
+                let helper_account, witness_outer, remaining_calls =
                   match calls with
-                  | [ { elt =
-                          { account_update = helper_token_owner
-                          ; calls =
-                              [ { elt =
-                                    { account_update = helper_account
-                                    ; calls = []
-                                    ; _
-                                    }
-                                ; _
-                                }
-                              ]
-                          ; _
-                          }
-                      ; _
-                      }
-                    ; { elt = { account_update = witness_outer; calls = []; _ }
-                      ; _
-                      }
-                    ] ->
-                      ((helper_token_owner, helper_account), witness_outer)
+                  | { elt =
+                        { account_update = _helper_token_owner
+                        ; calls =
+                            [ { elt =
+                                  { account_update = helper_account
+                                  ; calls = []
+                                  ; _
+                                  }
+                              ; _
+                              }
+                            ]
+                        ; _
+                        }
+                    ; _
+                    }
+                    :: { elt = { account_update = witness_outer; calls = []; _ }
+                       ; _
+                       }
+                       :: remaining_calls ->
+                      (helper_account, witness_outer, remaining_calls)
                   | _ ->
                       failwith
                         "cancel_deposit calls: no helper token owner or \
@@ -923,11 +1181,30 @@ module Finalize_cancelled_deposit = struct
                   | Error e ->
                       Error.raise e
                   | Ok ((body, _, calls), proof) ->
+                      (* Attach helper account signature *)
+                      let calls =
+                        match calls with
+                        | helper_account :: remaining_calls ->
+                            Zkapp_command.Call_forest.cons
+                              ~signature_kind:
+                                Zeko_circuits_config.Inputs.chain_l1
+                              ~calls:helper_account.elt.calls
+                              { helper_account.elt.account_update with
+                                authorization =
+                                  Control.Poly.Signature
+                                    helper_account_signature
+                              }
+                              remaining_calls
+                        | _ ->
+                            failwith "shouldn't be reachable"
+                      in
                       Utils.attach_proof_to_forest
                         ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
                         ~proof_cache_db:t.proof_cache_db ~body ~calls ~proof
                 in
-                let children = helper_forest @ witness_forest in
+                let children =
+                  helper_forest @ witness_forest @ remaining_calls
+                in
                 Utils.attach_proof_to_forest
                   ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
                   ~proof_cache_db:t.proof_cache_db ~body:cancelled_deposit_body

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -86,7 +86,7 @@ let create ~provers ~proof_cache_db ~preverify_l1 ~preverify_l2 =
   let%map verification_keys =
     Zeko_prover.Client.verification_keys provers >>| Or_error.ok_exn
   in
-  { proofs_memory = Proofs_memory.create ~lifetime:Float.(60. * 20.)
+  { proofs_memory = Proofs_memory.create ~lifetime:Float.(60. * 60.)
   ; provers
   ; proof_cache_db
   ; verification_keys

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -222,11 +222,11 @@ let execute_request ?label t ~logger ~(executor : Executor.t) (key, d) =
   |> Option.value_exn |> snd
   |> function
   | `Pending ->
-      failwith "unreachable"
+      return (Error (Error.of_string "Should not be reachable"))
   | `Proved (Error e) ->
       return (Error e)
   | `Executed _ ->
-      failwith "Already executed"
+      return (Error (Error.of_string "Already executed"))
   | `Proved (Ok forest) ->
       let command : Zkapp_command.t =
         { fee_payer =

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -85,9 +85,6 @@ let create ~provers ~proof_cache_db =
 let wrap_with_transferrer ~signature_kind transferrer calls =
   Zkapp_command.Call_forest.cons ~signature_kind transferrer calls
 
-let transferrer_key ~signature_kind:_ transferrer =
-  [%sexp_of: Account_update.Stable.Latest.t] transferrer |> Sexp.to_string
-
 let validate_transferrer ~expected_amount transferrer =
   (* TODO *)
   let _ = expected_amount in
@@ -267,20 +264,29 @@ module Deposit_request = struct
       Ok (forest, `Commitment tx_commitment)
     with exn -> Error (Error.of_exn exn)
 
-  let key t =
+  let key t (transferrer : Account_update.Stable.V1.t) =
+    let transferrer_hash =
+      Account_update.digest ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+        transferrer
+    in
+    let auth =
+      match transferrer.authorization with
+      | Control.Poly.Signature s ->
+          Signature.to_base58_check s
+      | Control.Poly.Proof _ ->
+          "Proof"
+      | Control.Poly.None_given ->
+          "None_given"
+    in
     let (Typ typ) = Key.typ in
     typ.value_to_fields t |> fst
+    |> Array.append [| transferrer_hash |]
     |> Random_oracle.hash
          ~init:(Hash_prefix_create.salt Zeko_constants.bridge_prover_cache)
-    |> Field.to_string
+    |> Field.to_string |> ( ^ ) ":" |> ( ^ ) auth
 
   let f ~t ~logger ({ deposit_params; transferrer } : t) =
-    let key =
-      key { deposit_params }
-      ^ ":"
-      ^ transferrer_key ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
-          transferrer
-    in
+    let key = key { deposit_params } transferrer in
     ( key
     , Proofs_memory.prove t.proofs_memory key ~f:(fun () ->
           let%map result =
@@ -438,12 +444,26 @@ module Withdrawal_request = struct
       Ok (forest, `Commitment tx_commitment)
     with exn -> Error (Error.of_exn exn)
 
-  let key t =
+  let key t (transferrer : Account_update.Stable.V1.t) =
+    let transferrer_hash =
+      Account_update.digest ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+        transferrer
+    in
+    let auth =
+      match transferrer.authorization with
+      | Control.Poly.Signature s ->
+          Signature.to_base58_check s
+      | Control.Poly.Proof _ ->
+          "Proof"
+      | Control.Poly.None_given ->
+          "None_given"
+    in
     let (Typ typ) = Key.typ in
     typ.value_to_fields t |> fst
+    |> Array.append [| transferrer_hash |]
     |> Random_oracle.hash
          ~init:(Hash_prefix_create.salt Zeko_constants.bridge_prover_cache)
-    |> Field.to_string
+    |> Field.to_string |> ( ^ ) ":" |> ( ^ ) auth
 
   let f ~t ~logger ({ withdrawal_params; transferrer } : t) =
     let bridge_fee = Zeko_circuits_config.Inputs.bridge_proof_fee in
@@ -451,12 +471,7 @@ module Withdrawal_request = struct
       Currency.Amount.add withdrawal_params.amount bridge_fee
       |> Option.value_exn
     in
-    let key =
-      key { withdrawal_params }
-      ^ ":"
-      ^ transferrer_key ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
-          transferrer
-    in
+    let key = key { withdrawal_params } transferrer in
     ( key
     , Proofs_memory.prove t.proofs_memory key ~f:(fun () ->
           let%map result =
@@ -1125,7 +1140,7 @@ module Finalize_withdrawal = struct
        ; commit_ase_elems
        ; withdrawal_ase_elems
        } :
-        t_ ) =
+        t_ ) (helper_account_signature : Signature.t) =
     let (Typ typ) = typ in
     let t =
       typ.value_to_fields
@@ -1144,8 +1159,10 @@ module Finalize_withdrawal = struct
     in
     let commit_ase_elems = Array.of_list commit_ase_elems in
     let withdrawal_ase_elems = Array.of_list withdrawal_ase_elems in
+    let r, _s = helper_account_signature in
     Array.append t commit_ase_elems
     |> Array.append withdrawal_ase_elems
+    |> Array.append [| r |]
     |> Random_oracle.hash
          ~init:(Hash_prefix_create.salt Zeko_constants.bridge_prover_cache)
     |> Field.to_string
@@ -1165,7 +1182,7 @@ module Finalize_withdrawal = struct
        ; helper_account_new
        } as request :
         t_ ) (helper_account_signature : Signature.t) =
-    let key = key request in
+    let key = key request helper_account_signature in
     ( key
     , Proofs_memory.prove t.proofs_memory key ~f:(fun () ->
           let%map result =

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -16,12 +16,13 @@ module Proofs_memory = struct
         ( string
         , float
           * [ `Pending
-            | `Done of
+            | `Proved of
               ( Account_update.Stable.V1.t
               , Zkapp_command.Digest.Account_update.t
               , Zkapp_command.Digest.Forest.t )
               Zkapp_command.Call_forest.t
-              Or_error.t ] )
+              Or_error.t
+            | `Executed of Mina_transaction.Transaction_hash.t Or_error.t ] )
         Hashtbl.t
     ; queue : (string * float) Queue.t
     ; lifetime : float
@@ -61,7 +62,7 @@ module Proofs_memory = struct
     else
       let () = add t key `Pending in
       let%map result = f () in
-      add t key (`Done result)
+      add t key (`Proved result)
 end
 
 type t =
@@ -132,9 +133,11 @@ let execute_request t ~logger ~(executor : Executor.t) (key, d) =
   |> function
   | `Pending ->
       failwith "unreachable"
-  | `Done (Error e) ->
+  | `Proved (Error e) ->
       return (Error e)
-  | `Done (Ok forest) ->
+  | `Executed _ ->
+      failwith "Already executed"
+  | `Proved (Ok forest) ->
       let command : Zkapp_command.t =
         { fee_payer =
             Account_update.Fee_payer.make
@@ -153,7 +156,9 @@ let execute_request t ~logger ~(executor : Executor.t) (key, d) =
         ; memo = Signed_command_memo.empty
         }
       in
-      Executor.send_zkapp_command ~logger executor command
+      let%map result = Executor.send_zkapp_command ~logger executor command in
+      Proofs_memory.add t.proofs_memory key (`Executed result) ;
+      result
 
 module Deposit_request = struct
   type t =
@@ -1250,4 +1255,5 @@ let prove t prover =
   let%map () = d in
   Proofs_memory.get t.proofs_memory key
   |> Option.value_exn |> snd
-  |> function `Pending -> failwith "unreachable" | `Done x -> x
+  |> function
+  | `Pending | `Executed _ -> failwith "unreachable" | `Proved x -> x

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -69,20 +69,16 @@ type t =
   { proofs_memory : Proofs_memory.t
   ; provers : Zeko_prover.Client.t
   ; proof_cache_db : Proof_cache_tag.cache_db
-  ; fee_recipient_l1 : Public_key.Compressed.t
-  ; fee_recipient_l2 : Public_key.Compressed.t
   ; verification_keys : Zeko_prover.Prover.Verification_key_hashes.t
   }
 
-let create ~provers ~proof_cache_db ~fee_recipient_l1 ~fee_recipient_l2 =
+let create ~provers ~proof_cache_db =
   let%map verification_keys =
     Zeko_prover.Client.verification_keys provers >>| Or_error.ok_exn
   in
   { proofs_memory = Proofs_memory.create ~lifetime:Float.(60. * 20.)
   ; provers
   ; proof_cache_db
-  ; fee_recipient_l1
-  ; fee_recipient_l2
   ; verification_keys
   }
 
@@ -126,7 +122,7 @@ let fold ~(init_fn : 'init_var -> 'stmt_var Checked.t)
      in
      As_prover.read stmt_typ stmt )
 
-let execute_request t ~logger ~(executor : Executor.t) (key, d) =
+let execute_request ?label t ~logger ~(executor : Executor.t) (key, d) =
   let%bind () = d in
   Proofs_memory.get t.proofs_memory key
   |> Option.value_exn |> snd
@@ -156,6 +152,14 @@ let execute_request t ~logger ~(executor : Executor.t) (key, d) =
         ; memo = Signed_command_memo.empty
         }
       in
+      let () =
+        match label with
+        | None ->
+            ()
+        | Some label ->
+            printf "%s: %s\n%!" label
+              (Yojson.Safe.to_string (Zkapp_command.to_yojson command))
+      in
       let%map result = Executor.send_zkapp_command ~logger executor command in
       Proofs_memory.add t.proofs_memory key (`Executed result) ;
       result
@@ -171,7 +175,7 @@ module Deposit_request = struct
     [@@deriving snarky]
   end
 
-  let make_witness t (deposit_params : Bridge_state.Deposit_params_base.t) :
+  let make_witness (deposit_params : Bridge_state.Deposit_params_base.t) :
       Bridge.Outer_action_witness.serializable =
     let receive_forest =
       let user_children =
@@ -200,7 +204,7 @@ module Deposit_request = struct
         ( Account_update.with_aux
             ~body:
               { Mina_base.Account_update.Body.dummy with
-                public_key = t.fee_recipient_l1
+                public_key = Zeko_circuits_config.Inputs.bridge_fee_recipient_l1
               ; balance_change =
                   Currency.Amount.Signed.of_unsigned
                     Zeko_circuits_config.Inputs.bridge_proof_fee
@@ -226,7 +230,7 @@ module Deposit_request = struct
       Bridge.Outer_action_witness.of_serializable
         ~proof_cache_db:(Proof_cache_tag.create_identity_db ())
         ~vk_hash:t.verification_keys.outer_rules
-        (make_witness t deposit_params)
+        (make_witness deposit_params)
     in
     try
       let _stmt, (body, _, calls) =
@@ -293,7 +297,7 @@ module Deposit_request = struct
                   | Error e ->
                       Error.raise e
                 in
-                let witness = make_witness t deposit_params in
+                let witness = make_witness deposit_params in
                 match%map
                   Zeko_prover.Client.outer_action_witness t.provers witness
                 with
@@ -363,7 +367,7 @@ module Withdrawal_request = struct
         ( Account_update.with_aux
             ~body:
               { Mina_base.Account_update.Body.dummy with
-                public_key = t.fee_recipient_l2
+                public_key = Zeko_circuits_config.Inputs.bridge_fee_recipient_l2
               ; balance_change =
                   Currency.Amount.Signed.of_unsigned
                     Zeko_circuits_config.Inputs.bridge_proof_fee

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -65,20 +65,24 @@ module Proofs_memory = struct
       add t key (`Proved result)
 end
 
+type precomputed_forest =
+  ( Account_update.Stable.V1.t
+  , Zkapp_command.Digest.Account_update.t
+  , Zkapp_command.Digest.Forest.t )
+  Zkapp_command.Call_forest.t
+
+type preverify_fn = precomputed_forest -> unit Deferred.Or_error.t
+
 type t =
   { proofs_memory : Proofs_memory.t
   ; provers : Zeko_prover.Client.t
   ; proof_cache_db : Proof_cache_tag.cache_db
   ; verification_keys : Zeko_prover.Prover.Verification_key_hashes.t
-  ; preverify_l2 :
-         ( Account_update.Stable.V1.t
-         , Zkapp_command.Digest.Account_update.t
-         , Zkapp_command.Digest.Forest.t )
-         Zkapp_command.Call_forest.t
-      -> unit Deferred.Or_error.t
+  ; preverify_l1 : preverify_fn
+  ; preverify_l2 : preverify_fn
   }
 
-let create ~provers ~proof_cache_db ~preverify_l2 =
+let create ~provers ~proof_cache_db ~preverify_l1 ~preverify_l2 =
   let%map verification_keys =
     Zeko_prover.Client.verification_keys provers >>| Or_error.ok_exn
   in
@@ -86,8 +90,53 @@ let create ~provers ~proof_cache_db ~preverify_l2 =
   ; provers
   ; proof_cache_db
   ; verification_keys
+  ; preverify_l1
   ; preverify_l2
   }
+
+(** For [Finalize_cancelled_deposit] and [Finalize_withdrawal] the helper
+    account update lives at [forest[0].calls[0].calls[0]] (nested inside the
+    helper_token_owner). [precompute_commitments] returns it with
+    [authorization = None_given], so the unchecked apply path's
+    is_signed/signature_verifies assertion would trip during preverify. This
+    splices [helper_account_signature] into the right account update so
+    preverify sees the same authorization the executor will eventually
+    submit. *)
+let attach_nested_helper_signature ~signature_kind
+    (forest : precomputed_forest) helper_signature : precomputed_forest =
+  match forest with
+  | [ ({ elt =
+           ( { calls =
+                 ( { elt =
+                       ( { calls = helper_tree :: helper_rest; _ } as
+                       hto_elt )
+                   ; _
+                   } as hto_tree )
+                 :: action_rest
+             ; _
+             } as top_elt )
+       ; _
+       } as top_tree )
+    ] ->
+      let new_inner_calls =
+        Zkapp_command.Call_forest.cons ~signature_kind
+          ~calls:helper_tree.elt.calls
+          { helper_tree.elt.account_update with
+            authorization = Control.Poly.Signature helper_signature
+          }
+          helper_rest
+      in
+      let new_hto_tree =
+        { hto_tree with elt = { hto_elt with calls = new_inner_calls } }
+      in
+      let new_top =
+        { top_tree with
+          elt = { top_elt with calls = new_hto_tree :: action_rest }
+        }
+      in
+      [ new_top ] |> Utils.rehash_forest ~signature_kind
+  | _ ->
+      failwith "attach_nested_helper_signature: unexpected forest layout"
 
 (** Verify a Schnorr signature against the partial transaction commitment. The
     signing public key is taken to be that of the supplied account update. Used
@@ -326,9 +375,9 @@ module Deposit_request = struct
                   | Error e ->
                       Error.raise e
                 in
-                (* Verify the transferrer signature against the precomputed
-                   commitment before spending compute on the proof. *)
-                let _forest, `Commitment commitment =
+                (* Verify the transferrer signature and preverify the command
+                   on L1 before spending compute on the proof. *)
+                let forest, `Commitment commitment =
                   precompute_commitments t { deposit_params; transferrer }
                   |> Or_error.ok_exn
                 in
@@ -342,6 +391,9 @@ module Deposit_request = struct
                       |> Or_error.ok_exn
                   | _ ->
                       failwith "Deposit_request: transferrer must be signed"
+                in
+                let%bind () =
+                  t.preverify_l1 forest >>| Or_error.ok_exn
                 in
                 let witness = make_witness deposit_params in
                 match%map
@@ -1206,9 +1258,8 @@ module Finalize_cancelled_deposit = struct
     , Proofs_memory.prove t.proofs_memory key ~f:(fun () ->
           let%map result =
             try_with (fun () ->
-                (* Verify the helper-account signature against the precomputed
-                   commitment before spending compute on the proof. This action
-                   targets L1, so we don't preverify here. *)
+                (* Verify the helper-account signature and preverify the
+                   command on L1 before spending compute on the proof. *)
                 let forest, `Commitment commitment =
                   precompute_commitments t request |> Or_error.ok_exn
                 in
@@ -1245,6 +1296,14 @@ module Finalize_cancelled_deposit = struct
                     ~tx_commitment:commitment ~public_key:helper_pk
                     helper_account_signature
                   |> Or_error.ok_exn
+                in
+                let forest =
+                  attach_nested_helper_signature
+                    ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+                    forest helper_account_signature
+                in
+                let%bind () =
+                  t.preverify_l1 forest >>| Or_error.ok_exn
                 in
                 let%bind ( (cancelled_deposit_body, _, calls)
                          , cancelled_deposit_proof ) =
@@ -1606,9 +1665,8 @@ module Finalize_withdrawal = struct
     , Proofs_memory.prove t.proofs_memory key ~f:(fun () ->
           let%map result =
             try_with (fun () ->
-                (* Verify the helper-account signature against the precomputed
-                   commitment before spending compute on the proof. This action
-                   targets L1, so we don't preverify here. *)
+                (* Verify the helper-account signature and preverify the
+                   command on L1 before spending compute on the proof. *)
                 let forest, `Commitment commitment =
                   precompute_commitments t request |> Or_error.ok_exn
                 in
@@ -1645,6 +1703,14 @@ module Finalize_withdrawal = struct
                     ~tx_commitment:commitment ~public_key:helper_pk
                     helper_account_signature
                   |> Or_error.ok_exn
+                in
+                let forest =
+                  attach_nested_helper_signature
+                    ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+                    forest helper_account_signature
+                in
+                let%bind () =
+                  t.preverify_l1 forest >>| Or_error.ok_exn
                 in
                 let%bind (withdrawal_body, _, calls), withdrawal_proof =
                   match%map

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -102,21 +102,19 @@ let create ~provers ~proof_cache_db ~preverify_l1 ~preverify_l2 =
     splices [helper_account_signature] into the right account update so
     preverify sees the same authorization the executor will eventually
     submit. *)
-let attach_nested_helper_signature ~signature_kind
-    (forest : precomputed_forest) helper_signature : precomputed_forest =
+let attach_nested_helper_signature ~signature_kind (forest : precomputed_forest)
+    helper_signature : precomputed_forest =
   match forest with
-  | [ ({ elt =
-           ( { calls =
-                 ( { elt =
-                       ( { calls = helper_tree :: helper_rest; _ } as
-                       hto_elt )
-                   ; _
-                   } as hto_tree )
-                 :: action_rest
-             ; _
-             } as top_elt )
-       ; _
-       } as top_tree )
+  | [ ( { elt =
+            { calls =
+                ( { elt = { calls = helper_tree :: helper_rest; _ } as hto_elt
+                  ; _
+                  } as hto_tree )
+                :: action_rest
+            ; _
+            } as top_elt
+        ; _
+        } as top_tree )
     ] ->
       let new_inner_calls =
         Zkapp_command.Call_forest.cons ~signature_kind
@@ -157,11 +155,38 @@ let verify_signature ~signature_kind ~tx_commitment ~public_key signature =
 let wrap_with_transferrer ~signature_kind transferrer calls =
   Zkapp_command.Call_forest.cons ~signature_kind transferrer calls
 
-let validate_transferrer ~expected_amount transferrer =
-  (* TODO *)
-  let _ = expected_amount in
-  let _ = transferrer in
-  Ok ()
+(* The transferrer is the user-supplied account update wrapped at the top of
+   submitDeposit/submitWithdrawal forests. Reject anything that isn't a
+   plain default-token transfer of [-(amount + bridge_fee)] from the user's
+   account, signed with a constant-nonce precondition and no children. *)
+let validate_transferrer ~expected_amount
+    (transferrer : Account_update.Stable.Latest.t) =
+  let proof_cache_db = Proof_cache_tag.create_identity_db () in
+  let transferrer =
+    Account_update.write_all_proofs_to_disk ~proof_cache_db transferrer
+  in
+  let forest =
+    Zkapp_command.Call_forest.cons (* signature_kind does not matter here *)
+      ~signature_kind:Mina_signature_kind.t_DEPRECATED transferrer []
+  in
+  let expected_balance_change =
+    Currency.Amount.Signed.(negate (of_unsigned expected_amount))
+  in
+  let spec : Utils.Forest_shape.field list list =
+    [ [ Token_id Token_id.default
+      ; Balance_change expected_balance_change
+      ; Increment_nonce true
+      ; Use_full_commitment false
+      ; Authorization_kind Signature
+      ; Preconditions_constant_nonce_only
+      ; Calls []
+      ]
+    ]
+  in
+  if Utils.Forest_shape.matches forest spec then Ok ()
+  else
+    Or_error.error_string
+      "validate_transferrer: account update does not match expected shape"
 
 let run_and_check_exn (input : 'input) out_typ
     (main :
@@ -392,9 +417,7 @@ module Deposit_request = struct
                   | _ ->
                       failwith "Deposit_request: transferrer must be signed"
                 in
-                let%bind () =
-                  t.preverify_l1 forest >>| Or_error.ok_exn
-                in
+                let%bind () = t.preverify_l1 forest >>| Or_error.ok_exn in
                 let witness = make_witness deposit_params in
                 match%map
                   Zeko_prover.Client.outer_action_witness t.provers witness
@@ -1299,12 +1322,10 @@ module Finalize_cancelled_deposit = struct
                 in
                 let forest =
                   attach_nested_helper_signature
-                    ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
-                    forest helper_account_signature
+                    ~signature_kind:Zeko_circuits_config.Inputs.chain_l1 forest
+                    helper_account_signature
                 in
-                let%bind () =
-                  t.preverify_l1 forest >>| Or_error.ok_exn
-                in
+                let%bind () = t.preverify_l1 forest >>| Or_error.ok_exn in
                 let%bind ( (cancelled_deposit_body, _, calls)
                          , cancelled_deposit_proof ) =
                   let deposit, check_accepted_elems =
@@ -1706,12 +1727,10 @@ module Finalize_withdrawal = struct
                 in
                 let forest =
                   attach_nested_helper_signature
-                    ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
-                    forest helper_account_signature
+                    ~signature_kind:Zeko_circuits_config.Inputs.chain_l1 forest
+                    helper_account_signature
                 in
-                let%bind () =
-                  t.preverify_l1 forest >>| Or_error.ok_exn
-                in
+                let%bind () = t.preverify_l1 forest >>| Or_error.ok_exn in
                 let%bind (withdrawal_body, _, calls), withdrawal_proof =
                   match%map
                     Zeko_prover.Client.finalize_withdrawal t.provers ~public_key

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -622,12 +622,12 @@ module Finalize_deposit = struct
       in
       let forest =
         Zkapp_command.Call_forest.cons
-          ~signature_kind:Zeko_circuits_config.Inputs.chain_l1 ~calls
+          ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 ~calls
           account_update []
         |> Zkapp_command.Call_forest.map
              ~f:Account_update.read_all_proofs_from_disk
         |> Utils.rehash_forest
-             ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+             ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
       in
       let tx_commitment =
         Zkapp_command.Transaction_commitment.create
@@ -645,7 +645,7 @@ module Finalize_deposit = struct
        ; ase_elems
        ; check_accepted_elems
        } :
-        t_ ) =
+        t_ ) (helper_account_signature : Signature.t) =
     let (Typ typ) = typ in
     let (Typ check_accepted_elems_typ) =
       Bridge_inst_mina.Check_accepted.Definition.Elem.typ
@@ -666,8 +666,10 @@ module Finalize_deposit = struct
           check_accepted_elems_typ.value_to_fields x |> fst |> Array.to_list )
       |> List.join |> List.to_array
     in
+    let r, _s = helper_account_signature in
     Array.append t ase_elems
     |> Array.append check_accepted_elems
+    |> Array.append [| r |]
     |> Random_oracle.hash
          ~init:(Hash_prefix_create.salt Zeko_constants.bridge_prover_cache)
     |> Field.to_string
@@ -682,7 +684,7 @@ module Finalize_deposit = struct
        ; helper_account_new
        } as request :
         t_ ) (helper_account_signature : Signature.t) =
-    let key = key request in
+    let key = key request helper_account_signature in
     ( key
     , Proofs_memory.prove t.proofs_memory key ~f:(fun () ->
           let%map result =

--- a/src/app/zeko/sequencer/lib/committer.ml
+++ b/src/app/zeko/sequencer/lib/committer.ml
@@ -66,7 +66,7 @@ module Commit_table = struct
 end
 
 let prove_commit ~logger ~proof_cache_db ~provers ~(executor : Executor.t)
-    ~(archive : Archive.t) ~zkapp_pk ~archive_uri ~l1_config
+    ~l1_uri ~(archive : Archive.t) ~zkapp_pk ~archive_uri ~l1_config
     ~commit_validity_period
     ({ old_inner_ledger
      ; new_inner_ledger
@@ -98,9 +98,7 @@ let prove_commit ~logger ~proof_cache_db ~provers ~(executor : Executor.t)
             ; status_flags
             ; _
             } =
-      Gql_client.infer_state ~logger
-        Executor.(executor.l1_uri)
-        ~zkapp_pk
+      Gql_client.infer_state ~logger l1_uri ~zkapp_pk
         ~signer_pk:(Signer_service.Signer.public_key executor.signer)
       >>| Utils.value_of_zkapp_state Rollup_state.Outer_state.typ
     in
@@ -207,11 +205,11 @@ let prove_commit ~logger ~proof_cache_db ~provers ~(executor : Executor.t)
   return command
 
 let recommit_all ~logger ~proof_cache_db ~db_pool ~provers
-    ~(executor : Executor.t) ~archive ~zkapp_pk ~archive_uri ~l1_config
+    ~(executor : Executor.t) ~l1_uri ~archive ~zkapp_pk ~archive_uri ~l1_config
     ~commit_validity_period =
   let open Deferred.Result.Let_syntax in
   let%bind { ledger_hash; _ } =
-    Gql_client.infer_state ~logger executor.l1_uri ~zkapp_pk
+    Gql_client.infer_state ~logger l1_uri ~zkapp_pk
       ~signer_pk:(Signer_service.Signer.public_key executor.signer)
     >>| Utils.value_of_zkapp_state Rollup_state.Outer_state.typ
   in
@@ -239,10 +237,11 @@ let recommit_all ~logger ~proof_cache_db ~db_pool ~provers
               ()
         in
         let%bind command =
-          prove_commit ~logger ~proof_cache_db ~provers ~executor ~archive
-            ~zkapp_pk ~archive_uri ~l1_config ~commit_validity_period witness
+          prove_commit ~logger ~proof_cache_db ~provers ~executor ~l1_uri
+            ~archive ~zkapp_pk ~archive_uri ~l1_config ~commit_validity_period
+            witness
         in
-        let%bind () = Executor.send_zkapp_command ~logger executor command in
+        let%bind _hash = Executor.send_zkapp_command ~logger executor command in
         recommit_next target_ledger_hash
   in
   recommit_next ledger_hash

--- a/src/app/zeko/sequencer/lib/deploy.ml
+++ b/src/app/zeko/sequencer/lib/deploy.ml
@@ -307,7 +307,7 @@ let deploy_token_owner_exn ~signature_kind ~(signer : Keypair.t)
     ~(token_owner_kp : Keypair.t) ~(fee : Currency.Fee.t)
     ~(nonce : Account.Nonce.t) ~(account_creation_fee : Currency.Fee.t) () =
   let%map _, _, `Token_owner token_owner_update =
-    L.with_ephemeral_ledger ~depth:35 ~f:(fun ledger ->
+    L.with_ledger ~depth:35 ~f:(fun ledger ->
         let%bind `Inner inner_account, `Holder holder_account =
           Z.Inner.initial_accounts ()
         in

--- a/src/app/zeko/sequencer/lib/deploy.ml
+++ b/src/app/zeko/sequencer/lib/deploy.ml
@@ -59,14 +59,11 @@ module Z = struct
           public_key = Zeko_constants.inner_public_key
         ; balance = Currency.Balance.max_int
         ; permissions =
-            { ( if
-                (* see #286 *)
-                Option.is_some Is_compile_simple_real.is_compile_simple_real
-              then proof_permissions
-              else none_permissions )
-              with
-              access = Permissions.Auth_required.None
-            }
+            ( if
+              (* see #286 *)
+              Option.is_some Is_compile_simple_real.is_compile_simple_real
+            then { proof_permissions with access = None }
+            else none_permissions )
         ; zkapp =
             Some
               { Zkapp_account.default with
@@ -150,14 +147,11 @@ module Z = struct
                      Pickles.Side_loaded.Verification_key.dummy ) )
         ; permissions =
             Set
-              { ( if
-                  (* see #286 *)
-                  Option.is_some Is_compile_simple_real.is_compile_simple_real
-                then proof_permissions
-                else none_permissions )
-                with
-                access = None
-              }
+              ( if
+                (* see #286 *)
+                Option.is_some Is_compile_simple_real.is_compile_simple_real
+              then { proof_permissions with access = None }
+              else none_permissions )
         }
       in
       let%bind holder_vk =
@@ -178,14 +172,11 @@ module Z = struct
                      Pickles.Side_loaded.Verification_key.dummy ) )
         ; permissions =
             Set
-              { ( if
-                  (* see #286 *)
-                  Option.is_some Is_compile_simple_real.is_compile_simple_real
-                then proof_permissions
-                else none_permissions )
-                with
-                access = None
-              }
+              ( if
+                (* see #286 *)
+                Option.is_some Is_compile_simple_real.is_compile_simple_real
+              then { proof_permissions with access = None }
+              else none_permissions )
         }
       in
       let%map token_owner_vk =
@@ -206,14 +197,11 @@ module Z = struct
                      Pickles.Side_loaded.Verification_key.dummy ) )
         ; permissions =
             Set
-              { ( if
-                  (* see #286 *)
-                  Option.is_some Is_compile_simple_real.is_compile_simple_real
-                then proof_permissions
-                else none_permissions )
-                with
-                access = Signature
-              }
+              ( if
+                (* see #286 *)
+                Option.is_some Is_compile_simple_real.is_compile_simple_real
+              then { proof_permissions with access = Either }
+              else none_permissions )
         }
       in
       ( `Outer outer_update

--- a/src/app/zeko/sequencer/lib/deploy.ml
+++ b/src/app/zeko/sequencer/lib/deploy.ml
@@ -206,11 +206,14 @@ module Z = struct
                      Pickles.Side_loaded.Verification_key.dummy ) )
         ; permissions =
             Set
-              ( if
-                (* see #286 *)
-                Option.is_some Is_compile_simple_real.is_compile_simple_real
-              then proof_permissions
-              else none_permissions )
+              { ( if
+                  (* see #286 *)
+                  Option.is_some Is_compile_simple_real.is_compile_simple_real
+                then proof_permissions
+                else none_permissions )
+                with
+                access = Signature
+              }
         }
       in
       ( `Outer outer_update
@@ -227,6 +230,138 @@ module Z = struct
       unsafe_deploy ~ledger_hash:(L.merkle_root l)
   end
 end
+
+let deploy_holder_exn ~signature_kind ~(signer : Keypair.t)
+    ~(holder_kp : Keypair.t) ~(fee : Currency.Fee.t) ~(nonce : Account.Nonce.t)
+    ~(account_creation_fee : Currency.Fee.t) () =
+  let%map _, `Holder holder_update, _ =
+    Z.Outer.deploy_exn
+      ~pause_key:
+        ( Public_key.compress
+            (Zeko_types.Even_PC.generate_even_signer ()).public_key
+        |> Zeko_types.Even_PC.create_exn )
+      ~sequencer:
+        ( Public_key.compress
+            (Zeko_types.Even_PC.generate_even_signer ()).public_key
+        |> Zeko_types.Even_PC.create_exn )
+      ~da_key:Field.zero ~acc_set:Account_set.dummy
+      (L.create_ephemeral ~depth:35 ())
+      ()
+  in
+  let holder_au =
+    Account_update.with_aux
+      ~body:
+        { Body.dummy with
+          public_key = Public_key.compress holder_kp.public_key
+        ; implicit_account_creation_fee = false
+        ; update = holder_update
+        ; use_full_commitment = true
+        ; authorization_kind = Signature
+        }
+      ~authorization:(Control.Poly.Signature Signature.dummy)
+  in
+  let sender_update =
+    Account_update.with_aux
+      ~body:
+        { Body.dummy with
+          public_key = Public_key.compress signer.public_key
+        ; balance_change =
+            Currency.Amount.(
+              of_fee account_creation_fee |> Signed.of_unsigned |> Signed.negate)
+        ; use_full_commitment = true
+        ; authorization_kind = Signature
+        }
+      ~authorization:(Control.Poly.Signature Signature.dummy)
+  in
+  let call_forest =
+    Zkapp_command.Call_forest.accumulate_hashes
+      ~hash_account_update:
+        (Zkapp_command.Call_forest.Digest.Account_update.create ~signature_kind)
+    @@ Zkapp_command.Call_forest.of_account_updates
+         ~account_update_depth:(fun _ -> 0)
+         [ holder_au; sender_update ]
+  in
+  let command : Zkapp_command.t =
+    { fee_payer =
+        { Account_update.Fee_payer.body =
+            { public_key = Public_key.compress signer.public_key
+            ; fee
+            ; valid_until = None
+            ; nonce
+            }
+        ; authorization = Signature.dummy
+        }
+    ; account_updates = call_forest
+    ; memo = Signed_command_memo.empty
+    }
+  in
+  Utils.sign_zkapp_command ~signature_kind command [ holder_kp; signer ]
+
+let deploy_token_owner_exn ~signature_kind ~(signer : Keypair.t)
+    ~(token_owner_kp : Keypair.t) ~(fee : Currency.Fee.t)
+    ~(nonce : Account.Nonce.t) ~(account_creation_fee : Currency.Fee.t) () =
+  let%map _, _, `Token_owner token_owner_update =
+    Z.Outer.deploy_exn
+      ~pause_key:
+        ( Public_key.compress
+            (Zeko_types.Even_PC.generate_even_signer ()).public_key
+        |> Zeko_types.Even_PC.create_exn )
+      ~sequencer:
+        ( Public_key.compress
+            (Zeko_types.Even_PC.generate_even_signer ()).public_key
+        |> Zeko_types.Even_PC.create_exn )
+      ~da_key:Field.zero ~acc_set:Account_set.dummy
+      (L.create_ephemeral ~depth:35 ())
+      ()
+  in
+  let token_owner_au =
+    Account_update.with_aux
+      ~body:
+        { Body.dummy with
+          public_key = Public_key.compress token_owner_kp.public_key
+        ; implicit_account_creation_fee = false
+        ; update = token_owner_update
+        ; use_full_commitment = true
+        ; authorization_kind = Signature
+        }
+      ~authorization:(Control.Poly.Signature Signature.dummy)
+  in
+  let sender_update =
+    Account_update.with_aux
+      ~body:
+        { Body.dummy with
+          public_key = Public_key.compress signer.public_key
+        ; balance_change =
+            Currency.Amount.(
+              of_fee account_creation_fee |> Signed.of_unsigned |> Signed.negate)
+        ; use_full_commitment = true
+        ; authorization_kind = Signature
+        }
+      ~authorization:(Control.Poly.Signature Signature.dummy)
+  in
+  let call_forest =
+    Zkapp_command.Call_forest.accumulate_hashes
+      ~hash_account_update:
+        (Zkapp_command.Call_forest.Digest.Account_update.create ~signature_kind)
+    @@ Zkapp_command.Call_forest.of_account_updates
+         ~account_update_depth:(fun _ -> 0)
+         [ token_owner_au; sender_update ]
+  in
+  let command : Zkapp_command.t =
+    { fee_payer =
+        { Account_update.Fee_payer.body =
+            { public_key = Public_key.compress signer.public_key
+            ; fee
+            ; valid_until = None
+            ; nonce
+            }
+        ; authorization = Signature.dummy
+        }
+    ; account_updates = call_forest
+    ; memo = Signed_command_memo.empty
+    }
+  in
+  Utils.sign_zkapp_command ~signature_kind command [ token_owner_kp; signer ]
 
 let deploy_command_exn ~signature_kind ~(signer : Keypair.t)
     ~(fee : Currency.Fee.t) ~(nonce : Account.Nonce.t) ~(outer_kp : Keypair.t)

--- a/src/app/zeko/sequencer/lib/deploy.ml
+++ b/src/app/zeko/sequencer/lib/deploy.ml
@@ -235,18 +235,24 @@ let deploy_holder_exn ~signature_kind ~(signer : Keypair.t)
     ~(holder_kp : Keypair.t) ~(fee : Currency.Fee.t) ~(nonce : Account.Nonce.t)
     ~(account_creation_fee : Currency.Fee.t) () =
   let%map _, `Holder holder_update, _ =
-    Z.Outer.deploy_exn
-      ~pause_key:
-        ( Public_key.compress
-            (Zeko_types.Even_PC.generate_even_signer ()).public_key
-        |> Zeko_types.Even_PC.create_exn )
-      ~sequencer:
-        ( Public_key.compress
-            (Zeko_types.Even_PC.generate_even_signer ()).public_key
-        |> Zeko_types.Even_PC.create_exn )
-      ~da_key:Field.zero ~acc_set:Account_set.dummy
-      (L.create_ephemeral ~depth:35 ())
-      ()
+    L.with_ephemeral_ledger ~depth:35 ~f:(fun ledger ->
+        let%bind `Inner inner_account, `Holder holder_account =
+          Z.Inner.initial_accounts ()
+        in
+        List.iter [ inner_account; holder_account ] ~f:(fun acc ->
+            L.create_new_account_exn ledger
+              (Account_id.create acc.public_key acc.token_id)
+              acc ) ;
+        Z.Outer.deploy_exn
+          ~pause_key:
+            ( Public_key.compress
+                (Zeko_types.Even_PC.generate_even_signer ()).public_key
+            |> Zeko_types.Even_PC.create_exn )
+          ~sequencer:
+            ( Public_key.compress
+                (Zeko_types.Even_PC.generate_even_signer ()).public_key
+            |> Zeko_types.Even_PC.create_exn )
+          ~da_key:Field.zero ~acc_set:Account_set.dummy ledger () )
   in
   let holder_au =
     Account_update.with_aux
@@ -301,18 +307,24 @@ let deploy_token_owner_exn ~signature_kind ~(signer : Keypair.t)
     ~(token_owner_kp : Keypair.t) ~(fee : Currency.Fee.t)
     ~(nonce : Account.Nonce.t) ~(account_creation_fee : Currency.Fee.t) () =
   let%map _, _, `Token_owner token_owner_update =
-    Z.Outer.deploy_exn
-      ~pause_key:
-        ( Public_key.compress
-            (Zeko_types.Even_PC.generate_even_signer ()).public_key
-        |> Zeko_types.Even_PC.create_exn )
-      ~sequencer:
-        ( Public_key.compress
-            (Zeko_types.Even_PC.generate_even_signer ()).public_key
-        |> Zeko_types.Even_PC.create_exn )
-      ~da_key:Field.zero ~acc_set:Account_set.dummy
-      (L.create_ephemeral ~depth:35 ())
-      ()
+    L.with_ephemeral_ledger ~depth:35 ~f:(fun ledger ->
+        let%bind `Inner inner_account, `Holder holder_account =
+          Z.Inner.initial_accounts ()
+        in
+        List.iter [ inner_account; holder_account ] ~f:(fun acc ->
+            L.create_new_account_exn ledger
+              (Account_id.create acc.public_key acc.token_id)
+              acc ) ;
+        Z.Outer.deploy_exn
+          ~pause_key:
+            ( Public_key.compress
+                (Zeko_types.Even_PC.generate_even_signer ()).public_key
+            |> Zeko_types.Even_PC.create_exn )
+          ~sequencer:
+            ( Public_key.compress
+                (Zeko_types.Even_PC.generate_even_signer ()).public_key
+            |> Zeko_types.Even_PC.create_exn )
+          ~da_key:Field.zero ~acc_set:Account_set.dummy ledger () )
   in
   let token_owner_au =
     Account_update.with_aux

--- a/src/app/zeko/sequencer/lib/dune
+++ b/src/app/zeko/sequencer/lib/dune
@@ -2,7 +2,7 @@
  (name sequencer_lib)
  (inline_tests)
  (libraries
- is_compile_simple_real
+  is_compile_simple_real
   signer_service
   kvdb_base
   da_layer

--- a/src/app/zeko/sequencer/lib/executor.ml
+++ b/src/app/zeko/sequencer/lib/executor.ml
@@ -2,33 +2,46 @@ open Async_kernel
 open Core_kernel
 open Mina_base
 open Mina_transaction
+open Signature_lib
+
+module Sequencer_harness = struct
+  type t =
+    { infer_nonce : Public_key.Compressed.t -> Account.Nonce.t
+    ; apply_user_command : User_command.t -> (unit, Error.t) result Deferred.t
+    }
+end
 
 type t =
-  { l1_uri : Uri.t
+  { kind : [ `L1 of Uri.t | `L2 of Sequencer_harness.t ]
   ; signer : Signer_service.Signer.t
   ; q : unit Throttle.t
   ; mutable nonce : Account.Nonce.t option
   ; max_attempts : int
   ; delay : Time_ns.Span.t
-  ; kvdb : Mina_ledger.Ledger.Kvdb.t
   ; signature_kind : Mina_signature_kind.t
   }
 
 let create ?(max_attempts = 5) ?(delay = Time_ns.Span.of_sec 5.) ?nonce
-    ~signature_kind ~l1_uri ~signer ~kvdb () =
-  { l1_uri
+    ~signature_kind ~signer ~kind () =
+  { kind
   ; signature_kind
   ; signer
   ; q = Throttle.create ~continue_on_error:false ~max_concurrent_jobs:1
   ; nonce
   ; max_attempts
   ; delay
-  ; kvdb
   }
 
 let refresh_nonce t = t.nonce <- None
 
 let increment_nonce t = t.nonce <- Option.map t.nonce ~f:Account.Nonce.(add one)
+
+let infer_nonce ~logger t pk =
+  match t.kind with
+  | `L1 l1_uri ->
+      Gql_client.infer_nonce ~logger l1_uri pk
+  | `L2 { infer_nonce; _ } ->
+      return (Ok (infer_nonce pk))
 
 let process_command ~logger t (command : Zkapp_command.t) =
   let rec retry attempt () =
@@ -46,8 +59,7 @@ let process_command ~logger t (command : Zkapp_command.t) =
         | Some nonce ->
             return (Ok nonce)
         | None ->
-            Gql_client.infer_nonce ~logger t.l1_uri
-              (Signer_service.Signer.public_key t.signer)
+            infer_nonce ~logger t (Signer_service.Signer.public_key t.signer)
             >>| Result.map_error ~f:(fun err -> `Nonce_inference_error err)
       in
       let command =
@@ -65,9 +77,21 @@ let process_command ~logger t (command : Zkapp_command.t) =
         >>| Result.map_error ~f:(fun err ->
                 `Send_zkapp_error (`Failed_request (Error.to_string_hum err)) )
       in
-      let%map.Deferred.Result _result =
-        Gql_client.send_zkapp t.l1_uri command
-        >>| Result.map_error ~f:(fun err -> `Send_zkapp_error err)
+      let%map.Deferred.Result () =
+        match t.kind with
+        | `L1 l1_uri ->
+            Gql_client.send_zkapp l1_uri command
+            >>| Result.map_error ~f:(fun err -> `Send_zkapp_error err)
+            >>| Result.map ~f:ignore
+        | `L2 { apply_user_command; _ } ->
+            apply_user_command
+              (Zkapp_command
+                 (Zkapp_command.write_all_proofs_to_disk
+                    ~signature_kind:t.signature_kind
+                    ~proof_cache_db:(Proof_cache_tag.create_identity_db ())
+                    command ) )
+            >>| Result.map_error ~f:(fun e ->
+                    `Send_zkapp_error (`Failed_request (Error.to_string_hum e)) )
       in
       command
     with
@@ -76,7 +100,10 @@ let process_command ~logger t (command : Zkapp_command.t) =
           Transaction_hash.(
             to_base58_check @@ hash_command (Zkapp_command command)) ;
         increment_nonce t ;
-        return (Ok ())
+        let hash : Mina_transaction.Transaction_hash.t =
+          Mina_transaction.Transaction_hash.hash_command (Zkapp_command command)
+        in
+        return (Ok hash)
     | Error err when attempt >= t.max_attempts ->
         return
           (Error

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -1783,12 +1783,13 @@ module Types = struct
               * Bridge.Check_accepted_mina.Elem.t list
           ; prev_next_deposit : Unsigned.uint32
           ; prev_nonce : Unsigned.uint32
+          ; helper_account_new : bool
           }
 
         let arg_typ ~proof_cache_db =
           obj "FinalizeDepositInput"
             ~coerce:(fun ase (check_accepted_init, check_accepted_elems)
-                         prev_next_deposit prev_nonce ->
+                         prev_next_deposit prev_nonce helper_account_new ->
               let%map.Result check_accepted_elems =
                 Result.all check_accepted_elems
               in
@@ -1796,9 +1797,11 @@ module Types = struct
               ; check_accepted = (check_accepted_init, check_accepted_elems)
               ; prev_next_deposit
               ; prev_nonce
+              ; helper_account_new
               } )
             ~split:(fun f (x : input) ->
-              f x.ase x.check_accepted x.prev_next_deposit x.prev_nonce )
+              f x.ase x.check_accepted x.prev_next_deposit x.prev_nonce
+                x.helper_account_new )
             ~fields:
               [ arg "ase" ~typ:(non_null Folder.Ase_with_length.arg_typ)
               ; arg "checkAccepted"
@@ -1807,6 +1810,7 @@ module Types = struct
                     @@ Folder.Check_accepted_mina.arg_typ ~proof_cache_db )
               ; arg "prevNextDeposit" ~typ:(non_null UInt32.arg_typ)
               ; arg "prevNonce" ~typ:(non_null UInt32.arg_typ)
+              ; arg "helperAccountNew" ~typ:(non_null bool)
               ]
       end
 
@@ -1886,13 +1890,14 @@ module Types = struct
           ; prev_next_withdrawal : Unsigned.uint32
           ; withdrawal_params : Withdrawal_params.input
           ; prev_nonce : Unsigned.uint32
+          ; helper_account_new : bool
           }
 
         let arg_typ ~proof_cache_db =
           obj "FinalizeWithdrawalInput"
             ~coerce:(fun public_key commit before_commit commit_ase
                          before_withdrawal withdrawal_ase prev_next_withdrawal
-                         withdrawal_params prev_nonce ->
+                         withdrawal_params prev_nonce helper_account_new ->
               let%map.Result commit =
                 match%bind.Result commit with
                 | Commit commit ->
@@ -1913,6 +1918,7 @@ module Types = struct
               ; prev_next_withdrawal
               ; withdrawal_params
               ; prev_nonce
+              ; helper_account_new
               } )
             ~split:(fun f (x : input) ->
               f x.public_key (Commit x.commit)
@@ -1922,7 +1928,7 @@ module Types = struct
                 (Zeko_circuits.Rollup_state.Inner_action_state.raw
                    x.before_withdrawal )
                 x.withdrawal_ase x.prev_next_withdrawal x.withdrawal_params
-                x.prev_nonce )
+                x.prev_nonce x.helper_account_new )
             ~fields:
               [ arg "publicKey" ~typ:(non_null PublicKey.arg_typ)
               ; arg "commit"
@@ -1939,6 +1945,7 @@ module Types = struct
               ; arg "withdrawalParams"
                   ~typ:(non_null @@ Withdrawal_params.arg_typ ~proof_cache_db)
               ; arg "prevNonce" ~typ:(non_null UInt32.arg_typ)
+              ; arg "helperAccountNew" ~typ:(non_null bool)
               ]
       end
     end
@@ -2356,6 +2363,7 @@ module Mutations = struct
                                        check_accepted_init, check_accepted_elems
                                    ; prev_next_deposit
                                    ; prev_nonce
+                                   ; helper_account_new
                                    } =
             return (Result.map_error witness ~f:Error.to_string_hum)
           in
@@ -2369,6 +2377,7 @@ module Mutations = struct
               ; check_accepted_elems
               ; prev_next_deposit
               ; prev_nonce
+              ; helper_account_new
               }
           in
           don't_wait_for d ; return (Ok key) )
@@ -2397,6 +2406,7 @@ module Mutations = struct
                                    ; prev_next_withdrawal
                                    ; withdrawal_params
                                    ; prev_nonce
+                                   ; helper_account_new
                                    } =
             return (Result.map_error witness ~f:Error.to_string_hum)
           in
@@ -2415,6 +2425,7 @@ module Mutations = struct
               ; prev_next_withdrawal
               ; withdrawal_params
               ; prev_nonce
+              ; helper_account_new
               }
           in
           don't_wait_for d ; return (Ok key) )

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -1448,7 +1448,8 @@ module Types = struct
         let arg_typ =
           scalar "BridgeTransferrerInput"
             ~doc:
-              "A single pre-signed account update encoded as accountUpdates JSON"
+              "A single pre-signed account update encoded as accountUpdates \
+               JSON"
             ~coerce:(function
               | `String s ->
                   Result.try_with (fun () ->
@@ -1476,12 +1477,12 @@ module Types = struct
             ~to_json:(fun account_update ->
               let forest =
                 Mina_base.Zkapp_command.Call_forest.cons
-                  ~signature_kind:Zeko_circuits_config.t.chain_l1
-                  account_update []
+                  ~signature_kind:Zeko_circuits_config.t.chain_l1 account_update
+                  []
               in
               `String
-                (Yojson.Safe.to_string
-                @@ Mina_base.Zkapp_command.account_updates_to_json forest) )
+                ( Yojson.Safe.to_string
+                @@ Mina_base.Zkapp_command.account_updates_to_json forest ) )
       end
 
       module Folder = struct
@@ -1781,21 +1782,23 @@ module Types = struct
               Bridge.Check_accepted_mina.Init.t
               * Bridge.Check_accepted_mina.Elem.t list
           ; prev_next_deposit : Unsigned.uint32
+          ; prev_nonce : Unsigned.uint32
           }
 
         let arg_typ ~proof_cache_db =
           obj "FinalizeDepositInput"
             ~coerce:(fun ase (check_accepted_init, check_accepted_elems)
-                         prev_next_deposit ->
+                         prev_next_deposit prev_nonce ->
               let%map.Result check_accepted_elems =
                 Result.all check_accepted_elems
               in
               { ase
               ; check_accepted = (check_accepted_init, check_accepted_elems)
               ; prev_next_deposit
+              ; prev_nonce
               } )
             ~split:(fun f (x : input) ->
-              f x.ase x.check_accepted x.prev_next_deposit )
+              f x.ase x.check_accepted x.prev_next_deposit x.prev_nonce )
             ~fields:
               [ arg "ase" ~typ:(non_null Folder.Ase_with_length.arg_typ)
               ; arg "checkAccepted"
@@ -1803,6 +1806,7 @@ module Types = struct
                     ( non_null
                     @@ Folder.Check_accepted_mina.arg_typ ~proof_cache_db )
               ; arg "prevNextDeposit" ~typ:(non_null UInt32.arg_typ)
+              ; arg "prevNonce" ~typ:(non_null UInt32.arg_typ)
               ]
       end
 
@@ -1881,13 +1885,14 @@ module Types = struct
           ; withdrawal_ase : Ase.With_length.Stmt.t * Field.t list
           ; prev_next_withdrawal : Unsigned.uint32
           ; withdrawal_params : Withdrawal_params.input
+          ; prev_nonce : Unsigned.uint32
           }
 
         let arg_typ ~proof_cache_db =
           obj "FinalizeWithdrawalInput"
             ~coerce:(fun public_key commit before_commit commit_ase
                          before_withdrawal withdrawal_ase prev_next_withdrawal
-                         withdrawal_params ->
+                         withdrawal_params prev_nonce ->
               let%map.Result commit =
                 match%bind.Result commit with
                 | Commit commit ->
@@ -1907,6 +1912,7 @@ module Types = struct
               ; withdrawal_ase
               ; prev_next_withdrawal
               ; withdrawal_params
+              ; prev_nonce
               } )
             ~split:(fun f (x : input) ->
               f x.public_key (Commit x.commit)
@@ -1915,7 +1921,8 @@ module Types = struct
                 x.commit_ase
                 (Zeko_circuits.Rollup_state.Inner_action_state.raw
                    x.before_withdrawal )
-                x.withdrawal_ase x.prev_next_withdrawal x.withdrawal_params )
+                x.withdrawal_ase x.prev_next_withdrawal x.withdrawal_params
+                x.prev_nonce )
             ~fields:
               [ arg "publicKey" ~typ:(non_null PublicKey.arg_typ)
               ; arg "commit"
@@ -1931,6 +1938,7 @@ module Types = struct
               ; arg "prevNextWithdrawal" ~typ:(non_null UInt32.arg_typ)
               ; arg "withdrawalParams"
                   ~typ:(non_null @@ Withdrawal_params.arg_typ ~proof_cache_db)
+              ; arg "prevNonce" ~typ:(non_null UInt32.arg_typ)
               ]
       end
     end
@@ -2321,7 +2329,8 @@ module Mutations = struct
                   @@ Types.Input.Provers.Withdrawal_request.arg_typ
                        ~proof_cache_db )
             ]
-        ~resolve:(fun { ctx = sequencer; _ } () { withdrawal_params; transferrer } ->
+        ~resolve:(fun { ctx = sequencer; _ } ()
+                      { withdrawal_params; transferrer } ->
           let key, d =
             Bridge_prover.Withdrawal_request.f
               ~t:Zeko_sequencer.(sequencer.bridge_prover)
@@ -2346,6 +2355,7 @@ module Mutations = struct
                                    ; check_accepted =
                                        check_accepted_init, check_accepted_elems
                                    ; prev_next_deposit
+                                   ; prev_nonce
                                    } =
             return (Result.map_error witness ~f:Error.to_string_hum)
           in
@@ -2358,6 +2368,7 @@ module Mutations = struct
               ; check_accepted_init
               ; check_accepted_elems
               ; prev_next_deposit
+              ; prev_nonce
               }
           in
           don't_wait_for d ; return (Ok key) )
@@ -2385,6 +2396,7 @@ module Mutations = struct
                                        , withdrawal_ase_elems )
                                    ; prev_next_withdrawal
                                    ; withdrawal_params
+                                   ; prev_nonce
                                    } =
             return (Result.map_error witness ~f:Error.to_string_hum)
           in
@@ -2402,6 +2414,7 @@ module Mutations = struct
               ; withdrawal_ase_elems
               ; prev_next_withdrawal
               ; withdrawal_params
+              ; prev_nonce
               }
           in
           don't_wait_for d ; return (Ok key) )

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -2276,8 +2276,8 @@ module Mutations = struct
               in
               match
                 Signed_command.create_with_signature_checked
-                  ~signature_kind:Mina_signature_kind.Testnet signature from
-                  payload
+                  ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 signature
+                  from payload
               with
               | Some command ->
                   return (Ok command)

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -1852,13 +1852,17 @@ module Types = struct
               * Bridge.Check_accepted_mina.Elem.t list
           ; check_accepted_ase : Ase.With_length.Stmt.t * Field.t list
           ; prev_next_cancelled_deposit : Unsigned.uint32
+          ; prev_nonce : Unsigned.uint32
+          ; helper_account_new : bool
+          ; helper_account_signature : Signature.t
           }
 
         let arg_typ ~proof_cache_db =
           obj "FinalizeCancelledDepositInput"
             ~coerce:(fun public_key commit before_commit commit_ase sync_ase
                          (check_accepted_init, check_accepted_elems)
-                         check_accepted_ase prev_next_cancelled_deposit ->
+                         check_accepted_ase prev_next_cancelled_deposit
+                         prev_nonce helper_account_new helper_account_signature ->
               let%bind.Result check_accepted_elems =
                 Result.all check_accepted_elems
               in
@@ -1879,13 +1883,18 @@ module Types = struct
               ; check_accepted = (check_accepted_init, check_accepted_elems)
               ; check_accepted_ase
               ; prev_next_cancelled_deposit
+              ; prev_nonce
+              ; helper_account_new
+              ; helper_account_signature =
+                  Result.ok_or_failwith helper_account_signature
               } )
             ~split:(fun f (x : input) ->
               f x.public_key (Commit x.commit)
                 (Zeko_circuits.Rollup_state.Outer_action_state.raw
                    x.before_commit )
                 x.commit_ase x.sync_ase x.check_accepted x.check_accepted_ase
-                x.prev_next_cancelled_deposit )
+                x.prev_next_cancelled_deposit x.prev_nonce x.helper_account_new
+                (Raw x.helper_account_signature) )
             ~fields:
               [ arg "publicKey" ~typ:(non_null PublicKey.arg_typ)
               ; arg "commit"
@@ -1902,6 +1911,10 @@ module Types = struct
               ; arg "checkAcceptedAse"
                   ~typ:(non_null Folder.Ase_with_length.arg_typ)
               ; arg "prevNextCancelledDeposit" ~typ:(non_null UInt32.arg_typ)
+              ; arg "prevNonce" ~typ:(non_null UInt32.arg_typ)
+              ; arg "helperAccountNew" ~typ:(non_null bool)
+              ; arg "helperAccountSignature"
+                  ~typ:(non_null SignatureInput.arg_typ)
               ]
       end
 
@@ -2507,7 +2520,7 @@ module Mutations = struct
                   @@ Types.Input.Provers.Finalize_cancelled_deposit.arg_typ
                        ~proof_cache_db )
             ]
-        ~resolve:(fun { ctx = { sequencer; _ }; _ } () witness ->
+        ~resolve:(fun { ctx = { sequencer; l1_executor; _ }; _ } () witness ->
           let%bind.Deferred.Result { public_key
                                    ; commit
                                    ; before_commit
@@ -2520,9 +2533,14 @@ module Mutations = struct
                                        ( check_accepted_ase_source
                                        , check_accepted_ase_elems )
                                    ; prev_next_cancelled_deposit
+                                   ; prev_nonce
+                                   ; helper_account_new
+                                   ; helper_account_signature
                                    } =
             return (Result.map_error witness ~f:Error.to_string_hum)
           in
+          let logger = Zeko_sequencer.(sequencer.logger) in
+          let t = Zeko_sequencer.(sequencer.bridge_prover) in
           let key, d =
             Bridge_prover.Finalize_cancelled_deposit.f
               ~t:Zeko_sequencer.(sequencer.bridge_prover)
@@ -2539,7 +2557,15 @@ module Mutations = struct
               ; check_accepted_ase_source
               ; check_accepted_ase_elems
               ; prev_next_cancelled_deposit
+              ; prev_nonce
+              ; helper_account_new
               }
+              helper_account_signature
+          in
+          let d =
+            Bridge_prover.execute_request t ~logger ~executor:l1_executor
+              (key, d)
+            >>| ignore
           in
           don't_wait_for d ; return (Ok key) )
 

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -1784,12 +1784,14 @@ module Types = struct
           ; prev_next_deposit : Unsigned.uint32
           ; prev_nonce : Unsigned.uint32
           ; helper_account_new : bool
+          ; helper_account_signature : Signature.t
           }
 
         let arg_typ ~proof_cache_db =
           obj "FinalizeDepositInput"
             ~coerce:(fun ase (check_accepted_init, check_accepted_elems)
-                         prev_next_deposit prev_nonce helper_account_new ->
+                         prev_next_deposit prev_nonce helper_account_new
+                         helper_account_signature ->
               let%map.Result check_accepted_elems =
                 Result.all check_accepted_elems
               in
@@ -1798,10 +1800,12 @@ module Types = struct
               ; prev_next_deposit
               ; prev_nonce
               ; helper_account_new
+              ; helper_account_signature =
+                  Result.ok_or_failwith helper_account_signature
               } )
             ~split:(fun f (x : input) ->
               f x.ase x.check_accepted x.prev_next_deposit x.prev_nonce
-                x.helper_account_new )
+                x.helper_account_new (Raw x.helper_account_signature) )
             ~fields:
               [ arg "ase" ~typ:(non_null Folder.Ase_with_length.arg_typ)
               ; arg "checkAccepted"
@@ -1811,6 +1815,8 @@ module Types = struct
               ; arg "prevNextDeposit" ~typ:(non_null UInt32.arg_typ)
               ; arg "prevNonce" ~typ:(non_null UInt32.arg_typ)
               ; arg "helperAccountNew" ~typ:(non_null bool)
+              ; arg "helperAccountSignature"
+                  ~typ:(non_null SignatureInput.arg_typ)
               ]
       end
 
@@ -2364,6 +2370,7 @@ module Mutations = struct
                                    ; prev_next_deposit
                                    ; prev_nonce
                                    ; helper_account_new
+                                   ; helper_account_signature
                                    } =
             return (Result.map_error witness ~f:Error.to_string_hum)
           in
@@ -2379,6 +2386,7 @@ module Mutations = struct
               ; prev_nonce
               ; helper_account_new
               }
+              helper_account_signature
           in
           don't_wait_for d ; return (Ok key) )
 

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -1442,6 +1442,48 @@ module Types = struct
               ]
       end
 
+      module Transferrer = struct
+        type input = Account_update.Stable.Latest.t
+
+        let arg_typ =
+          scalar "BridgeTransferrerInput"
+            ~doc:
+              "A single pre-signed account update encoded as accountUpdates JSON"
+            ~coerce:(function
+              | `String s ->
+                  Result.try_with (fun () ->
+                      let forest =
+                        Yojson.Safe.from_string s
+                        |> Mina_base.Zkapp_command.account_updates_of_json
+                        |> Mina_base.Zkapp_command.Call_forest
+                           .of_account_updates_map
+                             ~f:Account_update.of_graphql_repr
+                             ~account_update_depth:(fun au ->
+                               au.body.call_depth )
+                        |> Mina_base.Zkapp_command.Call_forest
+                           .accumulate_hashes_predicated
+                             ~signature_kind:Zeko_circuits_config.t.chain_l1
+                      in
+                      match forest with
+                      | [ tree ] when List.is_empty tree.elt.calls ->
+                          tree.elt.account_update
+                      | _ ->
+                          failwith
+                            "Expected a single account update with empty calls" )
+                  |> Result.map_error ~f:Exn.to_string
+              | _ ->
+                  Error "Expected JSON-encoded account update" )
+            ~to_json:(fun account_update ->
+              let forest =
+                Mina_base.Zkapp_command.Call_forest.cons
+                  ~signature_kind:Zeko_circuits_config.t.chain_l1
+                  account_update []
+              in
+              `String
+                (Yojson.Safe.to_string
+                @@ Mina_base.Zkapp_command.account_updates_to_json forest) )
+      end
+
       module Folder = struct
         module Ase_with_length = struct
           module Stmt = struct
@@ -1697,22 +1739,39 @@ module Types = struct
       end
 
       module Deposit_request = struct
-        type input = { deposit_params : Deposit_params.input }
+        type input =
+          { deposit_params : Deposit_params.input
+          ; transferrer : Transferrer.input
+          }
 
         let arg_typ ~proof_cache_db =
           obj "DepositRequestInput"
-            ~coerce:(fun deposit_params -> { deposit_params })
-            ~split:(fun f (x : input) -> f x.deposit_params)
+            ~coerce:(fun deposit_params transferrer ->
+              { deposit_params; transferrer } )
+            ~split:(fun f (x : input) -> f x.deposit_params x.transferrer)
             ~fields:
               [ arg "depositParams"
                   ~typ:(non_null @@ Deposit_params.arg_typ ~proof_cache_db)
+              ; arg "transferrer" ~typ:(non_null Transferrer.arg_typ)
               ]
       end
 
       module Withdrawal_request = struct
-        type input = Withdrawal_params.input
+        type input =
+          { withdrawal_params : Withdrawal_params.input
+          ; transferrer : Transferrer.input
+          }
 
-        let arg_typ ~proof_cache_db = Withdrawal_params.arg_typ ~proof_cache_db
+        let arg_typ ~proof_cache_db =
+          obj "WithdrawalRequestInput"
+            ~coerce:(fun withdrawal_params transferrer ->
+              { withdrawal_params; transferrer } )
+            ~split:(fun f (x : input) -> f x.withdrawal_params x.transferrer)
+            ~fields:
+              [ arg "withdrawalParams"
+                  ~typ:(non_null @@ Withdrawal_params.arg_typ ~proof_cache_db)
+              ; arg "transferrer" ~typ:(non_null Transferrer.arg_typ)
+              ]
       end
 
       module Finalize_deposit = struct
@@ -2233,7 +2292,7 @@ module Mutations = struct
                   @@ Types.Input.Provers.Deposit_request.arg_typ ~proof_cache_db
                   )
             ]
-        ~resolve:(fun { ctx = sequencer; _ } () { deposit_params } ->
+        ~resolve:(fun { ctx = sequencer; _ } () { deposit_params; transferrer } ->
           let ( + ) a b = Currency.Fee.add a b |> Option.value_exn in
           let account_creation_fee =
             Zeko_constants.constraint_constants.account_creation_fee
@@ -2247,7 +2306,7 @@ module Mutations = struct
               Bridge_prover.Deposit_request.f
                 ~t:Zeko_sequencer.(sequencer.bridge_prover)
                 ~logger:Zeko_sequencer.(sequencer.logger)
-                { deposit_params }
+                { deposit_params; transferrer }
             in
             don't_wait_for d ; return (Ok key) )
 
@@ -2262,12 +2321,12 @@ module Mutations = struct
                   @@ Types.Input.Provers.Withdrawal_request.arg_typ
                        ~proof_cache_db )
             ]
-        ~resolve:(fun { ctx = sequencer; _ } () withdrawal_params ->
+        ~resolve:(fun { ctx = sequencer; _ } () { withdrawal_params; transferrer } ->
           let key, d =
             Bridge_prover.Withdrawal_request.f
               ~t:Zeko_sequencer.(sequencer.bridge_prover)
               ~logger:Zeko_sequencer.(sequencer.logger)
-              { withdrawal_params }
+              { withdrawal_params; transferrer }
           in
           don't_wait_for d ; return (Ok key) )
 

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -1047,6 +1047,9 @@ module Types = struct
       ; chain_l2 : Mina_signature_kind.t
       ; withdrawal_delay : int
       ; outer_action_delay : int
+      ; bridge_fee_recipient_l1 : Public_key.Compressed.t
+      ; bridge_fee_recipient_l2 : Public_key.Compressed.t
+      ; bridge_proof_fee : Currency.Amount.t
       }
 
     let signature_kind_to_string = function
@@ -1090,6 +1093,15 @@ module Types = struct
           ; field "outerActionDelay" ~typ:(non_null int)
               ~args:Arg.[]
               ~resolve:(fun _ t -> t.outer_action_delay)
+          ; field "bridgeFeeRecipientL1" ~typ:(non_null public_key)
+              ~args:Arg.[]
+              ~resolve:(fun _ t -> t.bridge_fee_recipient_l1)
+          ; field "bridgeFeeRecipientL2" ~typ:(non_null public_key)
+              ~args:Arg.[]
+              ~resolve:(fun _ t -> t.bridge_fee_recipient_l2)
+          ; field "bridgeProofFee" ~typ:(non_null amount)
+              ~args:Arg.[]
+              ~resolve:(fun _ t -> t.bridge_proof_fee)
           ] )
   end
 
@@ -2757,6 +2769,9 @@ module Queries = struct
         ; outer_action_delay =
             Mina_numbers.Global_slot_span.to_int
               sequencer.config.commit_validity_period
+        ; bridge_fee_recipient_l1 = Inputs.bridge_fee_recipient_l1
+        ; bridge_fee_recipient_l2 = Inputs.bridge_fee_recipient_l2
+        ; bridge_proof_fee = Inputs.bridge_proof_fee
         } )
 
   let sequencer_pk =

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -2672,8 +2672,8 @@ module Queries = struct
       ~typ:(non_null Types.genesis_constants)
       ~resolve:(fun _ () -> ())
 
-  let proved_forest =
-    io_field "provedForest" ~doc:"Query proved forest in a JSON format"
+  let proving_result =
+    io_field "provingResult" ~doc:"Query proving result in a JSON format"
       ~typ:string
       ~args:Arg.[ arg "key" ~typ:(non_null string) ]
       ~resolve:(fun { ctx = Context.{ sequencer; _ }; _ } () key ->
@@ -2809,7 +2809,7 @@ module Queries = struct
     ; accounts_for_pk
     ; token_accounts
     ; genesis_constants
-    ; proved_forest
+    ; proving_result
     ; state_hashes
     ; token_owner
     ; network_id

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -1897,13 +1897,15 @@ module Types = struct
           ; withdrawal_params : Withdrawal_params.input
           ; prev_nonce : Unsigned.uint32
           ; helper_account_new : bool
+          ; helper_account_signature : Signature.t
           }
 
         let arg_typ ~proof_cache_db =
           obj "FinalizeWithdrawalInput"
             ~coerce:(fun public_key commit before_commit commit_ase
                          before_withdrawal withdrawal_ase prev_next_withdrawal
-                         withdrawal_params prev_nonce helper_account_new ->
+                         withdrawal_params prev_nonce helper_account_new
+                         helper_account_signature ->
               let%map.Result commit =
                 match%bind.Result commit with
                 | Commit commit ->
@@ -1925,6 +1927,8 @@ module Types = struct
               ; withdrawal_params
               ; prev_nonce
               ; helper_account_new
+              ; helper_account_signature =
+                  Result.ok_or_failwith helper_account_signature
               } )
             ~split:(fun f (x : input) ->
               f x.public_key (Commit x.commit)
@@ -1934,7 +1938,8 @@ module Types = struct
                 (Zeko_circuits.Rollup_state.Inner_action_state.raw
                    x.before_withdrawal )
                 x.withdrawal_ase x.prev_next_withdrawal x.withdrawal_params
-                x.prev_nonce x.helper_account_new )
+                x.prev_nonce x.helper_account_new
+                (Raw x.helper_account_signature) )
             ~fields:
               [ arg "publicKey" ~typ:(non_null PublicKey.arg_typ)
               ; arg "commit"
@@ -1952,6 +1957,8 @@ module Types = struct
                   ~typ:(non_null @@ Withdrawal_params.arg_typ ~proof_cache_db)
               ; arg "prevNonce" ~typ:(non_null UInt32.arg_typ)
               ; arg "helperAccountNew" ~typ:(non_null bool)
+              ; arg "helperAccountSignature"
+                  ~typ:(non_null SignatureInput.arg_typ)
               ]
       end
     end
@@ -2415,6 +2422,7 @@ module Mutations = struct
                                    ; withdrawal_params
                                    ; prev_nonce
                                    ; helper_account_new
+                                   ; helper_account_signature
                                    } =
             return (Result.map_error witness ~f:Error.to_string_hum)
           in
@@ -2435,6 +2443,7 @@ module Mutations = struct
               ; prev_nonce
               ; helper_account_new
               }
+              helper_account_signature
           in
           don't_wait_for d ; return (Ok key) )
 

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -9,6 +9,14 @@ open Currency
 module Schema = Graphql_wrapper.Make (Schema)
 module Zeko_sequencer = Zeko_sequencer.Sequencer
 
+module Context = struct
+  type t =
+    { sequencer : Zeko_sequencer.t
+    ; l1_executor : Executor.t
+    ; l2_executor : Executor.t
+    }
+end
+
 module Types = struct
   open Schema
 
@@ -98,7 +106,7 @@ module Types = struct
               match x with `Left _ -> None | `Right h -> Some h )
         ] )
 
-  let account_timing : (Zeko_sequencer.t, Account_timing.t option) typ =
+  let account_timing : (Context.t, Account_timing.t option) typ =
     obj "AccountTiming" ~fields:(fun _ ->
         [ field "initialMinimumBalance" ~typ:balance
             ~doc:"The initial minimum balance for a time-locked account"
@@ -818,7 +826,7 @@ module Types = struct
           resolve c uc.With_status.data )
 
     let user_command_shared_fields :
-        ( Zeko_sequencer.t
+        ( Context.t
         , (Signed_command.t, Transaction_hash.t) With_hash.t With_status.t )
         field
         list =
@@ -838,20 +846,20 @@ module Types = struct
             |> Account.Nonce.to_int )
       ; field_no_status "source" ~typ:(non_null AccountObj.account)
           ~args:[] ~doc:"Account that the command is sent from"
-          ~resolve:(fun { ctx = sequencer; _ } cmd ->
+          ~resolve:(fun { ctx = { sequencer; _ }; _ } cmd ->
             AccountObj.get_best_ledger_account
               (Ledger.of_database sequencer.ledger)
               (Signed_command.fee_payer cmd.With_hash.data) )
       ; field_no_status "receiver" ~typ:(non_null AccountObj.account)
           ~args:[] ~doc:"Account that the command applies to"
-          ~resolve:(fun { ctx = sequencer; _ } cmd ->
+          ~resolve:(fun { ctx = { sequencer; _ }; _ } cmd ->
             AccountObj.get_best_ledger_account
               (Ledger.of_database sequencer.ledger)
               (Signed_command.receiver cmd.With_hash.data) )
       ; field_no_status "feePayer" ~typ:(non_null AccountObj.account)
           ~args:[] ~doc:"Account that pays the fees for the command"
           ~deprecated:(Deprecated (Some "use source field instead"))
-          ~resolve:(fun { ctx = sequencer; _ } cmd ->
+          ~resolve:(fun { ctx = { sequencer; _ }; _ } cmd ->
             AccountObj.get_best_ledger_account
               (Ledger.of_database sequencer.ledger)
               (Signed_command.fee_payer cmd.With_hash.data) )
@@ -912,7 +920,7 @@ module Types = struct
       ; field_no_status "fromAccount" ~typ:(non_null AccountObj.account)
           ~args:[] ~doc:"Account of the sender"
           ~deprecated:(Deprecated (Some "use feePayer field instead"))
-          ~resolve:(fun { ctx = sequencer; _ } payment ->
+          ~resolve:(fun { ctx = { sequencer; _ }; _ } payment ->
             AccountObj.get_best_ledger_account
               (Ledger.of_database sequencer.ledger)
             @@ Signed_command.fee_payer payment.With_hash.data )
@@ -925,7 +933,7 @@ module Types = struct
           ~doc:"Account of the receiver"
           ~deprecated:(Deprecated (Some "use receiver field instead"))
           ~args:Arg.[]
-          ~resolve:(fun { ctx = sequencer; _ } cmd ->
+          ~resolve:(fun { ctx = { sequencer; _ }; _ } cmd ->
             AccountObj.get_best_ledger_account
               (Ledger.of_database sequencer.ledger)
             @@ Signed_command.receiver cmd.With_hash.data )
@@ -965,10 +973,10 @@ module Types = struct
     let zkapp_command =
       let conv
           (x :
-            ( Zeko_sequencer.t
+            ( Context.t
             , Zkapp_command.Stable.Latest.t )
             Fields_derivers_graphql.Schema.typ ) :
-          (Zeko_sequencer.t, Zkapp_command.Stable.Latest.t) typ =
+          (Context.t, Zkapp_command.Stable.Latest.t) typ =
         Obj.magic x
       in
       obj "ZkappCommandResult" ~fields:(fun _ ->
@@ -1003,7 +1011,7 @@ module Types = struct
   end
 
   module State_hashes = struct
-    let t : (Zeko_sequencer.t, Zeko_sequencer.State_hashes.t option) typ =
+    let t : (Context.t, Zeko_sequencer.State_hashes.t option) typ =
       let open Snark_params.Tick in
       obj "StateHashes" ~fields:(fun _ ->
           [ field "provedLedgerHash" ~typ:(non_null string)
@@ -1049,7 +1057,7 @@ module Types = struct
       | Other_network s ->
           s
 
-    let t : (Zeko_sequencer.t, t option) typ =
+    let t : (Context.t, t option) typ =
       obj "ZekoCircuitsConfig" ~fields:(fun _ ->
           [ field "zekoL1" ~typ:(non_null public_key)
               ~args:Arg.[]
@@ -2213,7 +2221,7 @@ module Mutations = struct
           [ arg "input" ~typ:(non_null Types.Input.SendPaymentInput.arg_typ)
           ; Types.Input.Fields.signature
           ]
-      ~resolve:(fun { ctx = sequencer; _ } ()
+      ~resolve:(fun { ctx = { sequencer; _ }; _ } ()
                     (from, to_, amount, fee, valid_until, memo, nonce_opt)
                     signature ->
         let payload =
@@ -2278,7 +2286,7 @@ module Mutations = struct
       ~typ:(non_null Types.Payload.send_zkapp)
       ~args:
         Arg.[ arg "input" ~typ:(non_null Types.Input.SendZkappInput.arg_typ) ]
-      ~resolve:(fun { ctx = sequencer; _ } () zkapp_command_stable ->
+      ~resolve:(fun { ctx = { sequencer; _ }; _ } () zkapp_command_stable ->
         let zkapp_command =
           Zkapp_command.write_all_proofs_to_disk
             ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
@@ -2320,7 +2328,8 @@ module Mutations = struct
                   @@ Types.Input.Provers.Deposit_request.arg_typ ~proof_cache_db
                   )
             ]
-        ~resolve:(fun { ctx = sequencer; _ } () { deposit_params; transferrer } ->
+        ~resolve:(fun { ctx = Context.{ sequencer; l1_executor; _ }; _ } ()
+                      { deposit_params; transferrer } ->
           let ( + ) a b = Currency.Fee.add a b |> Option.value_exn in
           let account_creation_fee =
             Zeko_constants.constraint_constants.account_creation_fee
@@ -2330,11 +2339,16 @@ module Mutations = struct
           if Currency.Amount.(deposit_params.amount < account_creation_fee) then
             return (Error "Amount must be at least 2 account creation fees")
           else
+            let logger = Zeko_sequencer.(sequencer.logger) in
+            let t = Zeko_sequencer.(sequencer.bridge_prover) in
             let key, d =
-              Bridge_prover.Deposit_request.f
-                ~t:Zeko_sequencer.(sequencer.bridge_prover)
-                ~logger:Zeko_sequencer.(sequencer.logger)
+              Bridge_prover.Deposit_request.f ~t ~logger
                 { deposit_params; transferrer }
+            in
+            let d =
+              Bridge_prover.execute_request t ~logger ~executor:l1_executor
+                (key, d)
+              >>| ignore
             in
             don't_wait_for d ; return (Ok key) )
 
@@ -2349,13 +2363,20 @@ module Mutations = struct
                   @@ Types.Input.Provers.Withdrawal_request.arg_typ
                        ~proof_cache_db )
             ]
-        ~resolve:(fun { ctx = sequencer; _ } ()
+        ~resolve:(fun { ctx = Context.{ sequencer; l2_executor; _ }; _ } ()
                       { withdrawal_params; transferrer } ->
+          let logger = Zeko_sequencer.(sequencer.logger) in
+          let t = Zeko_sequencer.(sequencer.bridge_prover) in
           let key, d =
             Bridge_prover.Withdrawal_request.f
               ~t:Zeko_sequencer.(sequencer.bridge_prover)
               ~logger:Zeko_sequencer.(sequencer.logger)
               { withdrawal_params; transferrer }
+          in
+          let d =
+            Bridge_prover.execute_request t ~logger ~executor:l2_executor
+              (key, d)
+            >>| ignore
           in
           don't_wait_for d ; return (Ok key) )
 
@@ -2370,7 +2391,8 @@ module Mutations = struct
                   @@ Types.Input.Provers.Finalize_deposit.arg_typ
                        ~proof_cache_db )
             ]
-        ~resolve:(fun { ctx = sequencer; _ } () witness ->
+        ~resolve:(fun { ctx = Context.{ sequencer; l2_executor; _ }; _ } ()
+                      witness ->
           let%bind.Deferred.Result { ase = ase_source, ase_elems
                                    ; check_accepted =
                                        check_accepted_init, check_accepted_elems
@@ -2381,6 +2403,8 @@ module Mutations = struct
                                    } =
             return (Result.map_error witness ~f:Error.to_string_hum)
           in
+          let logger = Zeko_sequencer.(sequencer.logger) in
+          let t = Zeko_sequencer.(sequencer.bridge_prover) in
           let key, d =
             Bridge_prover.Finalize_deposit.f
               ~t:Zeko_sequencer.(sequencer.bridge_prover)
@@ -2395,6 +2419,11 @@ module Mutations = struct
               }
               helper_account_signature
           in
+          let d =
+            Bridge_prover.execute_request t ~logger ~executor:l2_executor
+              (key, d)
+            >>| ignore
+          in
           don't_wait_for d ; return (Ok key) )
 
     let finalize_withdrawal ~proof_cache_db =
@@ -2408,7 +2437,8 @@ module Mutations = struct
                   @@ Types.Input.Provers.Finalize_withdrawal.arg_typ
                        ~proof_cache_db )
             ]
-        ~resolve:(fun { ctx = sequencer; _ } () witness ->
+        ~resolve:(fun { ctx = Context.{ sequencer; l1_executor; _ }; _ } ()
+                      witness ->
           let%bind.Deferred.Result { public_key
                                    ; commit
                                    ; before_commit
@@ -2426,6 +2456,8 @@ module Mutations = struct
                                    } =
             return (Result.map_error witness ~f:Error.to_string_hum)
           in
+          let logger = Zeko_sequencer.(sequencer.logger) in
+          let t = Zeko_sequencer.(sequencer.bridge_prover) in
           let key, d =
             Bridge_prover.Finalize_withdrawal.f
               ~t:Zeko_sequencer.(sequencer.bridge_prover)
@@ -2445,6 +2477,11 @@ module Mutations = struct
               }
               helper_account_signature
           in
+          let d =
+            Bridge_prover.execute_request t ~logger ~executor:l1_executor
+              (key, d)
+            >>| ignore
+          in
           don't_wait_for d ; return (Ok key) )
 
     let cancel_deposit ~proof_cache_db =
@@ -2458,7 +2495,7 @@ module Mutations = struct
                   @@ Types.Input.Provers.Finalize_cancelled_deposit.arg_typ
                        ~proof_cache_db )
             ]
-        ~resolve:(fun { ctx = sequencer; _ } () witness ->
+        ~resolve:(fun { ctx = { sequencer; _ }; _ } () witness ->
           let%bind.Deferred.Result { public_key
                                    ; commit
                                    ; before_commit
@@ -2562,7 +2599,7 @@ module Queries = struct
               ~typ:int
           ]
       ~typ:(non_null float)
-      ~resolve:(fun { ctx = sequencer; _ } () weight ->
+      ~resolve:(fun { ctx = Context.{ sequencer; _ }; _ } () weight ->
         Zeko_sequencer.calculate_required_fee sequencer
           (Option.value ~default:1 weight) )
 
@@ -2577,7 +2614,7 @@ module Queries = struct
               ~doc:"Token of account being retrieved (defaults to MINA)"
               ~typ:Types.Input.TokenId.arg_typ ~default:Token_id.default
           ]
-      ~resolve:(fun { ctx = sequencer; _ } () public_key token_id ->
+      ~resolve:(fun { ctx = { sequencer; _ }; _ } () public_key token_id ->
         let%map.Option account =
           Zeko_sequencer.get_account sequencer public_key token_id
         in
@@ -2592,7 +2629,7 @@ module Queries = struct
           [ arg "publicKey" ~doc:"Public key to find accounts for"
               ~typ:(non_null Types.Input.PublicKey.arg_typ)
           ]
-      ~resolve:(fun { ctx = sequencer; _ } () pk ->
+      ~resolve:(fun { ctx = Context.{ sequencer; _ }; _ } () pk ->
         let ledger = Ledger.of_database sequencer.ledger in
         let tokens = Ledger.tokens ledger pk |> Set.to_list in
         List.filter_map tokens ~f:(fun token ->
@@ -2611,7 +2648,7 @@ module Queries = struct
           [ arg "tokenId" ~doc:"Token ID to find accounts for"
               ~typ:(non_null Types.Input.TokenId.arg_typ)
           ]
-      ~resolve:(fun { ctx = sequencer; _ } () token_id ->
+      ~resolve:(fun { ctx = Context.{ sequencer; _ }; _ } () token_id ->
         let ledger = Ledger.of_database sequencer.ledger in
         let%map account_ids = Ledger.accounts ledger in
         Ok
@@ -2639,7 +2676,7 @@ module Queries = struct
     io_field "provedForest" ~doc:"Query proved forest in a JSON format"
       ~typ:string
       ~args:Arg.[ arg "key" ~typ:(non_null string) ]
-      ~resolve:(fun { ctx = sequencer; _ } () key ->
+      ~resolve:(fun { ctx = Context.{ sequencer; _ }; _ } () key ->
         match
           Bridge_prover.Proofs_memory.get
             Zeko_sequencer.(sequencer.bridge_prover.proofs_memory)
@@ -2649,20 +2686,34 @@ module Queries = struct
             return (Error "Invalid key")
         | Some (_, `Pending) ->
             return (Ok None)
-        | Some (_, `Done (Ok forest)) ->
+        | Some (_, `Proved (Ok forest)) ->
             return
               (Ok
                  (Some
                     ( Yojson.Safe.to_string
-                    @@ Zkapp_command.account_updates_to_json forest ) ) )
-        | Some (_, `Done (Error err)) ->
+                    @@ `Assoc
+                         [ ( "proved"
+                           , Zkapp_command.account_updates_to_json forest )
+                         ] ) ) )
+        | Some (_, `Executed (Ok hash)) ->
+            return
+              (Ok
+                 (Some
+                    ( Yojson.Safe.to_string
+                    @@ `Assoc
+                         [ ( "executed"
+                           , `String
+                               (Mina_transaction.Transaction_hash
+                                .to_base58_check hash ) )
+                         ] ) ) )
+        | Some (_, `Proved (Error err)) | Some (_, `Executed (Error err)) ->
             return (Error (Error.to_string_mach err)) )
 
   let state_hashes =
     field "stateHashes" ~doc:"Get current state of the rollup"
       ~typ:Types.State_hashes.t
       ~args:Arg.[]
-      ~resolve:(fun { ctx = sequencer; _ } () ->
+      ~resolve:(fun { ctx = { sequencer; _ }; _ } () ->
         Some (Zeko_sequencer.get_latest_state sequencer) )
 
   let token_owner =
@@ -2673,7 +2724,7 @@ module Queries = struct
           [ arg "tokenId" ~doc:"Token ID to find the owning account for"
               ~typ:(non_null Types.Input.TokenId.arg_typ)
           ]
-      ~resolve:(fun { ctx = sequencer; _ } () token ->
+      ~resolve:(fun { ctx = { sequencer; _ }; _ } () token ->
         let open Option.Let_syntax in
         let l = Ledger.of_database sequencer.ledger in
         let%map account_id = Ledger.token_owner l token in
@@ -2683,7 +2734,7 @@ module Queries = struct
     field "proverQueueSize" ~doc:"Get the size of the prover queue"
       ~typ:(non_null int)
       ~args:Arg.[]
-      ~resolve:(fun { ctx = sequencer; _ } () ->
+      ~resolve:(fun { ctx = Context.{ sequencer; _ }; _ } () ->
         Zeko_prover.Client.queue_size
           Zeko_sequencer.(sequencer.merger_ctx.provers) )
 
@@ -2691,7 +2742,7 @@ module Queries = struct
     field "circuitsConfig" ~doc:"Get the circuits config"
       ~typ:(non_null Types.Circuits_config.t)
       ~args:Arg.[]
-      ~resolve:(fun { ctx = sequencer; _ } () ->
+      ~resolve:(fun { ctx = { sequencer; _ }; _ } () ->
         let open Zeko_circuits_config in
         { Types.Circuits_config.zeko_l1 = Inputs.zeko_l1
         ; zeko_l2 = Inputs.zeko_l2
@@ -2712,7 +2763,7 @@ module Queries = struct
     field "sequencerPk" ~doc:"Get the sequencer's public key"
       ~typ:(non_null Types.public_key)
       ~args:Arg.[]
-      ~resolve:(fun { ctx = sequencer; _ } () ->
+      ~resolve:(fun { ctx = { sequencer; _ }; _ } () ->
         Signer_service.Signer.public_key sequencer.config.signer )
 
   module Archive = struct
@@ -2725,7 +2776,7 @@ module Queries = struct
                 ~typ:
                   (non_null Types.Input.Archive.ActionFilterOptionsInput.arg_typ)
             ]
-        ~resolve:(fun { ctx = sequencer; _ } ()
+        ~resolve:(fun { ctx = { sequencer; _ }; _ } ()
                       (public_key, token_id, from_action_state, end_action_state)
                       ->
           let token_id = Option.value ~default:Token_id.default token_id in
@@ -2743,7 +2794,7 @@ module Queries = struct
                 ~typ:
                   (non_null Types.Input.Archive.EventFilterOptionsInput.arg_typ)
             ]
-        ~resolve:(fun { ctx = sequencer; _ } () (public_key, token_id) ->
+        ~resolve:(fun { ctx = { sequencer; _ }; _ } () (public_key, token_id) ->
           let token_id = Option.value ~default:Token_id.default token_id in
           Archive.get_events sequencer.archive
             (Account_id.create public_key token_id) )

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -1086,11 +1086,8 @@ module Sequencer = struct
         }
     in
     let%bind merger = Merger.P.create_and_requeue ~logger merger_ctx db_pool in
-    let%bind bridge_prover =
-      Bridge_prover.create ~provers ~proof_cache_db
-        ~fee_recipient_l1:(Signer_service.Signer.public_key signer)
-        ~fee_recipient_l2:(Signer_service.Signer.public_key signer)
-    in
+    let%bind bridge_prover = Bridge_prover.create ~provers ~proof_cache_db in
+
     let t =
       { ledger
       ; imt

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -418,6 +418,20 @@ module Sequencer = struct
 
           let l = L.of_database t.ledger in
 
+          let () =
+            match command with
+            | Signed_command _ ->
+                ()
+            | Zkapp_command command ->
+                let commitment, full_commitment =
+                  Zkapp_command.get_transaction_commitments
+                    ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 command
+                in
+                Core.printf "full_commitment: %s\n"
+                  (Field.to_string full_commitment) ;
+                Core.printf "commitment: %s\n" (Field.to_string commitment)
+          in
+
           let%bind.Deferred.Result () =
             if skip_validity_check then return (Ok ())
             else

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -1097,8 +1097,8 @@ module Sequencer = struct
       ; da_client
       ; bridge_prover =
           Bridge_prover.create ~provers ~proof_cache_db
-            ~fee_recipient_l1:(Public_key.compress signer.public_key)
-            ~fee_recipient_l2:(Public_key.compress signer.public_key)
+            ~fee_recipient_l1:(Signer_service.Signer.public_key signer)
+            ~fee_recipient_l2:(Signer_service.Signer.public_key signer)
       ; merger
       ; merger_ctx
       ; closed = Ivar.create ()

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -1112,7 +1112,7 @@ module Sequencer = struct
         }
     in
     let%bind merger = Merger.P.create_and_requeue ~logger merger_ctx db_pool in
-    let preverify_l2 =
+    let state_view_template =
       let consensus_constants =
         let protocol_constants : Genesis_constants.Protocol.t =
           { k = 1
@@ -1132,61 +1132,81 @@ module Sequencer = struct
           ~constraint_constants ~consensus_constants
           ~genesis_body_reference:Staged_ledger_diff.genesis_body_reference
       in
-      let state_view_template =
-        Mina_state.Protocol_state.Body.view compile_time_genesis.data.body
-      in
-      fun forest ->
-        let mask = L.of_database ledger in
-        let signer_pk = !l2_fee_payer_pk in
-        let signer_aid = Account_id.create signer_pk Token_id.default in
-        let nonce =
-          match L.location_of_account mask signer_aid with
-          | Some loc ->
-              ( L.get mask loc
-              |> Option.value_exn ~message:"signer account missing" )
-                .nonce
-          | None ->
-              Account.Nonce.zero
-        in
-        let fee_payer : Account_update.Fee_payer.t =
+      Mina_state.Protocol_state.Body.view compile_time_genesis.data.body
+    in
+    let make_command ~fee_payer_pk ~nonce forest : Zkapp_command.t =
+      { fee_payer =
           { body =
-              { public_key = signer_pk
+              { public_key = fee_payer_pk
               ; fee = Currency.Fee.of_mina_string_exn "0.1"
               ; valid_until = None
               ; nonce
               }
           ; authorization = Signature.dummy
           }
+      ; account_updates =
+          Zkapp_command.Call_forest.map forest
+            ~f:
+              (Account_update.write_all_proofs_to_disk
+                 ~proof_cache_db:(Proof_cache_tag.create_identity_db ()) )
+      ; memo = Signed_command_memo.empty
+      }
+    in
+    let preverify_l2 forest =
+      let mask = L.of_database ledger in
+      let signer_pk = !l2_fee_payer_pk in
+      let signer_aid = Account_id.create signer_pk Token_id.default in
+      let nonce =
+        match L.location_of_account mask signer_aid with
+        | Some loc ->
+            ( L.get mask loc
+            |> Option.value_exn ~message:"signer account missing" )
+              .nonce
+        | None ->
+            Account.Nonce.zero
+      in
+      let command = make_command ~fee_payer_pk:signer_pk ~nonce forest in
+      let global_slot = Utils.Slot.global_slot ~l1_config in
+      let state_view : Zkapp_precondition.Protocol_state.View.t =
+        { state_view_template with
+          global_slot_since_genesis = global_slot
+        }
+      in
+      let get_account aid =
+        let acc =
+          let%bind.Option loc = L.location_of_account mask aid in
+          L.get mask loc
         in
-        let command : Zkapp_command.t =
-          { fee_payer
-          ; account_updates =
-              Zkapp_command.Call_forest.map forest
-                ~f:
-                  (Account_update.write_all_proofs_to_disk
-                     ~proof_cache_db:(Proof_cache_tag.create_identity_db ()) )
-          ; memo = Signed_command_memo.empty
-          }
-        in
-        let global_slot = Utils.Slot.global_slot ~l1_config in
-        let state_view : Zkapp_precondition.Protocol_state.View.t =
-          { state_view_template with
-            global_slot_since_genesis = global_slot
-          }
-        in
-        let get_account aid =
-          let acc =
-            let%bind.Option loc = L.location_of_account mask aid in
-            L.get mask loc
-          in
-          Async_kernel.Deferred.Or_error.return acc
-        in
-        Zeko_transaction_logic.preverify_user_command ~get_account
-          ~constraint_constants ~global_slot ~state_view
-          (User_command.Zkapp_command command)
+        Async_kernel.Deferred.Or_error.return acc
+      in
+      Zeko_transaction_logic.preverify_user_command ~get_account
+        ~constraint_constants ~global_slot ~state_view
+        (User_command.Zkapp_command command)
+    in
+    let preverify_l1 forest =
+      let signer_pk = Signer_service.Signer.public_key signer in
+      (* preverify simulates the command against the *committed* L1 state, so
+         use [fetch_nonce] (committed nonce) rather than [infer_nonce] (which
+         includes pooled commands and would advance past the on-chain nonce
+         the simulated fee payer is checked against). *)
+      let%bind.Deferred.Or_error nonce =
+        Gql_client.fetch_nonce ~logger config.l1_uri signer_pk
+      in
+      let command = make_command ~fee_payer_pk:signer_pk ~nonce forest in
+      let global_slot = Utils.Slot.global_slot ~l1_config in
+      let state_view : Zkapp_precondition.Protocol_state.View.t =
+        { state_view_template with
+          global_slot_since_genesis = global_slot
+        }
+      in
+      let get_account aid = Gql_client.fetch_account ~logger config.l1_uri aid in
+      Zeko_transaction_logic.preverify_user_command ~get_account
+        ~constraint_constants ~global_slot ~state_view
+        (User_command.Zkapp_command command)
     in
     let%bind bridge_prover =
-      Bridge_prover.create ~provers ~proof_cache_db ~preverify_l2
+      Bridge_prover.create ~provers ~proof_cache_db ~preverify_l1
+        ~preverify_l2
     in
 
     let t =

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -1125,6 +1125,19 @@ module Sequencer = struct
       Mina_state.Protocol_state.Body.view compile_time_genesis.data.body
     in
     let make_command ~fee_payer_pk ~nonce forest : Zkapp_command.t =
+      let proof_cache_db = Proof_cache_tag.create_identity_db () in
+      let attach_dummy_proof_to_proof_aus (au : Account_update.Stable.Latest.t)
+          : Account_update.Stable.Latest.t =
+        match Account_update.Poly.body au with
+        | { authorization_kind = Proof _; _ } ->
+            { au with
+              authorization =
+                Control.Poly.Proof
+                  (Lazy.force Mina_base.Proof.transaction_dummy)
+            }
+        | _ ->
+            au
+      in
       { fee_payer =
           { body =
               { public_key = fee_payer_pk
@@ -1135,10 +1148,9 @@ module Sequencer = struct
           ; authorization = Signature.dummy
           }
       ; account_updates =
-          Zkapp_command.Call_forest.map forest
-            ~f:
-              (Account_update.write_all_proofs_to_disk
-                 ~proof_cache_db:(Proof_cache_tag.create_identity_db ()) )
+          Zkapp_command.Call_forest.map forest ~f:(fun au ->
+              attach_dummy_proof_to_proof_aus au
+              |> Account_update.write_all_proofs_to_disk ~proof_cache_db )
       ; memo = Signed_command_memo.empty
       }
     in

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -418,22 +418,6 @@ module Sequencer = struct
 
           let l = L.of_database t.ledger in
 
-          let () =
-            match command with
-            | Signed_command _ ->
-                ()
-            | Zkapp_command command ->
-                let commitment, full_commitment =
-                  Zkapp_command.get_transaction_commitments
-                    ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 command
-                in
-                Core.printf "full_commitment: %s\n"
-                  (Field.to_string full_commitment) ;
-                Core.printf "commitment: %s\n" (Field.to_string commitment) ;
-                Core.printf "command: %s\n"
-                  (Zkapp_command.to_yojson command |> Yojson.Safe.to_string)
-          in
-
           let%bind.Deferred.Result () =
             if skip_validity_check then return (Ok ())
             else

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -238,7 +238,10 @@ module Sequencer = struct
     ; closed : unit Ivar.t
     ; apply_q : unit Sequencer.t
           (* Applying of the user command is async operation, but we need to keep the application synchronous *)
+    ; l2_fee_payer_pk : Public_key.Compressed.t ref
     }
+
+  let set_l2_fee_payer_pk t pk = t.l2_fee_payer_pk := pk
 
   let shutdown t =
     let logger = t.logger in
@@ -1043,6 +1046,13 @@ module Sequencer = struct
       ~(signer : Signer_service.Signer.t) ~deposit_delay_blocks ~mq_host
       ~fee_modifier ~minimum_fee ~slot_acceptance ~proof_cache_db ~l1_config
       ~commit_validity_period =
+    (* [l2_fee_payer_pk] holds the public key used as fee payer when the bridge
+       prover runs preverify against the L2 ledger. Defaults to the sequencer's
+       signer (matching production); tests can override via
+       [set_l2_fee_payer_pk] when their L2 executor uses a different account. *)
+    let l2_fee_payer_pk =
+      ref (Signer_service.Signer.public_key signer)
+    in
     [%log info] "Precomputing srs" ;
     Pickles.Side_loaded.srs_precomputation () ;
     let db_dir =
@@ -1102,7 +1112,82 @@ module Sequencer = struct
         }
     in
     let%bind merger = Merger.P.create_and_requeue ~logger merger_ctx db_pool in
-    let%bind bridge_prover = Bridge_prover.create ~provers ~proof_cache_db in
+    let preverify_l2 =
+      let consensus_constants =
+        let protocol_constants : Genesis_constants.Protocol.t =
+          { k = 1
+          ; slots_per_epoch = 1000
+          ; slots_per_sub_window = 1
+          ; grace_period_slots = 1
+          ; delta = 1
+          ; genesis_state_timestamp = Int64.one
+          }
+        in
+        Consensus.Constants.create ~constraint_constants ~protocol_constants
+      in
+      let compile_time_genesis =
+        Mina_state.Genesis_protocol_state.t
+          ~genesis_ledger:Genesis_ledger.(Packed.t for_unit_tests)
+          ~genesis_epoch_data:Consensus.Genesis_epoch_data.for_unit_tests
+          ~constraint_constants ~consensus_constants
+          ~genesis_body_reference:Staged_ledger_diff.genesis_body_reference
+      in
+      let state_view_template =
+        Mina_state.Protocol_state.Body.view compile_time_genesis.data.body
+      in
+      fun forest ->
+        let mask = L.of_database ledger in
+        let signer_pk = !l2_fee_payer_pk in
+        let signer_aid = Account_id.create signer_pk Token_id.default in
+        let nonce =
+          match L.location_of_account mask signer_aid with
+          | Some loc ->
+              ( L.get mask loc
+              |> Option.value_exn ~message:"signer account missing" )
+                .nonce
+          | None ->
+              Account.Nonce.zero
+        in
+        let fee_payer : Account_update.Fee_payer.t =
+          { body =
+              { public_key = signer_pk
+              ; fee = Currency.Fee.of_mina_string_exn "0.1"
+              ; valid_until = None
+              ; nonce
+              }
+          ; authorization = Signature.dummy
+          }
+        in
+        let command : Zkapp_command.t =
+          { fee_payer
+          ; account_updates =
+              Zkapp_command.Call_forest.map forest
+                ~f:
+                  (Account_update.write_all_proofs_to_disk
+                     ~proof_cache_db:(Proof_cache_tag.create_identity_db ()) )
+          ; memo = Signed_command_memo.empty
+          }
+        in
+        let global_slot = Utils.Slot.global_slot ~l1_config in
+        let state_view : Zkapp_precondition.Protocol_state.View.t =
+          { state_view_template with
+            global_slot_since_genesis = global_slot
+          }
+        in
+        let get_account aid =
+          let acc =
+            let%bind.Option loc = L.location_of_account mask aid in
+            L.get mask loc
+          in
+          Async_kernel.Deferred.Or_error.return acc
+        in
+        Zeko_transaction_logic.preverify_user_command ~get_account
+          ~constraint_constants ~global_slot ~state_view
+          (User_command.Zkapp_command command)
+    in
+    let%bind bridge_prover =
+      Bridge_prover.create ~provers ~proof_cache_db ~preverify_l2
+    in
 
     let t =
       { ledger
@@ -1118,6 +1203,7 @@ module Sequencer = struct
       ; merger_ctx
       ; closed = Ivar.create ()
       ; apply_q = Sequencer.create ()
+      ; l2_fee_payer_pk
       }
     in
     let%bind () =

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -1095,7 +1095,10 @@ module Sequencer = struct
       ; archive
       ; config
       ; da_client
-      ; bridge_prover = Bridge_prover.create ~provers ~proof_cache_db
+      ; bridge_prover =
+          Bridge_prover.create ~provers ~proof_cache_db
+            ~fee_recipient_l1:(Public_key.compress signer.public_key)
+            ~fee_recipient_l2:(Public_key.compress signer.public_key)
       ; merger
       ; merger_ctx
       ; closed = Ivar.create ()

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -172,13 +172,13 @@ module Sequencer = struct
               in
               let%bind command =
                 Committer.prove_commit ~logger ~proof_cache_db ~provers
-                  ~executor ~archive
+                  ~executor ~l1_uri:config.l1_uri ~archive
                   ~zkapp_pk:Zeko_circuits_config.Inputs.zeko_l1
                   ~archive_uri:config.archive_uri ~l1_config:config.l1_config
                   ~commit_validity_period:config.commit_validity_period
                   commit_witness
               in
-              let%bind () =
+              let%bind _hash =
                 Executor.send_zkapp_command ~logger executor command
               in
               State.Last_committed_ledger.set sequencer_state
@@ -1068,8 +1068,8 @@ module Sequencer = struct
     let kvdb = L.Db.zeko_kvdb ledger in
     let%bind provers = Zeko_prover.Client.create ~logger ~db_pool ~mq_host in
     let executor =
-      Executor.create ~l1_uri:config.l1_uri
-        ~signature_kind:Zeko_circuits_config.Inputs.chain_l1 ~signer ~kvdb ()
+      Executor.create ~kind:(`L1 config.l1_uri)
+        ~signature_kind:Zeko_circuits_config.Inputs.chain_l1 ~signer ()
     in
     let archive = Archive.create ~kvdb in
     let merger_ctx =
@@ -1115,7 +1115,8 @@ module Sequencer = struct
     let%bind () =
       Committer.recommit_all ~logger ~proof_cache_db
         ~provers:t.bridge_prover.provers ~executor:t.merger_ctx.executor
-        ~archive ~db_pool ~zkapp_pk:Zeko_circuits_config.Inputs.zeko_l1
+        ~l1_uri:config.l1_uri ~archive ~db_pool
+        ~zkapp_pk:Zeko_circuits_config.Inputs.zeko_l1
         ~archive_uri:config.archive_uri ~l1_config ~commit_validity_period
       >>| Or_error.ok_exn
     in

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -1086,6 +1086,11 @@ module Sequencer = struct
         }
     in
     let%bind merger = Merger.P.create_and_requeue ~logger merger_ctx db_pool in
+    let%bind bridge_prover =
+      Bridge_prover.create ~provers ~proof_cache_db
+        ~fee_recipient_l1:(Signer_service.Signer.public_key signer)
+        ~fee_recipient_l2:(Signer_service.Signer.public_key signer)
+    in
     let t =
       { ledger
       ; imt
@@ -1095,10 +1100,7 @@ module Sequencer = struct
       ; archive
       ; config
       ; da_client
-      ; bridge_prover =
-          Bridge_prover.create ~provers ~proof_cache_db
-            ~fee_recipient_l1:(Signer_service.Signer.public_key signer)
-            ~fee_recipient_l2:(Signer_service.Signer.public_key signer)
+      ; bridge_prover
       ; merger
       ; merger_ctx
       ; closed = Ivar.create ()

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -429,7 +429,9 @@ module Sequencer = struct
                 in
                 Core.printf "full_commitment: %s\n"
                   (Field.to_string full_commitment) ;
-                Core.printf "commitment: %s\n" (Field.to_string commitment)
+                Core.printf "commitment: %s\n" (Field.to_string commitment) ;
+                Core.printf "command: %s\n"
+                  (Zkapp_command.to_yojson command |> Yojson.Safe.to_string)
           in
 
           let%bind.Deferred.Result () =

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -238,10 +238,7 @@ module Sequencer = struct
     ; closed : unit Ivar.t
     ; apply_q : unit Sequencer.t
           (* Applying of the user command is async operation, but we need to keep the application synchronous *)
-    ; l2_fee_payer_pk : Public_key.Compressed.t ref
     }
-
-  let set_l2_fee_payer_pk t pk = t.l2_fee_payer_pk := pk
 
   let shutdown t =
     let logger = t.logger in
@@ -1046,13 +1043,6 @@ module Sequencer = struct
       ~(signer : Signer_service.Signer.t) ~deposit_delay_blocks ~mq_host
       ~fee_modifier ~minimum_fee ~slot_acceptance ~proof_cache_db ~l1_config
       ~commit_validity_period =
-    (* [l2_fee_payer_pk] holds the public key used as fee payer when the bridge
-       prover runs preverify against the L2 ledger. Defaults to the sequencer's
-       signer (matching production); tests can override via
-       [set_l2_fee_payer_pk] when their L2 executor uses a different account. *)
-    let l2_fee_payer_pk =
-      ref (Signer_service.Signer.public_key signer)
-    in
     [%log info] "Precomputing srs" ;
     Pickles.Side_loaded.srs_precomputation () ;
     let db_dir =
@@ -1154,7 +1144,7 @@ module Sequencer = struct
     in
     let preverify_l2 forest =
       let mask = L.of_database ledger in
-      let signer_pk = !l2_fee_payer_pk in
+      let signer_pk = Signer_service.Signer.public_key signer in
       let signer_aid = Account_id.create signer_pk Token_id.default in
       let nonce =
         match L.location_of_account mask signer_aid with
@@ -1168,9 +1158,7 @@ module Sequencer = struct
       let command = make_command ~fee_payer_pk:signer_pk ~nonce forest in
       let global_slot = Utils.Slot.global_slot ~l1_config in
       let state_view : Zkapp_precondition.Protocol_state.View.t =
-        { state_view_template with
-          global_slot_since_genesis = global_slot
-        }
+        { state_view_template with global_slot_since_genesis = global_slot }
       in
       let get_account aid =
         let acc =
@@ -1182,6 +1170,20 @@ module Sequencer = struct
       Zeko_transaction_logic.preverify_user_command ~get_account
         ~constraint_constants ~global_slot ~state_view
         (User_command.Zkapp_command command)
+    in
+    (* The other constraint_constants (ledger_depth, transaction_capacity, …)
+       are block-production related and don't affect [apply_user_command], so
+       we can reuse [Zeko_constants.constraint_constants] for those. The one
+       field that matters here is [account_creation_fee], which differs by
+       network — fetch it from the L1 daemon. *)
+    let%bind l1_account_creation_fee =
+      Gql_client.fetch_account_creation_fee ~logger config.l1_uri
+      >>| Or_error.ok_exn
+    in
+    let l1_constraint_constants =
+      { constraint_constants with
+        account_creation_fee = l1_account_creation_fee
+      }
     in
     let preverify_l1 forest =
       let signer_pk = Signer_service.Signer.public_key signer in
@@ -1195,18 +1197,17 @@ module Sequencer = struct
       let command = make_command ~fee_payer_pk:signer_pk ~nonce forest in
       let global_slot = Utils.Slot.global_slot ~l1_config in
       let state_view : Zkapp_precondition.Protocol_state.View.t =
-        { state_view_template with
-          global_slot_since_genesis = global_slot
-        }
+        { state_view_template with global_slot_since_genesis = global_slot }
       in
-      let get_account aid = Gql_client.fetch_account ~logger config.l1_uri aid in
+      let get_account aid =
+        Gql_client.fetch_account ~logger config.l1_uri aid
+      in
       Zeko_transaction_logic.preverify_user_command ~get_account
-        ~constraint_constants ~global_slot ~state_view
+        ~constraint_constants:l1_constraint_constants ~global_slot ~state_view
         (User_command.Zkapp_command command)
     in
     let%bind bridge_prover =
-      Bridge_prover.create ~provers ~proof_cache_db ~preverify_l1
-        ~preverify_l2
+      Bridge_prover.create ~provers ~proof_cache_db ~preverify_l1 ~preverify_l2
     in
 
     let t =
@@ -1223,7 +1224,6 @@ module Sequencer = struct
       ; merger_ctx
       ; closed = Ivar.create ()
       ; apply_q = Sequencer.create ()
-      ; l2_fee_payer_pk
       }
     in
     let%bind () =

--- a/src/app/zeko/sequencer/lib/zeko_transaction_logic.ml
+++ b/src/app/zeko/sequencer/lib/zeko_transaction_logic.ml
@@ -1,4 +1,5 @@
 open Core_kernel
+open Async_kernel
 open Mina_base
 open Mina_ledger
 open Mina_transaction_logic
@@ -561,3 +562,76 @@ let apply_fee_transfer_unchecked ~(receiver_pk : Even_PC.t) ~fee
               Base_witness.
                 { ledger_path_handler = source_ledger; update_acc_set_witness }
           } )
+
+let status_to_or_error : Transaction_status.t -> unit Or_error.t = function
+  | Applied ->
+      Ok ()
+  | Failed failures ->
+      Or_error.error_string
+        (sprintf "Transaction failed: %s"
+           (Yojson.Safe.pretty_to_string
+              (Transaction_status.Failure.Collection.to_yojson failures) ) )
+
+(** Preverify a [User_command.t] by simulating its application against a sparse
+    ledger built from accounts produced by [get_account]. Authorization
+    (signatures and proofs) is NOT verified — only the state-transition logic
+    (balances, nonces, preconditions, permissions, account creation, …) is
+    checked. Useful for both L1 and L2: provide L1 [constraint_constants] and a
+    [get_account] that fetches via GraphQL for L1, or L2 constants and a
+    function that reads from the local ledger for L2. *)
+let preverify_user_command
+    ~(get_account : Account_id.t -> Account.t option Deferred.Or_error.t)
+    ~(constraint_constants : Genesis_constants.Constraint_constants.t)
+    ~(global_slot : Mina_numbers.Global_slot_since_genesis.t)
+    ~(state_view : Zkapp_precondition.Protocol_state.View.t)
+    (command : User_command.t) : unit Deferred.Or_error.t =
+  let open Deferred.Or_error.Let_syntax in
+  let accounts_referenced = User_command.accounts_referenced command in
+  let%bind accounts =
+    Deferred.Or_error.List.map ~how:`Sequential accounts_referenced
+      ~f:(fun aid ->
+        let%map acc = get_account aid in
+        (aid, acc) )
+  in
+  Deferred.return
+  @@ Or_error.try_with_join (fun () ->
+         Ledger.with_ephemeral_ledger ~depth:constraint_constants.ledger_depth
+           ~f:(fun ledger ->
+             List.iter accounts ~f:(fun (aid, acc) ->
+                 match acc with
+                 | None ->
+                     ()
+                 | Some acc ->
+                     Ledger.create_new_account_exn ledger aid acc ) ;
+             let sparse_ledger =
+               Sparse_ledger.of_ledger_subset_exn ledger accounts_referenced
+             in
+             match command with
+             | Signed_command sc ->
+                 let (`If_this_is_used_it_should_have_a_comment_justifying_it
+                       valid ) =
+                   Signed_command.to_valid_unsafe sc
+                 in
+                 let open Or_error.Let_syntax in
+                 let%bind _, applied =
+                   Sparse_ledger.apply_user_command ~constraint_constants
+                     ~txn_global_slot:global_slot sparse_ledger valid
+                 in
+                 status_to_or_error applied.common.user_command.status
+             | Zkapp_command zc ->
+                 let open Or_error.Let_syntax in
+                 let%bind partial_txn, states =
+                   Sparse_ledger
+                   .apply_zkapp_first_pass_unchecked_with_states
+                     ~constraint_constants ~global_slot ~state_view
+                     ~fee_excess:Currency.Amount.Signed.zero
+                     ~supply_increase:Currency.Amount.Signed.zero
+                     ~first_pass_ledger:sparse_ledger
+                     ~second_pass_ledger:sparse_ledger zc
+                 in
+                 let%bind applied, _ =
+                   Sparse_ledger
+                   .apply_zkapp_second_pass_unchecked_with_states ~init:states
+                     sparse_ledger partial_txn
+                 in
+                 status_to_or_error applied.command.status ) )

--- a/src/app/zeko/sequencer/prover/lib/client.ml
+++ b/src/app/zeko/sequencer/prover/lib/client.ml
@@ -577,7 +577,7 @@ let finalize_cancelled_deposit t ~public_key ~may_use_token
        * Field.t
        * Bridge.Check_accepted_mina.Elem.t list )
     ~(check_accepted_ase : Ase.With_length.Stmt.t * Field.t list)
-    ~prev_next_cancelled_deposit =
+    ~prev_next_cancelled_deposit ~prev_nonce ~helper_account_new =
   let%bind.Deferred.Result commit_ase =
     let ase_source, ase_elms = commit_ase in
     let%map.Deferred.Result proof, target, excess =
@@ -655,6 +655,8 @@ let finalize_cancelled_deposit t ~public_key ~may_use_token
            ; verify_two_outer_ases
            ; verify_check_accepted_and_ase
            ; prev_next_cancelled_deposit
+           ; prev_nonce
+           ; helper_account_new
            } ))
   >>| function
   | Prover.Output.Call_forest (parent_with_calls, proof) ->

--- a/src/app/zeko/sequencer/prover/lib/client.ml
+++ b/src/app/zeko/sequencer/prover/lib/client.ml
@@ -731,3 +731,13 @@ let outer_token_owner t witness =
       Error (Error.of_string err)
   | _ ->
       failwith "Unexpected response from prover"
+
+let verification_keys t =
+  send t Prover.Input.Verification_keys
+  >>| function
+  | Prover.Output.Verification_keys vk ->
+      Ok vk
+  | Prover.Output.Error err ->
+      Error (Error.of_string err)
+  | _ ->
+      failwith "Unexpected response from prover"

--- a/src/app/zeko/sequencer/prover/lib/client.ml
+++ b/src/app/zeko/sequencer/prover/lib/client.ml
@@ -511,7 +511,8 @@ let finalize_deposit t ~public_key ~may_use_token ~inner_authorization_kind
     ~(check_accepted :
        Bridge.Check_accepted_mina.Init.t
        * Field.t
-       * Bridge.Check_accepted_mina.Elem.t list ) ~prev_next_deposit ~prev_nonce =
+       * Bridge.Check_accepted_mina.Elem.t list ) ~prev_next_deposit ~prev_nonce
+    ~helper_account_new =
   let%bind.Deferred.Result ase =
     let ase_source, ase_elms = ase in
     let%map.Deferred.Result proof, target, excess =
@@ -557,6 +558,7 @@ let finalize_deposit t ~public_key ~may_use_token ~inner_authorization_kind
            ; check_accepted
            ; prev_next_deposit
            ; prev_nonce
+           ; helper_account_new
            } ))
   >>| function
   | Prover.Output.Call_forest (parent_with_calls, proof) ->
@@ -674,7 +676,7 @@ let inner_receive t witness =
 
 let finalize_withdrawal t ~public_key ~may_use_token ~outer_authorization_kind
     ~commit ~before_commit ~commit_ase ~before_withdrawal ~withdrawal_ase
-    ~prev_next_withdrawal ~withdrawal_params ~prev_nonce =
+    ~prev_next_withdrawal ~withdrawal_params ~prev_nonce ~helper_account_new =
   let%bind.Deferred.Result commit_ase =
     let source, elems = commit_ase in
     let%map.Deferred.Result proof, target, excess =
@@ -710,6 +712,7 @@ let finalize_withdrawal t ~public_key ~may_use_token ~outer_authorization_kind
            ; prev_next_withdrawal
            ; withdrawal_params
            ; prev_nonce
+           ; helper_account_new
            } ))
   >>| function
   | Prover.Output.Call_forest (parent_with_calls, proof) ->

--- a/src/app/zeko/sequencer/prover/lib/client.ml
+++ b/src/app/zeko/sequencer/prover/lib/client.ml
@@ -511,7 +511,7 @@ let finalize_deposit t ~public_key ~may_use_token ~inner_authorization_kind
     ~(check_accepted :
        Bridge.Check_accepted_mina.Init.t
        * Field.t
-       * Bridge.Check_accepted_mina.Elem.t list ) ~prev_next_deposit =
+       * Bridge.Check_accepted_mina.Elem.t list ) ~prev_next_deposit ~prev_nonce =
   let%bind.Deferred.Result ase =
     let ase_source, ase_elms = ase in
     let%map.Deferred.Result proof, target, excess =
@@ -556,6 +556,7 @@ let finalize_deposit t ~public_key ~may_use_token ~inner_authorization_kind
            ; ase
            ; check_accepted
            ; prev_next_deposit
+           ; prev_nonce
            } ))
   >>| function
   | Prover.Output.Call_forest (parent_with_calls, proof) ->
@@ -673,7 +674,7 @@ let inner_receive t witness =
 
 let finalize_withdrawal t ~public_key ~may_use_token ~outer_authorization_kind
     ~commit ~before_commit ~commit_ase ~before_withdrawal ~withdrawal_ase
-    ~prev_next_withdrawal ~withdrawal_params =
+    ~prev_next_withdrawal ~withdrawal_params ~prev_nonce =
   let%bind.Deferred.Result commit_ase =
     let source, elems = commit_ase in
     let%map.Deferred.Result proof, target, excess =
@@ -708,6 +709,7 @@ let finalize_withdrawal t ~public_key ~may_use_token ~outer_authorization_kind
            ; withdrawal_ase
            ; prev_next_withdrawal
            ; withdrawal_params
+           ; prev_nonce
            } ))
   >>| function
   | Prover.Output.Call_forest (parent_with_calls, proof) ->

--- a/src/app/zeko/sequencer/prover/lib/prover.ml
+++ b/src/app/zeko/sequencer/prover/lib/prover.ml
@@ -22,6 +22,21 @@ let time ?fake_proving_time ~logger label (d : 'a Deferred.t) =
     (Time.Span.to_string_hum @@ Time.diff stop start) ;
   return x
 
+(* let run_and_check (input : 'input) out_typ
+     (main :
+          'input V.t
+       -> ('a, _) Compile_simple.main_return Snark_params.Tick.Checked.t ) =
+   let open Snark_params.Tick in
+   Snark_params.Tick.run_and_check_exn
+   @@
+   let open Checked in
+   exists Typ.unit ~compute:(fun _ -> ())
+   >>= fun () ->
+   main (V.return input)
+   >>| fun { out; _ } ->
+   let open As_prover in
+   read out_typ out >>= fun out -> return out *)
+
 module Make_folder (System : sig
   module Stmt : sig
     type t [@@deriving yojson]

--- a/src/app/zeko/sequencer/prover/lib/prover.ml
+++ b/src/app/zeko/sequencer/prover/lib/prover.ml
@@ -22,21 +22,6 @@ let time ?fake_proving_time ~logger label (d : 'a Deferred.t) =
     (Time.Span.to_string_hum @@ Time.diff stop start) ;
   return x
 
-(* let run_and_check (input : 'input) out_typ
-     (main :
-          'input V.t
-       -> ('a, _) Compile_simple.main_return Snark_params.Tick.Checked.t ) =
-   let open Snark_params.Tick in
-   Snark_params.Tick.run_and_check_exn
-   @@
-   let open Checked in
-   exists Typ.unit ~compute:(fun _ -> ())
-   >>= fun () ->
-   main (V.return input)
-   >>| fun { out; _ } ->
-   let open As_prover in
-   read out_typ out >>= fun out -> return out *)
-
 module Make_folder (System : sig
   module Stmt : sig
     type t [@@deriving yojson]
@@ -215,6 +200,18 @@ module Input = struct
           .serializable )
     | Outer_commit of Outer_commit.Witness.serializable
     | Bridge of Bridge.t
+    | Verification_keys
+  [@@deriving yojson]
+end
+
+module Verification_key_hashes = struct
+  type t =
+    { outer_rules : F.t
+    ; inner_rules : F.t
+    ; bridge_mina_l1 : F.t
+    ; bridge_mina_token_owner : F.t
+    ; bridge_mina_l2 : F.t
+    }
   [@@deriving yojson]
 end
 
@@ -248,6 +245,7 @@ module Output = struct
           , Zkapp_command.Digest.Forest.t )
           Zkapp_command.Call_forest.t )
         * Compile_simple.Proof.t
+    | Verification_keys of Verification_key_hashes.t
   [@@deriving yojson]
 end
 
@@ -595,6 +593,34 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
               (Zkapp_command.Call_forest.map
                  ~f:Account_update.read_all_proofs_from_disk )
         , proof )
+  | Verification_keys ->
+      let%bind outer_rules =
+        Compile_simple.Verification_key.of_tag (Lazy.force Outer_rules_inst.tag)
+        |> Promise.to_deferred >>| Compile_simple.Verification_key.hash
+      and inner_rules =
+        Compile_simple.Verification_key.of_tag (Lazy.force Inner_rules_inst.tag)
+        |> Promise.to_deferred >>| Compile_simple.Verification_key.hash
+      and bridge_mina_l1 =
+        Compile_simple.Verification_key.of_tag
+          (Lazy.force Bridge_inst_mina.System_L1_enabled.tag)
+        |> Promise.to_deferred >>| Compile_simple.Verification_key.hash
+      and bridge_mina_token_owner =
+        Compile_simple.Verification_key.of_tag
+          (Lazy.force Bridge_inst_mina.System_L1_token_owner.tag)
+        |> Promise.to_deferred >>| Compile_simple.Verification_key.hash
+      and bridge_mina_l2 =
+        Compile_simple.Verification_key.of_tag
+          (Lazy.force Bridge_inst_mina.System_L2.tag)
+        |> Promise.to_deferred >>| Compile_simple.Verification_key.hash
+      in
+      return
+        (Output.Verification_keys
+           { outer_rules
+           ; inner_rules
+           ; bridge_mina_l1
+           ; bridge_mina_token_owner
+           ; bridge_mina_l2
+           } )
 
 let run ?fake_proving_time ~logger ~mq_host () =
   let proof_cache_db = Proof_cache_tag.create_identity_db () in

--- a/src/app/zeko/sequencer/run.ml
+++ b/src/app/zeko/sequencer/run.ml
@@ -26,27 +26,42 @@ let run ~logger ~port ~max_pool_size ~commitment_period ~da_config ~da_keys
   [%log info] "Current slot: %d"
     ( Utils.Slot.global_slot ~l1_config
     |> Mina_numbers.Global_slot_since_genesis.to_int ) ;
+  let signer =
+    Thread_safe.block_on_async_exn (fun () ->
+        Signer_service.Client.create ~logger
+          ~location:(Host_and_port.of_string signer)
+        >>| Signer_service.Signer.of_client )
+  in
   let sequencer =
     Thread_safe.block_on_async_exn (fun () ->
-        let%bind signer =
-          Signer_service.Client.create ~logger
-            ~location:(Host_and_port.of_string signer)
-          >>| Signer_service.Signer.of_client
-        in
         Sequencer.create ~logger ~max_pool_size ~da_config ~da_keys ~da_quorum
           ~db_dir:(Some db_dir) ~checkpoints_dir:(Some checkpoints_dir)
           ~postgres_uri ~l1_uri ~archive_uri
-          ~commitment_period_sec:commitment_period ~deposit_delay_blocks
-          ~signer
+          ~commitment_period_sec:commitment_period ~deposit_delay_blocks ~signer
           ~mq_host ~fee_modifier ~minimum_fee ~slot_acceptance ~proof_cache_db
           ~l1_config ~commit_validity_period )
   in
 
   Sequencer.run_committer sequencer ;
 
+  let l2_executor =
+    Executor.create
+      ~kind:
+        (`L2
+          { infer_nonce = Sequencer.infer_nonce sequencer
+          ; apply_user_command = Sequencer.apply_user_command sequencer
+          } )
+      ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 ~signer ()
+  in
+
   let graphql_callback =
     Graphql_cohttp_async.make_callback
-      (fun ~with_seq_no:_ _req -> sequencer)
+      (fun ~with_seq_no:_ _req ->
+        Gql.Context.
+          { sequencer
+          ; l1_executor = sequencer.merger_ctx.executor
+          ; l2_executor
+          } )
       (Gql.schema ~proof_cache_db)
   in
   let () =
@@ -122,8 +137,7 @@ let () =
          (optional_with_default 20 int)
          ~doc:"int Commit validity period in slots"
      and signer =
-       flag "--signer" (required string)
-         ~doc:"string Signer service host:port"
+       flag "--signer" (required string) ~doc:"string Signer service host:port"
      in
      let slot_acceptance = Time.Span.of_min slot_acceptance_m in
      let da_config = Da_layer.Client.Config.of_string_list da_nodes in

--- a/src/app/zeko/sequencer/tests/dune
+++ b/src/app/zeko/sequencer/tests/dune
@@ -51,3 +51,17 @@
  (preprocess
   (pps ppx_let ppx_jane ppx_mina))
  (modules imt_benchmark))
+
+(executable
+ (name preverify_test)
+ (libraries
+  sequencer_lib
+  is_compile_simple_real_real
+  consensus
+  staged_ledger_diff
+  genesis_ledger
+  mina_state
+  cli_lib)
+ (preprocess
+  (pps ppx_let ppx_jane ppx_mina))
+ (modules preverify_test))

--- a/src/app/zeko/sequencer/tests/preverify_test.ml
+++ b/src/app/zeko/sequencer/tests/preverify_test.ml
@@ -1,0 +1,333 @@
+open Core_kernel
+open Async
+open Mina_base
+open Mina_numbers
+open Currency
+open Signature_lib
+open Sequencer_lib
+module L = Mina_ledger.Ledger
+
+let logger =
+  Cli_lib.Stdout_log.setup false Logger.Level.Info ;
+  Logger.create ()
+
+let signature_kind = Mina_signature_kind.t_DEPRECATED
+
+let proof_cache_db = Proof_cache_tag.For_tests.create_db ()
+
+(* L2 constants — same as the sequencer uses. Account creation fee is 0.1 mina. *)
+let l2_constraint_constants = Zeko_constants.constraint_constants
+
+(* Simulated L1 constants — same shape, but with the larger 1 mina account
+   creation fee that mainnet/devnet use. This is enough to exercise the
+   "different constants" path through the preverify utility. *)
+let l1_constraint_constants : Genesis_constants.Constraint_constants.t =
+  { l2_constraint_constants with
+    account_creation_fee = Currency.Fee.of_mina_string_exn "1.0"
+  }
+
+let consensus_constants =
+  let protocol_constants : Genesis_constants.Protocol.t =
+    { k = 1
+    ; slots_per_epoch = 1000
+    ; slots_per_sub_window = 1
+    ; grace_period_slots = 1
+    ; delta = 1
+    ; genesis_state_timestamp = Int64.one
+    }
+  in
+  Consensus.Constants.create ~constraint_constants:l2_constraint_constants
+    ~protocol_constants
+
+let compile_time_genesis =
+  Mina_state.Genesis_protocol_state.t
+    ~genesis_ledger:Genesis_ledger.(Packed.t for_unit_tests)
+    ~genesis_epoch_data:Consensus.Genesis_epoch_data.for_unit_tests
+    ~constraint_constants:l2_constraint_constants ~consensus_constants
+    ~genesis_body_reference:Staged_ledger_diff.genesis_body_reference
+
+let state_view ~global_slot : Zkapp_precondition.Protocol_state.View.t =
+  let s = Mina_state.Protocol_state.Body.view compile_time_genesis.data.body in
+  { snarked_ledger_hash = s.snarked_ledger_hash
+  ; blockchain_length = s.blockchain_length
+  ; min_window_density = s.min_window_density
+  ; total_currency = s.total_currency
+  ; global_slot_since_genesis = global_slot
+  ; staking_epoch_data = s.staking_epoch_data
+  ; next_epoch_data = s.next_epoch_data
+  }
+
+let global_slot = Global_slot_since_genesis.zero
+
+(* Build a fully funded test ledger with two accounts. *)
+let make_ledger ~depth (accounts : (Account_id.t * Account.t) list) : L.t =
+  let ledger = L.create_ephemeral ~depth () in
+  List.iter accounts ~f:(fun (aid, acc) -> L.create_new_account_exn ledger aid acc) ;
+  ledger
+
+let funded_account aid balance : Account.t =
+  let acc = Account.create aid (Balance.of_mina_int_exn balance) in
+  acc
+
+let make_payment ~sender ~receiver ~amount ~fee ~nonce : Signed_command.t =
+  let sender_pk = Public_key.compress sender.Keypair.public_key in
+  let payload : Signed_command.Payload.t =
+    Signed_command.Payload.create ~fee ~fee_payer_pk:sender_pk ~nonce
+      ~memo:Signed_command_memo.dummy ~valid_until:None
+      ~body:(Payment { receiver_pk = receiver; amount })
+  in
+  Signed_command.sign ~signature_kind sender payload
+  |> Signed_command.forget_check
+
+let make_zkapp_send ~sender ~receiver ~amount ~fee ~nonce : Zkapp_command.t =
+  let sender_pk = Public_key.compress sender.Keypair.public_key in
+  let zkapp_command : Zkapp_command.Simple.t =
+    { fee_payer =
+        Account_update.Fee_payer.make
+          ~body:
+            { public_key = sender_pk; fee; valid_until = None; nonce }
+          ~authorization:Signature.dummy
+    ; account_updates =
+        [ Account_update.with_no_aux
+            ~body:
+              { Account_update.Body.Simple.public_key = sender_pk
+              ; update = Account_update.Update.noop
+              ; token_id = Token_id.default
+              ; balance_change = Amount.Signed.(negate (of_unsigned amount))
+              ; increment_nonce = true
+              ; events = []
+              ; actions = []
+              ; call_data = Snark_params.Tick.Field.zero
+              ; call_depth = 0
+              ; preconditions =
+                  { network = Zkapp_precondition.Protocol_state.accept
+                  ; account = Zkapp_precondition.Account.accept
+                  ; valid_while = Zkapp_basic.Or_ignore.Ignore
+                  }
+              ; may_use_token = No
+              ; use_full_commitment = true
+              ; implicit_account_creation_fee = true
+              ; authorization_kind = Signature
+              }
+            ~authorization:(Control.Poly.Signature Signature.dummy)
+        ; Account_update.with_no_aux
+            ~body:
+              { Account_update.Body.Simple.public_key = receiver
+              ; update = Account_update.Update.noop
+              ; token_id = Token_id.default
+              ; balance_change = Amount.Signed.of_unsigned amount
+              ; increment_nonce = false
+              ; events = []
+              ; actions = []
+              ; call_data = Snark_params.Tick.Field.zero
+              ; call_depth = 0
+              ; preconditions =
+                  { network = Zkapp_precondition.Protocol_state.accept
+                  ; account = Zkapp_precondition.Account.accept
+                  ; valid_while = Zkapp_basic.Or_ignore.Ignore
+                  }
+              ; may_use_token = No
+              ; use_full_commitment = false
+              ; implicit_account_creation_fee = true
+              ; authorization_kind = None_given
+              }
+            ~authorization:Control.Poly.None_given
+        ]
+    ; memo = Signed_command_memo.empty
+    }
+  in
+  Zkapp_command.of_simple ~signature_kind ~proof_cache_db zkapp_command
+
+(* Get-account function that reads from a local in-memory ledger. Models the
+   L2 path: the sequencer holds the canonical ledger locally and answers
+   synchronously. *)
+let get_account_from_ledger ledger : Account_id.t -> Account.t option Deferred.Or_error.t
+    =
+ fun aid ->
+  let result =
+    let%bind.Option loc = L.location_of_account ledger aid in
+    L.get ledger loc
+  in
+  Deferred.Or_error.return result
+
+(* Get-account function that reads from a precomputed table. Models the
+   L1 path: the caller has fetched accounts via GraphQL and stuffed them in a
+   table. The point of this test isn't network round-trips, just that the
+   preverify function does not care where accounts come from. *)
+let get_account_from_table table : Account_id.t -> Account.t option Deferred.Or_error.t =
+ fun aid -> Deferred.Or_error.return (Hashtbl.find table aid)
+
+let assert_ok ~msg = function
+  | Ok () ->
+      ()
+  | Error err ->
+      failwithf "%s: %s" msg (Error.to_string_hum err) ()
+
+let assert_error ~msg = function
+  | Ok () ->
+      failwithf "expected error but got Ok: %s" msg ()
+  | Error _ ->
+      ()
+
+let run = Thread_safe.block_on_async_exn
+
+let () = print_endline "(* preverify: L2 — successful payment via local ledger *)"
+
+let () =
+  let sender_kp = Keypair.create () in
+  let receiver_kp = Keypair.create () in
+  let sender_pk = Public_key.compress sender_kp.public_key in
+  let receiver_pk = Public_key.compress receiver_kp.public_key in
+  let sender_aid = Account_id.create sender_pk Token_id.default in
+  let receiver_aid = Account_id.create receiver_pk Token_id.default in
+  let ledger =
+    make_ledger ~depth:l2_constraint_constants.ledger_depth
+      [ (sender_aid, funded_account sender_aid 1000)
+      ; (receiver_aid, funded_account receiver_aid 0)
+      ]
+  in
+  let payment =
+    make_payment ~sender:sender_kp ~receiver:receiver_pk
+      ~amount:(Amount.of_mina_int_exn 5)
+      ~fee:(Fee.of_mina_int_exn 1) ~nonce:Account_nonce.zero
+  in
+  let result =
+    run (fun () ->
+        Zeko_transaction_logic.preverify_user_command
+          ~get_account:(get_account_from_ledger ledger)
+          ~constraint_constants:l2_constraint_constants ~global_slot
+          ~state_view:(state_view ~global_slot)
+          (User_command.Signed_command payment) )
+  in
+  assert_ok ~msg:"L2 payment should succeed" result ;
+  [%log info] "OK: L2 payment preverified"
+
+let () =
+  print_endline
+    "(* preverify: L1 — same payment via fetched-account table, larger \
+     account_creation_fee *)"
+
+let () =
+  let sender_kp = Keypair.create () in
+  let receiver_kp = Keypair.create () in
+  let sender_pk = Public_key.compress sender_kp.public_key in
+  let receiver_pk = Public_key.compress receiver_kp.public_key in
+  let sender_aid = Account_id.create sender_pk Token_id.default in
+  let receiver_aid = Account_id.create receiver_pk Token_id.default in
+  let table = Hashtbl.create (module Account_id) in
+  Hashtbl.set table ~key:sender_aid ~data:(funded_account sender_aid 1000) ;
+  Hashtbl.set table ~key:receiver_aid ~data:(funded_account receiver_aid 0) ;
+  let payment =
+    make_payment ~sender:sender_kp ~receiver:receiver_pk
+      ~amount:(Amount.of_mina_int_exn 5)
+      ~fee:(Fee.of_mina_int_exn 2) ~nonce:Account_nonce.zero
+  in
+  let result =
+    run (fun () ->
+        Zeko_transaction_logic.preverify_user_command
+          ~get_account:(get_account_from_table table)
+          ~constraint_constants:l1_constraint_constants ~global_slot
+          ~state_view:(state_view ~global_slot)
+          (User_command.Signed_command payment) )
+  in
+  assert_ok ~msg:"L1 payment should succeed" result ;
+  [%log info] "OK: L1 payment preverified"
+
+let () =
+  print_endline
+    "(* preverify: insufficient balance — payment should fail at preverify *)"
+
+let () =
+  let sender_kp = Keypair.create () in
+  let receiver_kp = Keypair.create () in
+  let sender_pk = Public_key.compress sender_kp.public_key in
+  let receiver_pk = Public_key.compress receiver_kp.public_key in
+  let sender_aid = Account_id.create sender_pk Token_id.default in
+  let receiver_aid = Account_id.create receiver_pk Token_id.default in
+  let ledger =
+    make_ledger ~depth:l2_constraint_constants.ledger_depth
+      [ (sender_aid, funded_account sender_aid 1)
+      ; (receiver_aid, funded_account receiver_aid 0)
+      ]
+  in
+  let payment =
+    make_payment ~sender:sender_kp ~receiver:receiver_pk
+      ~amount:(Amount.of_mina_int_exn 100)
+      ~fee:(Fee.of_mina_int_exn 1) ~nonce:Account_nonce.zero
+  in
+  let result =
+    run (fun () ->
+        Zeko_transaction_logic.preverify_user_command
+          ~get_account:(get_account_from_ledger ledger)
+          ~constraint_constants:l2_constraint_constants ~global_slot
+          ~state_view:(state_view ~global_slot)
+          (User_command.Signed_command payment) )
+  in
+  assert_error ~msg:"insufficient-balance payment should fail at preverify"
+    result ;
+  [%log info] "OK: underfunded payment caught"
+
+let () =
+  print_endline
+    "(* preverify: L2 — successful zkapp_command (no real signatures) *)"
+
+let () =
+  let sender_kp = Keypair.create () in
+  let receiver_kp = Keypair.create () in
+  let sender_pk = Public_key.compress sender_kp.public_key in
+  let receiver_pk = Public_key.compress receiver_kp.public_key in
+  let sender_aid = Account_id.create sender_pk Token_id.default in
+  let receiver_aid = Account_id.create receiver_pk Token_id.default in
+  let ledger =
+    make_ledger ~depth:l2_constraint_constants.ledger_depth
+      [ (sender_aid, funded_account sender_aid 1000)
+      ; (receiver_aid, funded_account receiver_aid 0)
+      ]
+  in
+  let cmd =
+    make_zkapp_send ~sender:sender_kp ~receiver:receiver_pk
+      ~amount:(Amount.of_mina_int_exn 5)
+      ~fee:(Fee.of_mina_int_exn 1) ~nonce:Account_nonce.zero
+  in
+  let result =
+    run (fun () ->
+        Zeko_transaction_logic.preverify_user_command
+          ~get_account:(get_account_from_ledger ledger)
+          ~constraint_constants:l2_constraint_constants ~global_slot
+          ~state_view:(state_view ~global_slot)
+          (User_command.Zkapp_command cmd) )
+  in
+  assert_ok ~msg:"L2 zkapp_command should succeed" result ;
+  [%log info] "OK: L2 zkapp_command preverified"
+
+let () =
+  print_endline
+    "(* preverify: L1 — same zkapp_command via fetched-account table *)"
+
+let () =
+  let sender_kp = Keypair.create () in
+  let receiver_kp = Keypair.create () in
+  let sender_pk = Public_key.compress sender_kp.public_key in
+  let receiver_pk = Public_key.compress receiver_kp.public_key in
+  let sender_aid = Account_id.create sender_pk Token_id.default in
+  let receiver_aid = Account_id.create receiver_pk Token_id.default in
+  let table = Hashtbl.create (module Account_id) in
+  Hashtbl.set table ~key:sender_aid ~data:(funded_account sender_aid 1000) ;
+  Hashtbl.set table ~key:receiver_aid ~data:(funded_account receiver_aid 0) ;
+  let cmd =
+    make_zkapp_send ~sender:sender_kp ~receiver:receiver_pk
+      ~amount:(Amount.of_mina_int_exn 5)
+      ~fee:(Fee.of_mina_int_exn 2) ~nonce:Account_nonce.zero
+  in
+  let result =
+    run (fun () ->
+        Zeko_transaction_logic.preverify_user_command
+          ~get_account:(get_account_from_table table)
+          ~constraint_constants:l1_constraint_constants ~global_slot
+          ~state_view:(state_view ~global_slot)
+          (User_command.Zkapp_command cmd) )
+  in
+  assert_ok ~msg:"L1 zkapp_command should succeed" result ;
+  [%log info] "OK: L1 zkapp_command preverified"
+
+let () = print_endline "All preverify tests passed."

--- a/src/app/zeko/sequencer/tests/run-sequencer-test.sh
+++ b/src/app/zeko/sequencer/tests/run-sequencer-test.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: $0 <fake|real> <num_provers>" >&2
+  echo "Usage: $0 <fake|real> <num_provers> <agent?> <wait_for_port?>" >&2
   exit 1
 }
 
-if [ "$#" -ne 2 ]; then
+if [ "$#" -ne 4 ]; then
   usage
 fi
 
@@ -15,6 +15,14 @@ NUM_PROVERS="$2"
 PROVER_PIDS=()
 SIGNER_PIDS=()
 PROVERS=()
+
+AGENT="$3"
+if [ "$AGENT" = "true" ]; then
+  echo "Redirecting output to /tmp/sequencer_test_output.log"
+  exec > /tmp/sequencer_test_output.log 2>&1
+fi
+
+WAIT_FOR_PORT="$4"
 
 case "$MODE" in
 fake | real) ;;
@@ -52,18 +60,23 @@ export ZEKO_CIRCUITS_CONFIG=test
 TMP_DIR=$(mktemp -d)
 
 wait_for_port() {
-  local port=$1
-  local pid=$2
-  while ! nc -z localhost $port; do
-    sleep 1
+  if [ "$WAIT_FOR_PORT" = "true" ]; then
+    local port=$1
+    local pid=$2
+    while ! nc -z localhost $port; do
+      sleep 1
 
-    if ! kill -0 $pid 2>/dev/null; then
-      echo "Process for port $port failed to start"
-      exit 1
-    fi
-  done
+      if ! kill -0 $pid 2>/dev/null; then
+        echo "Process for port $port failed to start"
+        exit 1
+      fi
+    done
 
-  echo "Port $port is now open"
+    echo "Port $port is now open"
+  else
+    echo "Waiting for 2 seconds..."
+    sleep 2
+  fi
 }
 
 KEYGEN_BIN="$SEQUENCER_BUILD_ROOT/cli.exe"

--- a/src/app/zeko/sequencer/tests/run-sequencer-test.sh
+++ b/src/app/zeko/sequencer/tests/run-sequencer-test.sh
@@ -110,22 +110,35 @@ DA3_SIGNER_PRIVATE_KEY="$(generate_even_key)"
 export ZEKO_TEST_SEQUENCER_SIGNER="127.0.0.1:8600"
 export ZEKO_TEST_SEQUENCER_SIGNER_PRIVATE_KEY
 
-MINA_PRIVATE_KEY="$ZEKO_TEST_SEQUENCER_SIGNER_PRIVATE_KEY" \
+run() {
+  name="$1"
+  shift
+
+  stdbuf -oL -eL "$@" \
+    > >(awk -v n="$name" '{ print "[" n "] " $0; fflush(); }') \
+    2> >(awk -v n="$name" '{ print "[" n "][ERR] " $0; fflush(); }' >&2)
+}
+
+run "sequencer-signer" \
+  env MINA_PRIVATE_KEY="$ZEKO_TEST_SEQUENCER_SIGNER_PRIVATE_KEY" \
   "$SEQUENCER_SIGNER_BIN" run --port 8600 --allow-zkapp-signing --max-fee 10 --max-balance-change 1000000 &
 signer_seq_pid=$!
 SIGNER_PIDS+=("$signer_seq_pid")
 
-MINA_PRIVATE_KEY="$DA1_SIGNER_PRIVATE_KEY" \
+run "da1-signer" \
+  env MINA_PRIVATE_KEY="$DA1_SIGNER_PRIVATE_KEY" \
   "$DA_SIGNER_BIN" run --port 8601 --allow-field-signing &
 signer_da1_pid=$!
 SIGNER_PIDS+=("$signer_da1_pid")
 
-MINA_PRIVATE_KEY="$DA2_SIGNER_PRIVATE_KEY" \
+run "da2-signer" \
+  env MINA_PRIVATE_KEY="$DA2_SIGNER_PRIVATE_KEY" \
   "$DA_SIGNER_BIN" run --port 8602 --allow-field-signing &
 signer_da2_pid=$!
 SIGNER_PIDS+=("$signer_da2_pid")
 
-MINA_PRIVATE_KEY="$DA3_SIGNER_PRIVATE_KEY" \
+run "da3-signer" \
+  env MINA_PRIVATE_KEY="$DA3_SIGNER_PRIVATE_KEY" \
   "$DA_SIGNER_BIN" run --port 8603 --allow-field-signing &
 signer_da3_pid=$!
 SIGNER_PIDS+=("$signer_da3_pid")
@@ -135,16 +148,16 @@ wait_for_port 8601 $signer_da1_pid
 wait_for_port 8602 $signer_da2_pid
 wait_for_port 8603 $signer_da3_pid
 
-$SEQUENCER_BUILD_ROOT/tests/testing_ledger/run.exe -p 8080 --db-dir "$TMP_DIR/l1_db" --network-id testnet --block-period 9999999 &
+run "l1" $SEQUENCER_BUILD_ROOT/tests/testing_ledger/run.exe -p 8080 --db-dir "$TMP_DIR/l1_db" --network-id testnet --block-period 9999999 &
 l1_pid=$!
 
-$SEQUENCER_BUILD_ROOT/../da_layer/cli.exe run-node --port 8555 --healthcheck-port 8558 --network-id testnet --db-dir "$TMP_DIR/da1_db" --signer 127.0.0.1:8601 &
+run "da1" $SEQUENCER_BUILD_ROOT/../da_layer/cli.exe run-node --port 8555 --healthcheck-port 8558 --network-id testnet --db-dir "$TMP_DIR/da1_db" --signer 127.0.0.1:8601 &
 da1_pid=$!
 
-$SEQUENCER_BUILD_ROOT/../da_layer/cli.exe run-node --port 8556 --healthcheck-port 8559 --network-id testnet --db-dir "$TMP_DIR/da2_db" --signer 127.0.0.1:8602 &
+run "da2" $SEQUENCER_BUILD_ROOT/../da_layer/cli.exe run-node --port 8556 --healthcheck-port 8559 --network-id testnet --db-dir "$TMP_DIR/da2_db" --signer 127.0.0.1:8602 &
 da2_pid=$!
 
-$SEQUENCER_BUILD_ROOT/../da_layer/cli.exe run-node --port 8557 --healthcheck-port 8560 --network-id testnet --db-dir "$TMP_DIR/da3_db" --signer 127.0.0.1:8603 &
+run "da3" $SEQUENCER_BUILD_ROOT/../da_layer/cli.exe run-node --port 8557 --healthcheck-port 8560 --network-id testnet --db-dir "$TMP_DIR/da3_db" --signer 127.0.0.1:8603 &
 da3_pid=$!
 
 # Launch provers
@@ -157,7 +170,9 @@ else
 fi
 for ((i = 0; i < NUM_PROVERS; i++)); do
   PORT=$((9990 + i))
-  ZEKO_CIRCUITS_MODE=$MODE $BIN run-server --mq-host "localhost:5672" &
+  run "prover-$i" \
+    env ZEKO_CIRCUITS_MODE=$MODE \
+    $BIN run-server --mq-host "localhost:5672" &
   PROVER_PID=$!
   PROVER_PIDS+=("$PROVER_PID")
   PROVERS+=("localhost:$PORT")
@@ -174,7 +189,11 @@ wait_for_port 8557 $da3_pid
 echo "All services started successfully"
 
 if [ "$MODE" = "fake" ]; then
-  ZEKO_CIRCUITS_MODE=$MODE  $SEQUENCER_BUILD_ROOT/tests/sequencer_test_fake.exe "${PROVERS[@]}"
+  run "sequencer-test" \
+    env ZEKO_CIRCUITS_MODE=$MODE \
+    $SEQUENCER_BUILD_ROOT/tests/sequencer_test_fake.exe "${PROVERS[@]}"
 else
-  ZEKO_CIRCUITS_MODE=$MODE $SEQUENCER_BUILD_ROOT/tests/sequencer_test.exe "${PROVERS[@]}"
+  run "sequencer-test" \
+    env ZEKO_CIRCUITS_MODE=$MODE \
+    $SEQUENCER_BUILD_ROOT/tests/sequencer_test.exe "${PROVERS[@]}"
 fi

--- a/src/app/zeko/sequencer/tests/run-sequencer-test.sh
+++ b/src/app/zeko/sequencer/tests/run-sequencer-test.sh
@@ -40,7 +40,29 @@ fi
 cleanup() {
   local exit_status=$1
   echo "Cleaning up..."
-  kill ${l1_pid:-} ${da1_pid:-} ${da2_pid:-} ${da3_pid:-} "${PROVER_PIDS[@]}" "${SIGNER_PIDS[@]}" 2>/dev/null
+  local -a service_pids=(
+    "${l1_pid:-}"
+    "${da1_pid:-}"
+    "${da2_pid:-}"
+    "${da3_pid:-}"
+    "${PROVER_PIDS[@]}"
+    "${SIGNER_PIDS[@]}"
+  )
+
+  trap - SIGINT SIGTERM EXIT
+
+  for pid in "${service_pids[@]}"; do
+    [ -n "$pid" ] || continue
+    kill_process_tree TERM "$pid"
+  done
+
+  sleep 1
+
+  for pid in "${service_pids[@]}"; do
+    [ -n "$pid" ] || continue
+    kill_process_tree KILL "$pid"
+  done
+
   rm -rf "$TMP_DIR"
   docker rm -f pg-sequencer 2>/dev/null
   docker rm -f rabbitmq-sequencer 2>/dev/null
@@ -58,6 +80,24 @@ export ZEKO_SIGNATURE_KIND=testnet
 export ZEKO_CIRCUITS_CONFIG=test
 
 TMP_DIR=$(mktemp -d)
+
+list_child_pids() {
+  local parent_pid="$1"
+  ps -axo pid=,ppid= | awk -v parent="$parent_pid" '$2 == parent { print $1 }'
+}
+
+kill_process_tree() {
+  local signal="$1"
+  local pid="$2"
+  local child_pid
+
+  while read -r child_pid; do
+    [ -n "$child_pid" ] || continue
+    kill_process_tree "$signal" "$child_pid"
+  done < <(list_child_pids "$pid")
+
+  kill "-$signal" "$pid" 2>/dev/null || true
+}
 
 wait_for_port() {
   if [ "$WAIT_FOR_PORT" = "true" ]; then
@@ -111,12 +151,17 @@ export ZEKO_TEST_SEQUENCER_SIGNER="127.0.0.1:8600"
 export ZEKO_TEST_SEQUENCER_SIGNER_PRIVATE_KEY
 
 run() {
-  name="$1"
+  local name="$1"
   shift
 
-  stdbuf -oL -eL "$@" \
-    > >(awk -v n="$name" '{ print "[" n "] " $0; fflush(); }') \
-    2> >(awk -v n="$name" '{ print "[" n "][ERR] " $0; fflush(); }' >&2)
+  bash -c '
+    name="$1"
+    shift
+
+    exec stdbuf -oL -eL "$@" \
+      > >(awk -v n="$name" '"'"'{ print "[" n "] " $0; fflush(); }'"'"') \
+      2> >(awk -v n="$name" '"'"'{ print "[" n "][ERR] " $0; fflush(); }'"'"' >&2)
+  ' bash "$name" "$@"
 }
 
 run "sequencer-signer" \

--- a/src/app/zeko/sequencer/tests/run-sequencer-test.sh
+++ b/src/app/zeko/sequencer/tests/run-sequencer-test.sh
@@ -76,7 +76,7 @@ SEQUENCER_ROOT="$(git rev-parse --show-toplevel)/src/app/zeko/sequencer"
 SEQUENCER_BUILD_ROOT="$(git rev-parse --show-toplevel)/_build/default/src/app/zeko/sequencer"
 SIGNER_BUILD_ROOT="$(git rev-parse --show-toplevel)/_build/default/src/app/zeko/signer"
 
-export ZEKO_SIGNATURE_KIND=testnet
+export ZEKO_SIGNATURE_KIND=zeko-testnet
 export ZEKO_CIRCUITS_CONFIG=test
 
 TMP_DIR=$(mktemp -d)
@@ -193,16 +193,16 @@ wait_for_port 8601 $signer_da1_pid
 wait_for_port 8602 $signer_da2_pid
 wait_for_port 8603 $signer_da3_pid
 
-run "l1" $SEQUENCER_BUILD_ROOT/tests/testing_ledger/run.exe -p 8080 --db-dir "$TMP_DIR/l1_db" --network-id testnet --block-period 9999999 &
+run "l1" $SEQUENCER_BUILD_ROOT/tests/testing_ledger/run.exe -p 8080 --db-dir "$TMP_DIR/l1_db" --network-id mainnet --block-period 9999999 &
 l1_pid=$!
 
-run "da1" $SEQUENCER_BUILD_ROOT/../da_layer/cli.exe run-node --port 8555 --healthcheck-port 8558 --network-id testnet --db-dir "$TMP_DIR/da1_db" --signer 127.0.0.1:8601 &
+run "da1" $SEQUENCER_BUILD_ROOT/../da_layer/cli.exe run-node --port 8555 --healthcheck-port 8558 --network-id zeko-testnet --db-dir "$TMP_DIR/da1_db" --signer 127.0.0.1:8601 &
 da1_pid=$!
 
-run "da2" $SEQUENCER_BUILD_ROOT/../da_layer/cli.exe run-node --port 8556 --healthcheck-port 8559 --network-id testnet --db-dir "$TMP_DIR/da2_db" --signer 127.0.0.1:8602 &
+run "da2" $SEQUENCER_BUILD_ROOT/../da_layer/cli.exe run-node --port 8556 --healthcheck-port 8559 --network-id zeko-testnet --db-dir "$TMP_DIR/da2_db" --signer 127.0.0.1:8602 &
 da2_pid=$!
 
-run "da3" $SEQUENCER_BUILD_ROOT/../da_layer/cli.exe run-node --port 8557 --healthcheck-port 8560 --network-id testnet --db-dir "$TMP_DIR/da3_db" --signer 127.0.0.1:8603 &
+run "da3" $SEQUENCER_BUILD_ROOT/../da_layer/cli.exe run-node --port 8557 --healthcheck-port 8560 --network-id zeko-testnet --db-dir "$TMP_DIR/da3_db" --signer 127.0.0.1:8603 &
 da3_pid=$!
 
 # Launch provers

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -833,7 +833,8 @@ let () =
                     (Random_oracle.Input.Chunked.field tx_commitment) ) )
         in
         Bridge_prover.(
-          execute_request ~logger ~executor:l1_executor !sequencer.bridge_prover
+          execute_request ~label:"SubmitDeposit" ~logger ~executor:l1_executor
+            !sequencer.bridge_prover
             (Deposit_request.f ~t:!sequencer.bridge_prover ~logger
                { deposit_params; transferrer = transferrer_update } ))
         >>| Or_error.ok_exn
@@ -1084,7 +1085,8 @@ let () =
             (Random_oracle.Input.Chunked.field commitment)
         in
         Bridge_prover.(
-          execute_request ~logger ~executor:l2_executor !sequencer.bridge_prover
+          execute_request ~label:"FinalizeDeposit" ~logger ~executor:l2_executor
+            !sequencer.bridge_prover
             (Finalize_deposit.f ~t:!sequencer.bridge_prover ~logger witness
                helper_account_signature ))
         >>| Or_error.ok_exn
@@ -1402,7 +1404,8 @@ let () =
                     (Random_oracle.Input.Chunked.field tx_commitment) ) )
         in
         Bridge_prover.(
-          execute_request ~logger ~executor:l2_executor !sequencer.bridge_prover
+          execute_request ~label:"SubmitWithdrawal" ~logger
+            ~executor:l2_executor !sequencer.bridge_prover
             (Withdrawal_request.f ~t:!sequencer.bridge_prover ~logger
                { withdrawal_params; transferrer = transferrer_update } ))
         >>| Or_error.ok_exn
@@ -1643,7 +1646,8 @@ let () =
             (Random_oracle.Input.Chunked.field commitment)
         in
         Bridge_prover.(
-          execute_request ~logger ~executor:l1_executor !sequencer.bridge_prover
+          execute_request ~label:"FinalizeWithdrawal" ~logger
+            ~executor:l1_executor !sequencer.bridge_prover
             (Finalize_withdrawal.f ~t:!sequencer.bridge_prover ~logger witness
                helper_account_signature ))
         >>| Or_error.ok_exn

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -791,7 +791,7 @@ let () =
       let submit_deposit (signer : Keypair.t)
           (deposit_params : C.Bridge_state.Deposit_params_base.t) =
         let%bind nonce =
-          Gql_client.fetch_nonce ~logger gql_uri
+          Gql_client.infer_nonce ~logger gql_uri
             (Signature_lib.Public_key.compress signer.public_key)
           >>| Or_error.ok_exn
         in
@@ -812,12 +812,25 @@ let () =
               ; authorization_kind = Signature
               ; preconditions =
                   { Account_update.Preconditions.accept with
-                    account =
-                      Zkapp_precondition.Account.nonce
-                        (Account.Nonce.succ nonce)
+                    account = Zkapp_precondition.Account.nonce nonce
                   }
               }
             ~authorization:(Control.Poly.Signature Signature.dummy)
+        in
+        let _forest, `Commitment tx_commitment =
+          Bridge_prover.Deposit_request.precompute_commitments
+            !sequencer.bridge_prover
+            { deposit_params; transferrer = transferrer_update }
+          |> Or_error.ok_exn
+        in
+        let transferrer_update =
+          Account_update.with_no_aux ~body:transferrer_update.body
+            ~authorization:
+              (Control.Poly.Signature
+                 (Signature_lib.Schnorr.Chunked.sign
+                    ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+                    signer.private_key
+                    (Random_oracle.Input.Chunked.field tx_commitment) ) )
         in
         Bridge_prover.(
           execute_request ~logger ~executor:l1_executor !sequencer.bridge_prover
@@ -1049,17 +1062,31 @@ let () =
                  UInt32.of_string
                    (Mina_numbers.Account_nonce.to_string acc.nonce) ) )
         in
+        let witness : Bridge_prover.Finalize_deposit.t_ =
+          { ase_source = fst ase
+          ; ase_elems = snd ase
+          ; check_accepted_init = fst check_accepted
+          ; check_accepted_elems = snd check_accepted
+          ; prev_next_deposit
+          ; prev_nonce
+          ; helper_account_new = Option.is_none helper_account
+          }
+        in
+        let _forest, `Commitment commitment =
+          Bridge_prover.Finalize_deposit.precompute_commitments
+            !sequencer.bridge_prover witness
+          |> Or_error.ok_exn
+        in
+        let helper_account_signature =
+          Signature_lib.Schnorr.Chunked.sign
+            ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+            signer.private_key
+            (Random_oracle.Input.Chunked.field commitment)
+        in
         Bridge_prover.(
           execute_request ~logger ~executor:l2_executor !sequencer.bridge_prover
-            (Finalize_deposit.f ~t:!sequencer.bridge_prover ~logger
-               { ase_source = fst ase
-               ; ase_elems = snd ase
-               ; check_accepted_init = fst check_accepted
-               ; check_accepted_elems = snd check_accepted
-               ; prev_next_deposit
-               ; prev_nonce
-               ; helper_account_new = Option.is_none helper_account
-               } ))
+            (Finalize_deposit.f ~t:!sequencer.bridge_prover ~logger witness
+               helper_account_signature ))
         >>| Or_error.ok_exn
       in
 

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -1080,7 +1080,7 @@ let () =
         in
         let helper_account_signature =
           Signature_lib.Schnorr.Chunked.sign
-            ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+            ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
             signer.private_key
             (Random_oracle.Input.Chunked.field commitment)
         in

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -766,7 +766,14 @@ let () =
        ~slot_acceptance:(Time.Span.of_min 10.)
        ~commit_validity_period:(Global_slot_span.of_int 20)
        () )
-    ~f:(fun { outer_kp; sequencer; signer_pk; l1_config; _ } ->
+    ~f:(fun { outer_kp
+            ; sequencer
+            ; signer_pk
+            ; l1_config
+            ; l1_executor
+            ; l2_executor
+            ; _
+            } ->
       (* Create l1 accounts *)
       let l1_accounts =
         Array.create ~len:6 ()
@@ -781,23 +788,12 @@ let () =
               in
               return () ) ) ;
 
-      let submit_deposit ~fee (signer : Keypair.t)
+      let submit_deposit (signer : Keypair.t)
           (deposit_params : C.Bridge_state.Deposit_params_base.t) =
         let%bind nonce =
           Gql_client.fetch_nonce ~logger gql_uri
             (Signature_lib.Public_key.compress signer.public_key)
           >>| Or_error.ok_exn
-        in
-        let fee_payer =
-          Account_update.Fee_payer.
-            { body =
-                { public_key = Public_key.compress signer.public_key
-                ; fee = Currency.Fee.of_mina_int_exn fee
-                ; valid_until = None
-                ; nonce = Account.Nonce.of_uint32 nonce
-                }
-            ; authorization = Signature.dummy
-            }
         in
         let bridge_proof_fee = Zeko_circuits_config.Inputs.bridge_proof_fee in
         let transferrer_update =
@@ -823,28 +819,11 @@ let () =
               }
             ~authorization:(Control.Poly.Signature Signature.dummy)
         in
-        let%map transfer_forest =
-          Bridge_prover.(
-            prove !sequencer.bridge_prover
-              (Deposit_request.f ~logger
-                 { deposit_params; transferrer = transferrer_update } ))
-          >>| Or_error.ok_exn
-        in
-        let transfer_cmd : Zkapp_command.t =
-          { fee_payer
-          ; account_updates =
-              transfer_forest
-              |> Zkapp_command.Call_forest.map
-                   ~f:(Account_update.write_all_proofs_to_disk ~proof_cache_db)
-              |> Utils.rehash_forest
-                   ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
-          ; memo = Signed_command_memo.empty
-          }
-        in
-        Utils.sign_zkapp_command
-          ~signature_kind:Zeko_circuits_config.Inputs.chain_l1 transfer_cmd
-          [ signer ]
-        |> Zkapp_command.read_all_proofs_from_disk
+        Bridge_prover.(
+          execute_request ~logger ~executor:l1_executor !sequencer.bridge_prover
+            (Deposit_request.f ~t:!sequencer.bridge_prover ~logger
+               { deposit_params; transferrer = transferrer_update } ))
+        >>| Or_error.ok_exn
       in
       let deposit ~amount ~(account : Keypair.t) ~timeout :
           C.Bridge_state.Deposit_params_base.t =
@@ -874,18 +853,10 @@ let () =
             let deposit2 = deposit ~amount:20 ~account:account2 ~timeout:40 in
             let deposit3 = deposit ~amount:30 ~account:account3 ~timeout:40 in
 
-            let%bind _ =
-              submit_deposit ~fee:6 account1 deposit1
-              >>= Gql_client.send_zkapp gql_uri
-            in
-            let%bind _ =
-              submit_deposit ~fee:5 account2 deposit2
-              >>= Gql_client.send_zkapp gql_uri
-            in
-            let%bind _ =
-              submit_deposit ~fee:4 account3 deposit3
-              >>= Gql_client.send_zkapp gql_uri
-            in
+            let%bind _hash = submit_deposit account1 deposit1 in
+            let%bind _hash = submit_deposit account2 deposit2 in
+            let%bind _hash = submit_deposit account3 deposit3 in
+
             let%bind _created =
               Gql_client.For_tests.create_new_block ~logger gql_uri
             in
@@ -924,18 +895,10 @@ let () =
               let deposit5 = deposit ~amount:50 ~account:account2 ~timeout:40 in
               let deposit6 = deposit ~amount:60 ~account:account3 ~timeout:40 in
 
-              let%bind _ =
-                submit_deposit ~fee:3 account1 deposit4
-                >>= Gql_client.send_zkapp gql_uri
-              in
-              let%bind _ =
-                submit_deposit ~fee:2 account2 deposit5
-                >>= Gql_client.send_zkapp gql_uri
-              in
-              let%bind _ =
-                submit_deposit ~fee:1 account3 deposit6
-                >>= Gql_client.send_zkapp gql_uri
-              in
+              let%bind _hash = submit_deposit account1 deposit4 in
+              let%bind _hash = submit_deposit account2 deposit5 in
+              let%bind _hash = submit_deposit account3 deposit6 in
+
               let%bind _created =
                 Gql_client.For_tests.create_new_block ~logger gql_uri
               in
@@ -987,17 +950,6 @@ let () =
           [%test_eq: Ledger_hash.t] committed_ledger_hash target_ledger_hash ) ;
 
       let finalize_deposit (signer : Keypair.t) deposit_params =
-        let fee_payer =
-          Account_update.Fee_payer.
-            { body =
-                { public_key = Public_key.Compressed.empty
-                ; fee = Currency.Fee.zero
-                ; valid_until = None
-                ; nonce = Account.Nonce.zero
-                }
-            ; authorization = Signature.dummy
-            }
-        in
         let%bind actions =
           Gql_client.fetch_actions ~logger gql_uri
             (Public_key.compress outer_kp.public_key)
@@ -1097,45 +1049,25 @@ let () =
                  UInt32.of_string
                    (Mina_numbers.Account_nonce.to_string acc.nonce) ) )
         in
-        let%map transfer_forest =
-          Bridge_prover.(
-            prove !sequencer.bridge_prover
-              (Finalize_deposit.f ~logger
-                 { ase_source = fst ase
-                 ; ase_elems = snd ase
-                 ; check_accepted_init = fst check_accepted
-                 ; check_accepted_elems = snd check_accepted
-                 ; prev_next_deposit
-                 ; prev_nonce
-                 ; helper_account_new = Option.is_none helper_account
-                 } ))
-          >>| Or_error.ok_exn
-        in
-        let transfer_cmd : Zkapp_command.t =
-          { fee_payer
-          ; account_updates =
-              transfer_forest
-              |> Zkapp_command.Call_forest.map
-                   ~f:(Account_update.write_all_proofs_to_disk ~proof_cache_db)
-          ; memo = Signed_command_memo.empty
-          }
-        in
-        printf "transfer_cmd: %s\n%!"
-          (Zkapp_command.to_yojson transfer_cmd |> Yojson.Safe.pretty_to_string) ;
-        Utils.sign_zkapp_command
-          ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 transfer_cmd
-          [ signer ]
+        Bridge_prover.(
+          execute_request ~logger ~executor:l2_executor !sequencer.bridge_prover
+            (Finalize_deposit.f ~t:!sequencer.bridge_prover ~logger
+               { ase_source = fst ase
+               ; ase_elems = snd ase
+               ; check_accepted_init = fst check_accepted
+               ; check_accepted_elems = snd check_accepted
+               ; prev_next_deposit
+               ; prev_nonce
+               ; helper_account_new = Option.is_none helper_account
+               } ))
+        >>| Or_error.ok_exn
       in
 
       print_endline "(* Finalize all deposits *)" ;
       run (fun () ->
           Deferred.List.iteri deposits ~f:(fun i (signer, deposit_params) ->
               printf "(* Finalizing deposit %d *)\n%!" i ;
-              let%bind command = finalize_deposit signer deposit_params in
-              let%map result =
-                apply_user_command !sequencer (Zkapp_command command)
-              in
-              [%test_eq: unit Or_error.t] result (Ok ()) ) ) ;
+              finalize_deposit signer deposit_params >>| ignore ) ) ;
 
       print_endline "(* Send 7-9 deposits *)" ;
       let timeout_deposits =
@@ -1144,18 +1076,10 @@ let () =
             let deposit8 = deposit ~amount:80 ~account:account2 ~timeout:10 in
             let deposit9 = deposit ~amount:90 ~account:account3 ~timeout:10 in
 
-            let%bind _ =
-              submit_deposit ~fee:3 account1 deposit7
-              >>= Gql_client.send_zkapp gql_uri
-            in
-            let%bind _ =
-              submit_deposit ~fee:2 account2 deposit8
-              >>= Gql_client.send_zkapp gql_uri
-            in
-            let%bind _ =
-              submit_deposit ~fee:1 account3 deposit9
-              >>= Gql_client.send_zkapp gql_uri
-            in
+            let%bind _hash = submit_deposit account1 deposit7 in
+            let%bind _hash = submit_deposit account2 deposit8 in
+            let%bind _hash = submit_deposit account3 deposit9 in
+
             let%bind _created =
               Gql_client.For_tests.create_new_block ~logger gql_uri
             in
@@ -1407,22 +1331,11 @@ let () =
 
       print_endline "Started test 'withdrawals'" ;
 
-      let submit_withdrawal ~fee (signer : Keypair.t)
+      let submit_withdrawal (signer : Keypair.t)
           (withdrawal_params : C.Bridge_state.Withdrawal_params_base.t) =
         let nonce =
           Sequencer.infer_nonce !sequencer
             (Signature_lib.Public_key.compress signer.public_key)
-        in
-        let fee_payer =
-          Account_update.Fee_payer.
-            { body =
-                { public_key = Public_key.compress signer.public_key
-                ; fee = Currency.Fee.of_mina_int_exn fee
-                ; valid_until = None
-                ; nonce = Account.Nonce.of_uint32 nonce
-                }
-            ; authorization = Signature.dummy
-            }
         in
         let bridge_proof_fee = Zeko_circuits_config.Inputs.bridge_proof_fee in
         let transferrer_update =
@@ -1448,28 +1361,13 @@ let () =
               }
             ~authorization:(Control.Poly.Signature Signature.dummy)
         in
-        let%map transfer_forest =
-          Bridge_prover.(
-            prove !sequencer.bridge_prover
-              (Withdrawal_request.f ~logger
-                 { withdrawal_params; transferrer = transferrer_update } ))
-          >>| Or_error.ok_exn
-        in
-        let transfer_cmd : Zkapp_command.t =
-          { fee_payer
-          ; account_updates =
-              transfer_forest
-              |> Zkapp_command.Call_forest.map
-                   ~f:(Account_update.write_all_proofs_to_disk ~proof_cache_db)
-              |> Utils.rehash_forest
-                   ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
-          ; memo = Signed_command_memo.empty
-          }
-        in
-        Utils.sign_zkapp_command
-          ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 transfer_cmd
-          [ signer ]
+        Bridge_prover.(
+          execute_request ~logger ~executor:l2_executor !sequencer.bridge_prover
+            (Withdrawal_request.f ~t:!sequencer.bridge_prover ~logger
+               { withdrawal_params; transferrer = transferrer_update } ))
+        >>| Or_error.ok_exn
       in
+
       let withdrawal ~amount ~(account : Keypair.t) :
           C.Bridge_state.Withdrawal_params_base.t =
         { children = []
@@ -1489,24 +1387,10 @@ let () =
             let withdrawal2 = withdrawal ~amount:15 ~account:account2 in
             let withdrawal3 = withdrawal ~amount:25 ~account:account3 in
 
-            let%bind () =
-              submit_withdrawal ~fee:6 account1 withdrawal1
-              >>= fun command ->
-              apply_user_command !sequencer (Zkapp_command command)
-              >>| [%test_eq: unit Or_error.t] (Ok ())
-            in
-            let%bind () =
-              submit_withdrawal ~fee:5 account2 withdrawal2
-              >>= fun command ->
-              apply_user_command !sequencer (Zkapp_command command)
-              >>| [%test_eq: unit Or_error.t] (Ok ())
-            in
-            let%bind () =
-              submit_withdrawal ~fee:4 account3 withdrawal3
-              >>= fun command ->
-              apply_user_command !sequencer (Zkapp_command command)
-              >>| [%test_eq: unit Or_error.t] (Ok ())
-            in
+            let%bind _hash = submit_withdrawal account1 withdrawal1 in
+            let%bind _hash = submit_withdrawal account2 withdrawal2 in
+            let%bind _hash = submit_withdrawal account3 withdrawal3 in
+
             return
               [ (account1, withdrawal1)
               ; (account2, withdrawal2)
@@ -1542,24 +1426,10 @@ let () =
               let withdrawal5 = withdrawal ~amount:45 ~account:account2 in
               let withdrawal6 = withdrawal ~amount:55 ~account:account3 in
 
-              let%bind () =
-                submit_withdrawal ~fee:3 account1 withdrawal4
-                >>= fun command ->
-                apply_user_command !sequencer (Zkapp_command command)
-                >>| [%test_eq: unit Or_error.t] (Ok ())
-              in
-              let%bind () =
-                submit_withdrawal ~fee:2 account2 withdrawal5
-                >>= fun command ->
-                apply_user_command !sequencer (Zkapp_command command)
-                >>| [%test_eq: unit Or_error.t] (Ok ())
-              in
-              let%bind () =
-                submit_withdrawal ~fee:1 account3 withdrawal6
-                >>= fun command ->
-                apply_user_command !sequencer (Zkapp_command command)
-                >>| [%test_eq: unit Or_error.t] (Ok ())
-              in
+              let%bind _hash = submit_withdrawal account1 withdrawal4 in
+              let%bind _hash = submit_withdrawal account2 withdrawal5 in
+              let%bind _hash = submit_withdrawal account3 withdrawal6 in
+
               let%bind _created =
                 Gql_client.For_tests.create_new_block ~logger gql_uri
               in
@@ -1590,23 +1460,7 @@ let () =
           let target_ledger_hash = get_root !sequencer in
           [%test_eq: Ledger_hash.t] committed_ledger_hash target_ledger_hash ) ;
 
-      let finalize_withdrawal ~fee (signer : Keypair.t) withdrawal_params =
-        let%bind nonce =
-          Gql_client.fetch_nonce ~logger gql_uri
-            (Signature_lib.Public_key.compress signer.public_key)
-          >>| Or_error.ok_exn
-        in
-        let fee_payer =
-          Account_update.Fee_payer.
-            { body =
-                { public_key = Public_key.compress signer.public_key
-                ; fee = Currency.Fee.of_mina_int_exn fee
-                ; valid_until = None
-                ; nonce = Account.Nonce.of_uint32 nonce
-                }
-            ; authorization = Signature.dummy
-            }
-        in
+      let finalize_withdrawal (signer : Keypair.t) withdrawal_params =
         let%bind l1_actions =
           Gql_client.fetch_actions ~logger gql_uri
             (Public_key.compress outer_kp.public_key)
@@ -1718,44 +1572,27 @@ let () =
           | None ->
               UInt32.zero
         in
-        let%map transfer_forest =
-          Bridge_prover.(
-            prove !sequencer.bridge_prover
-              (Finalize_withdrawal.f ~logger
-                 { public_key =
-                     List.hd_exn Zeko_circuits_config.Inputs.holder_accounts_l1
-                 ; commit = last_commit
-                 ; before_commit =
-                     C.Rollup_state.Outer_action_state.unsafe_value_of_field
-                       before_last_commit
-                 ; commit_ase_source = fst commit_ase
-                 ; commit_ase_elems = snd commit_ase
-                 ; before_withdrawal
-                 ; withdrawal_ase_source = fst withdrawal_ase
-                 ; withdrawal_ase_elems = snd withdrawal_ase
-                 ; prev_next_withdrawal =
-                     Option.value prev_next_withdrawal ~default:UInt32.zero
-                 ; withdrawal_params
-                 ; prev_nonce
-                 ; helper_account_new = Option.is_none prev_next_withdrawal
-                 } ))
-          >>| Or_error.ok_exn
-        in
-        let transfer_cmd : Zkapp_command.t =
-          { fee_payer
-          ; account_updates =
-              transfer_forest
-              |> Zkapp_command.Call_forest.map
-                   ~f:(Account_update.write_all_proofs_to_disk ~proof_cache_db)
-              |> Utils.rehash_forest
-                   ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
-          ; memo = Signed_command_memo.empty
-          }
-        in
-        Utils.sign_zkapp_command
-          ~signature_kind:Zeko_circuits_config.Inputs.chain_l1 transfer_cmd
-          [ signer ]
-        |> Zkapp_command.read_all_proofs_from_disk
+        Bridge_prover.(
+          execute_request ~logger ~executor:l2_executor !sequencer.bridge_prover
+            (Finalize_withdrawal.f ~t:!sequencer.bridge_prover ~logger
+               { public_key =
+                   List.hd_exn Zeko_circuits_config.Inputs.holder_accounts_l1
+               ; commit = last_commit
+               ; before_commit =
+                   C.Rollup_state.Outer_action_state.unsafe_value_of_field
+                     before_last_commit
+               ; commit_ase_source = fst commit_ase
+               ; commit_ase_elems = snd commit_ase
+               ; before_withdrawal
+               ; withdrawal_ase_source = fst withdrawal_ase
+               ; withdrawal_ase_elems = snd withdrawal_ase
+               ; prev_next_withdrawal =
+                   Option.value prev_next_withdrawal ~default:UInt32.zero
+               ; withdrawal_params
+               ; prev_nonce
+               ; helper_account_new = Option.is_none prev_next_withdrawal
+               } ))
+        >>| Or_error.ok_exn
       in
 
       print_endline "(* Finalize all withdrawals *)" ;
@@ -1767,17 +1604,13 @@ let () =
             Deferred.List.iteri withdrawals
               ~f:(fun i (signer, withdrawal_params) ->
                 printf "(* Finalizing withdrawal %d *)\n%!" i ;
-                let%bind command =
-                  finalize_withdrawal ~fee:1 signer withdrawal_params
-                in
-                let%bind _ = Gql_client.send_zkapp gql_uri command in
+                let%bind hash = finalize_withdrawal signer withdrawal_params in
                 let%bind _created =
                   Gql_client.For_tests.create_new_block ~logger gql_uri
                 in
                 let%map status =
                   Gql_client.For_tests.get_zkapp_command_status ~logger gql_uri
-                    (Mina_transaction.Transaction_hash.hash_command
-                       (Zkapp_command command) )
+                    hash
                 in
                 [%test_eq: string list list option] status None )
           in

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -811,8 +811,15 @@ let () =
                     @@ Option.value_exn
                          (Currency.Amount.add deposit_params.amount
                             bridge_proof_fee ))
-              ; use_full_commitment = true
+              ; use_full_commitment = false
+              ; increment_nonce = true
               ; authorization_kind = Signature
+              ; preconditions =
+                  { Account_update.Preconditions.accept with
+                    account =
+                      Zkapp_precondition.Account.nonce
+                        (Account.Nonce.succ nonce)
+                  }
               }
             ~authorization:(Control.Poly.Signature Signature.dummy)
         in
@@ -1100,6 +1107,7 @@ let () =
                  ; check_accepted_elems = snd check_accepted
                  ; prev_next_deposit
                  ; prev_nonce
+                 ; helper_account_new = Option.is_none helper_account
                  } ))
           >>| Or_error.ok_exn
         in
@@ -1428,8 +1436,15 @@ let () =
                     @@ Option.value_exn
                          (Currency.Amount.add withdrawal_params.amount
                             bridge_proof_fee ))
-              ; use_full_commitment = true
+              ; use_full_commitment = false
               ; authorization_kind = Signature
+              ; increment_nonce = true
+              ; preconditions =
+                  { Account_update.Preconditions.accept with
+                    account =
+                      Zkapp_precondition.Account.nonce
+                        (Account.Nonce.succ nonce)
+                  }
               }
             ~authorization:(Control.Poly.Signature Signature.dummy)
         in
@@ -1722,6 +1737,7 @@ let () =
                      Option.value prev_next_withdrawal ~default:UInt32.zero
                  ; withdrawal_params
                  ; prev_nonce
+                 ; helper_account_new = Option.is_none prev_next_withdrawal
                  } ))
           >>| Or_error.ok_exn
         in

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -1621,6 +1621,12 @@ let () =
           let%bind _shifted =
             Gql_client.For_tests.shift_slots ~logger gql_uri 200
           in
+          (* Keep the sequencer's slot view in sync with the testing-ledger's
+             shifted slot, so preverify_l1 simulates against the same slot the
+             actual L1 transaction will see (otherwise time-based
+             preconditions like [valid_while] on finalize_withdrawal trip). *)
+          Utils.Slot.For_tests.add_to_global_slot :=
+            Stdlib.( ! ) Utils.Slot.For_tests.add_to_global_slot + 200 ;
           let%bind () =
             Deferred.List.iteri withdrawals
               ~f:(fun i (signer, withdrawal_params) ->

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -41,8 +41,7 @@ let run = Thread_safe.block_on_async_exn
 let get_test_signer () =
   run (fun () ->
       let location =
-        Sys.getenv_exn "ZEKO_TEST_SEQUENCER_SIGNER"
-        |> Host_and_port.of_string
+        Sys.getenv_exn "ZEKO_TEST_SEQUENCER_SIGNER" |> Host_and_port.of_string
       in
       Signer_service.Client.create ~logger ~location
       >>| Signer_service.Signer.of_client )
@@ -79,7 +78,8 @@ let () =
          ; accounts
          ; l1_config
          ; _
-         } ->
+         }
+       ->
       let commands =
         List.mapi specs ~f:(fun i spec ->
             if i % 2 = 0 then
@@ -153,8 +153,7 @@ let () =
             Executor.wait_to_finish !sequencer.merger_ctx.executor
           in
           let%bind { ledger_hash = committed_ledger_hash; _ } =
-            Gql_client.infer_state ~logger gql_uri
-              ~signer_pk
+            Gql_client.infer_state ~logger gql_uri ~signer_pk
               ~zkapp_pk:(Public_key.compress outer_kp.public_key)
             >>| Or_error.ok_exn
             >>| Utils.value_of_zkapp_state
@@ -185,8 +184,7 @@ let () =
             Gql_client.For_tests.create_new_block ~logger gql_uri
           in
           let%map { ledger_hash = committed_ledger_hash; _ } =
-            Gql_client.infer_state ~logger gql_uri
-              ~signer_pk
+            Gql_client.infer_state ~logger gql_uri ~signer_pk
               ~zkapp_pk:(Public_key.compress outer_kp.public_key)
             >>| Or_error.ok_exn
             >>| Utils.value_of_zkapp_state
@@ -212,8 +210,7 @@ let () =
               Gql_client.For_tests.create_new_block ~logger gql_uri
             in
             let%bind { ledger_hash = committed_ledger_hash; _ } =
-              Gql_client.infer_state ~logger gql_uri
-                ~signer_pk
+              Gql_client.infer_state ~logger gql_uri ~signer_pk
                 ~zkapp_pk:(Public_key.compress outer_kp.public_key)
               >>| Or_error.ok_exn
               >>| Utils.value_of_zkapp_state
@@ -235,9 +232,8 @@ let () =
                 ~commitment_period_sec:0. ~da_config:da_config_with2 ~da_keys
                 ~da_quorum ~db_dir:None ~checkpoints_dir:None
                 ~postgres_uri:postgres_uri2 ~l1_uri:gql_uri ~archive_uri:gql_uri
-                ~signer:(get_test_signer ())
-                ~deposit_delay_blocks:0 ~mq_host ~fee_modifier:1.0
-                ~minimum_fee:0.01 ~slot_acceptance
+                ~signer:(get_test_signer ()) ~deposit_delay_blocks:0 ~mq_host
+                ~fee_modifier:1.0 ~minimum_fee:0.01 ~slot_acceptance
                 ~proof_cache_db:(Proof_cache_tag.create_identity_db ())
                 ~l1_config
                 ~commit_validity_period:
@@ -338,10 +334,9 @@ let () =
             Sequencer.create ~logger ~max_pool_size:10 ~commitment_period_sec:0.
               ~da_config:da_config_with3 ~da_quorum ~db_dir:(Some db_dir)
               ~checkpoints_dir:None ~postgres_uri ~l1_uri:gql_uri
-              ~archive_uri:gql_uri
-              ~signer:(get_test_signer ())
-              ~deposit_delay_blocks:0 ~mq_host
-              ~da_keys ~fee_modifier:1.0 ~minimum_fee:0.01 ~slot_acceptance
+              ~archive_uri:gql_uri ~signer:(get_test_signer ())
+              ~deposit_delay_blocks:0 ~mq_host ~da_keys ~fee_modifier:1.0
+              ~minimum_fee:0.01 ~slot_acceptance
               ~proof_cache_db:(Proof_cache_tag.create_identity_db ())
               ~l1_config
               ~commit_validity_period:(Mina_numbers.Global_slot_span.of_int 10) )
@@ -356,8 +351,7 @@ let () =
               Executor.wait_to_finish new_sequencer.merger_ctx.executor
             in
             let%map { ledger_hash = committed_ledger_hash; _ } =
-              Gql_client.infer_state ~logger gql_uri
-                ~signer_pk
+              Gql_client.infer_state ~logger gql_uri ~signer_pk
                 ~zkapp_pk:(Public_key.compress outer_kp.public_key)
               >>| Or_error.ok_exn
               >>| Utils.value_of_zkapp_state
@@ -451,8 +445,7 @@ let () =
               Executor.wait_to_finish !sequencer.merger_ctx.executor
             in
             let%map { ledger_hash = committed_ledger_hash; _ } =
-              Gql_client.infer_state ~logger gql_uri
-                ~signer_pk
+              Gql_client.infer_state ~logger gql_uri ~signer_pk
                 ~zkapp_pk:(Public_key.compress outer_kp.public_key)
               >>| Or_error.ok_exn
               >>| Utils.value_of_zkapp_state
@@ -472,9 +465,8 @@ let () =
               ~da_config:da_config_with3 ~da_quorum ~db_dir:(Some db_dir2)
               ~checkpoints_dir:(Some checkpoints_dir)
               ~postgres_uri:postgres_uri2 ~l1_uri:gql_uri ~archive_uri:gql_uri
-              ~signer:(get_test_signer ())
-              ~deposit_delay_blocks:0 ~mq_host ~da_keys
-              ~fee_modifier:1.0 ~minimum_fee:0.01 ~slot_acceptance
+              ~signer:(get_test_signer ()) ~deposit_delay_blocks:0 ~mq_host
+              ~da_keys ~fee_modifier:1.0 ~minimum_fee:0.01 ~slot_acceptance
               ~proof_cache_db:(Proof_cache_tag.create_identity_db ())
               ~l1_config
               ~commit_validity_period:(Mina_numbers.Global_slot_span.of_int 10) )
@@ -560,8 +552,7 @@ let () =
               Gql_client.For_tests.clear_pool ~logger gql_uri
             in
             let%map { ledger_hash = committed_ledger_hash; _ } =
-              Gql_client.infer_state ~logger gql_uri
-                ~signer_pk
+              Gql_client.infer_state ~logger gql_uri ~signer_pk
                 ~zkapp_pk:(Public_key.compress outer_kp.public_key)
               >>| Or_error.ok_exn
               >>| Utils.value_of_zkapp_state
@@ -579,10 +570,9 @@ let () =
             Sequencer.create ~logger ~max_pool_size:10 ~commitment_period_sec:0.
               ~da_config:da_config_with2 ~da_quorum ~db_dir:(Some db_dir)
               ~checkpoints_dir:None ~postgres_uri ~l1_uri:gql_uri
-              ~archive_uri:gql_uri
-              ~signer:(get_test_signer ())
-              ~deposit_delay_blocks:0 ~mq_host
-              ~da_keys ~fee_modifier:1.0 ~minimum_fee:0.01 ~slot_acceptance
+              ~archive_uri:gql_uri ~signer:(get_test_signer ())
+              ~deposit_delay_blocks:0 ~mq_host ~da_keys ~fee_modifier:1.0
+              ~minimum_fee:0.01 ~slot_acceptance
               ~proof_cache_db:(Proof_cache_tag.create_identity_db ())
               ~l1_config
               ~commit_validity_period:(Mina_numbers.Global_slot_span.of_int 10) )
@@ -594,8 +584,7 @@ let () =
             Gql_client.For_tests.create_new_block ~logger gql_uri
           in
           let%map { ledger_hash = committed_ledger_hash; _ } =
-            Gql_client.infer_state ~logger gql_uri
-              ~signer_pk
+            Gql_client.infer_state ~logger gql_uri ~signer_pk
               ~zkapp_pk:(Public_key.compress outer_kp.public_key)
             >>| Or_error.ok_exn
             >>| Utils.value_of_zkapp_state
@@ -749,8 +738,7 @@ let () =
             Gql_client.For_tests.create_new_block ~logger gql_uri
           in
           let%map { ledger_hash = committed_ledger_hash; _ } =
-            Gql_client.infer_state ~logger gql_uri
-              ~signer_pk
+            Gql_client.infer_state ~logger gql_uri ~signer_pk
               ~zkapp_pk:(Public_key.compress outer_kp.public_key)
             >>| Or_error.ok_exn
             >>| Utils.value_of_zkapp_state
@@ -811,6 +799,7 @@ let () =
             ; authorization = Signature.dummy
             }
         in
+        let bridge_proof_fee = Zeko_circuits_config.Inputs.bridge_proof_fee in
         let transferrer_update =
           Account_update.with_no_aux
             ~body:
@@ -818,7 +807,10 @@ let () =
                 public_key = Public_key.compress signer.public_key
               ; balance_change =
                   Currency.Amount.Signed.(
-                    negate @@ of_unsigned deposit_params.amount)
+                    negate @@ of_unsigned
+                    @@ Option.value_exn
+                         (Currency.Amount.add deposit_params.amount
+                            bridge_proof_fee ))
               ; use_full_commitment = true
               ; authorization_kind = Signature
               }
@@ -827,7 +819,8 @@ let () =
         let%map transfer_forest =
           Bridge_prover.(
             prove !sequencer.bridge_prover
-              (Deposit_request.f ~logger { deposit_params; transferrer = transferrer_update }))
+              (Deposit_request.f ~logger
+                 { deposit_params; transferrer = transferrer_update } ))
           >>| Or_error.ok_exn
         in
         let transfer_cmd : Zkapp_command.t =
@@ -836,6 +829,8 @@ let () =
               transfer_forest
               |> Zkapp_command.Call_forest.map
                    ~f:(Account_update.write_all_proofs_to_disk ~proof_cache_db)
+              |> Utils.rehash_forest
+                   ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
           ; memo = Signed_command_memo.empty
           }
         in
@@ -905,8 +900,7 @@ let () =
             Gql_client.For_tests.create_new_block ~logger gql_uri
           in
           let%map { ledger_hash = committed_ledger_hash; _ } =
-            Gql_client.infer_state ~logger gql_uri
-              ~signer_pk
+            Gql_client.infer_state ~logger gql_uri ~signer_pk
               ~zkapp_pk:(Public_key.compress outer_kp.public_key)
             >>| Or_error.ok_exn
             >>| Utils.value_of_zkapp_state
@@ -956,8 +950,7 @@ let () =
             Gql_client.For_tests.create_new_block ~logger gql_uri
           in
           let%map { ledger_hash = committed_ledger_hash; _ } =
-            Gql_client.infer_state ~logger gql_uri
-              ~signer_pk
+            Gql_client.infer_state ~logger gql_uri ~signer_pk
               ~zkapp_pk:(Public_key.compress outer_kp.public_key)
             >>| Or_error.ok_exn
             >>| Utils.value_of_zkapp_state
@@ -977,8 +970,7 @@ let () =
             Gql_client.For_tests.create_new_block ~logger gql_uri
           in
           let%map { ledger_hash = committed_ledger_hash; _ } =
-            Gql_client.infer_state ~logger gql_uri
-              ~signer_pk
+            Gql_client.infer_state ~logger gql_uri ~signer_pk
               ~zkapp_pk:(Public_key.compress outer_kp.public_key)
             >>| Or_error.ok_exn
             >>| Utils.value_of_zkapp_state
@@ -1092,6 +1084,12 @@ let () =
              in
              UInt32.of_string (Field.to_string next_deposit) )
         in
+        let prev_nonce =
+          Option.value ~default:UInt32.zero
+            (Option.map helper_account ~f:(fun acc ->
+                 UInt32.of_string
+                   (Mina_numbers.Account_nonce.to_string acc.nonce) ) )
+        in
         let%map transfer_forest =
           Bridge_prover.(
             prove !sequencer.bridge_prover
@@ -1101,45 +1099,21 @@ let () =
                  ; check_accepted_init = fst check_accepted
                  ; check_accepted_elems = snd check_accepted
                  ; prev_next_deposit
+                 ; prev_nonce
                  } ))
           >>| Or_error.ok_exn
-        in
-        let transferrer_update =
-          Account_update.with_no_aux
-            ~body:
-              { Account_update.Body.dummy with
-                public_key = Public_key.compress signer.public_key
-              ; balance_change =
-                  (let ( + ) a b = Currency.Fee.add a b |> Option.value_exn in
-                   let account_creation_fee =
-                     if Option.is_some helper_account then Currency.Amount.zero
-                     else
-                       constraint_constants.account_creation_fee
-                       + constraint_constants.account_creation_fee
-                       |> Currency.Amount.of_fee
-                   in
-                   Currency.Amount.(
-                     Signed.of_unsigned
-                     @@ Option.value_exn
-                          ~message:"Amount insufficient to create 2 accounts"
-                     @@ sub deposit_params.amount account_creation_fee) )
-              ; implicit_account_creation_fee = false
-              ; use_full_commitment = true
-              ; authorization_kind = None_given
-              }
-            ~authorization:Control.Poly.None_given
         in
         let transfer_cmd : Zkapp_command.t =
           { fee_payer
           ; account_updates =
-              Zkapp_command.Call_forest.cons
-                ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
-                transferrer_update transfer_forest
+              transfer_forest
               |> Zkapp_command.Call_forest.map
                    ~f:(Account_update.write_all_proofs_to_disk ~proof_cache_db)
           ; memo = Signed_command_memo.empty
           }
         in
+        printf "transfer_cmd: %s\n%!"
+          (Zkapp_command.to_yojson transfer_cmd |> Yojson.Safe.pretty_to_string) ;
         Utils.sign_zkapp_command
           ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 transfer_cmd
           [ signer ]
@@ -1202,8 +1176,7 @@ let () =
             Gql_client.For_tests.create_new_block ~logger gql_uri
           in
           let%map { ledger_hash = committed_ledger_hash; _ } =
-            Gql_client.infer_state ~logger gql_uri
-              ~signer_pk
+            Gql_client.infer_state ~logger gql_uri ~signer_pk
               ~zkapp_pk:(Public_key.compress outer_kp.public_key)
             >>| Or_error.ok_exn
             >>| Utils.value_of_zkapp_state
@@ -1443,6 +1416,7 @@ let () =
             ; authorization = Signature.dummy
             }
         in
+        let bridge_proof_fee = Zeko_circuits_config.Inputs.bridge_proof_fee in
         let transferrer_update =
           Account_update.with_no_aux
             ~body:
@@ -1450,7 +1424,10 @@ let () =
                 public_key = Public_key.compress signer.public_key
               ; balance_change =
                   Currency.Amount.Signed.(
-                    negate @@ of_unsigned withdrawal_params.amount)
+                    negate @@ of_unsigned
+                    @@ Option.value_exn
+                         (Currency.Amount.add withdrawal_params.amount
+                            bridge_proof_fee ))
               ; use_full_commitment = true
               ; authorization_kind = Signature
               }
@@ -1460,7 +1437,7 @@ let () =
           Bridge_prover.(
             prove !sequencer.bridge_prover
               (Withdrawal_request.f ~logger
-                 { withdrawal_params; transferrer = transferrer_update }))
+                 { withdrawal_params; transferrer = transferrer_update } ))
           >>| Or_error.ok_exn
         in
         let transfer_cmd : Zkapp_command.t =
@@ -1469,6 +1446,8 @@ let () =
               transfer_forest
               |> Zkapp_command.Call_forest.map
                    ~f:(Account_update.write_all_proofs_to_disk ~proof_cache_db)
+              |> Utils.rehash_forest
+                   ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
           ; memo = Signed_command_memo.empty
           }
         in
@@ -1531,8 +1510,7 @@ let () =
             Gql_client.For_tests.create_new_block ~logger gql_uri
           in
           let%map { ledger_hash = committed_ledger_hash; _ } =
-            Gql_client.infer_state ~logger gql_uri
-              ~signer_pk
+            Gql_client.infer_state ~logger gql_uri ~signer_pk
               ~zkapp_pk:(Public_key.compress outer_kp.public_key)
             >>| Or_error.ok_exn
             >>| Utils.value_of_zkapp_state
@@ -1588,8 +1566,7 @@ let () =
             Gql_client.For_tests.create_new_block ~logger gql_uri
           in
           let%map { ledger_hash = committed_ledger_hash; _ } =
-            Gql_client.infer_state ~logger gql_uri
-              ~signer_pk
+            Gql_client.infer_state ~logger gql_uri ~signer_pk
               ~zkapp_pk:(Public_key.compress outer_kp.public_key)
             >>| Or_error.ok_exn
             >>| Utils.value_of_zkapp_state
@@ -1697,16 +1674,16 @@ let () =
                 }
             , elems ) )
         in
+        let helper_aid =
+          Account_id.create
+            (Public_key.compress signer.public_key)
+            (Account_id.derive_token_id
+               ~owner:
+                 (Account_id.of_public_key
+                    (Public_key.decompress_exn
+                       Zeko_circuits_config.Inputs.helper_token_owner_l1 ) ) )
+        in
         let%bind prev_next_withdrawal =
-          let helper_aid =
-            Account_id.create
-              (Public_key.compress signer.public_key)
-              (Account_id.derive_token_id
-                 ~owner:
-                   (Account_id.of_public_key
-                      (Public_key.decompress_exn
-                         Zeko_circuits_config.Inputs.helper_token_owner_l1 ) ) )
-          in
           match%map
             Gql_client.fetch_state_opt ~logger gql_uri helper_aid
             >>| Or_error.ok_exn
@@ -1715,6 +1692,16 @@ let () =
               Some (UInt32.of_string (Field.to_string next_withdrawal))
           | None ->
               None
+        in
+        let%bind prev_nonce =
+          match%map
+            Gql_client.fetch_nonce_opt ~logger gql_uri helper_aid
+            >>| Or_error.ok_exn
+          with
+          | Some nonce ->
+              nonce
+          | None ->
+              UInt32.zero
         in
         let%map transfer_forest =
           Bridge_prover.(
@@ -1734,39 +1721,14 @@ let () =
                  ; prev_next_withdrawal =
                      Option.value prev_next_withdrawal ~default:UInt32.zero
                  ; withdrawal_params
+                 ; prev_nonce
                  } ))
           >>| Or_error.ok_exn
-        in
-        let transferrer_update =
-          Account_update.with_no_aux
-            ~body:
-              { Account_update.Body.dummy with
-                public_key = Public_key.compress signer.public_key
-              ; balance_change =
-                  (let account_creation_fee =
-                     if Option.is_some prev_next_withdrawal then
-                       Currency.Amount.zero
-                     else
-                       constraint_constants.account_creation_fee
-                       |> Currency.Amount.of_fee
-                   in
-                   Currency.Amount.(
-                     Signed.of_unsigned
-                     @@ Option.value_exn
-                          ~message:"Amount insufficient to create 1 account"
-                     @@ sub withdrawal_params.amount account_creation_fee) )
-              ; implicit_account_creation_fee = false
-              ; use_full_commitment = true
-              ; authorization_kind = None_given
-              }
-            ~authorization:Control.Poly.None_given
         in
         let transfer_cmd : Zkapp_command.t =
           { fee_payer
           ; account_updates =
-              Zkapp_command.Call_forest.cons
-                ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
-                transferrer_update transfer_forest
+              transfer_forest
               |> Zkapp_command.Call_forest.map
                    ~f:(Account_update.write_all_proofs_to_disk ~proof_cache_db)
               |> Utils.rehash_forest

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -1146,23 +1146,7 @@ let () =
           let target_ledger_hash = get_root !sequencer in
           [%test_eq: Ledger_hash.t] committed_ledger_hash target_ledger_hash ) ;
 
-      let cancel_deposit ~fee (signer : Keypair.t) deposit_params =
-        let%bind nonce =
-          Gql_client.fetch_nonce ~logger gql_uri
-            (Signature_lib.Public_key.compress signer.public_key)
-          >>| Or_error.ok_exn
-        in
-        let fee_payer =
-          Account_update.Fee_payer.
-            { body =
-                { public_key = Public_key.compress signer.public_key
-                ; fee = Currency.Fee.of_mina_int_exn fee
-                ; valid_until = None
-                ; nonce = Account.Nonce.of_uint32 nonce
-                }
-            ; authorization = Signature.dummy
-            }
-        in
+      let cancel_deposit (signer : Keypair.t) deposit_params =
         let%bind actions =
           Gql_client.fetch_actions ~logger gql_uri
             (Public_key.compress outer_kp.public_key)
@@ -1251,16 +1235,16 @@ let () =
                    [ Utils.actions_of_outer_action action ]
                    |> Zkapp_account.Actions_impl.hash ) )
         in
+        let helper_aid =
+          Account_id.create
+            (Public_key.compress signer.public_key)
+            (Account_id.derive_token_id
+               ~owner:
+                 (Account_id.of_public_key
+                    (Public_key.decompress_exn
+                       Zeko_circuits_config.Inputs.helper_token_owner_l1 ) ) )
+        in
         let%bind prev_next_cancelled_deposit =
-          let helper_aid =
-            Account_id.create
-              (Public_key.compress signer.public_key)
-              (Account_id.derive_token_id
-                 ~owner:
-                   (Account_id.of_public_key
-                      (Public_key.decompress_exn
-                         Zeko_circuits_config.Inputs.helper_token_owner_l1 ) ) )
-          in
           match%map
             Gql_client.fetch_state_opt ~logger gql_uri helper_aid
             >>| Or_error.ok_exn
@@ -1270,71 +1254,54 @@ let () =
           | None ->
               None
         in
-        let%map transfer_forest =
-          Bridge_prover.(
-            prove !sequencer.bridge_prover
-              (Finalize_cancelled_deposit.f ~logger
-                 { public_key =
-                     List.hd_exn Zeko_circuits_config.Inputs.holder_accounts_l1
-                 ; commit = nearest_commit
-                 ; before_commit =
-                     C.Rollup_state.Outer_action_state.unsafe_value_of_field
-                       before_nearest_commit_action_state
-                 ; commit_ase_source = fst commit_ase
-                 ; commit_ase_elems = snd commit_ase
-                 ; sync_ase_source = fst sync_ase
-                 ; sync_ase_elems = snd sync_ase
-                 ; check_accepted_init = fst check_accepted
-                 ; check_accepted_elems = snd check_accepted
-                 ; check_accepted_ase_source = fst check_accepted_ase
-                 ; check_accepted_ase_elems = snd check_accepted_ase
-                 ; prev_next_cancelled_deposit =
-                     Option.value prev_next_cancelled_deposit
-                       ~default:UInt32.zero
-                 } ))
-          >>| Or_error.ok_exn
+        let%bind prev_nonce =
+          match%map
+            Gql_client.fetch_nonce_opt ~logger gql_uri helper_aid
+            >>| Or_error.ok_exn
+          with
+          | Some nonce ->
+              nonce
+          | None ->
+              UInt32.zero
         in
-        let transferrer_update =
-          Account_update.with_no_aux
-            ~body:
-              { Account_update.Body.dummy with
-                public_key = Public_key.compress signer.public_key
-              ; balance_change =
-                  (let account_creation_fee =
-                     if Option.is_some prev_next_cancelled_deposit then
-                       Currency.Amount.zero
-                     else
-                       constraint_constants.account_creation_fee
-                       |> Currency.Amount.of_fee
-                   in
-                   Currency.Amount.(
-                     Signed.of_unsigned
-                     @@ Option.value_exn
-                          ~message:"Amount insufficient to create 2 accounts"
-                     @@ sub deposit_params.amount account_creation_fee) )
-              ; implicit_account_creation_fee = false
-              ; use_full_commitment = true
-              ; authorization_kind = None_given
-              }
-            ~authorization:Control.Poly.None_given
-        in
-        let transfer_cmd : Zkapp_command.t =
-          { fee_payer
-          ; account_updates =
-              Zkapp_command.Call_forest.cons
-                ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
-                transferrer_update transfer_forest
-              |> Zkapp_command.Call_forest.map
-                   ~f:(Account_update.write_all_proofs_to_disk ~proof_cache_db)
-              |> Utils.rehash_forest
-                   ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
-          ; memo = Signed_command_memo.empty
+        let witness : Bridge_prover.Finalize_cancelled_deposit.t_ =
+          { public_key =
+              List.hd_exn Zeko_circuits_config.Inputs.holder_accounts_l1
+          ; commit = nearest_commit
+          ; before_commit =
+              C.Rollup_state.Outer_action_state.unsafe_value_of_field
+                before_nearest_commit_action_state
+          ; commit_ase_source = fst commit_ase
+          ; commit_ase_elems = snd commit_ase
+          ; sync_ase_source = fst sync_ase
+          ; sync_ase_elems = snd sync_ase
+          ; check_accepted_init = fst check_accepted
+          ; check_accepted_elems = snd check_accepted
+          ; check_accepted_ase_source = fst check_accepted_ase
+          ; check_accepted_ase_elems = snd check_accepted_ase
+          ; prev_next_cancelled_deposit =
+              Option.value prev_next_cancelled_deposit ~default:UInt32.zero
+          ; prev_nonce
+          ; helper_account_new = Option.is_none prev_next_cancelled_deposit
           }
         in
-        Utils.sign_zkapp_command
-          ~signature_kind:Zeko_circuits_config.Inputs.chain_l1 transfer_cmd
-          [ signer ]
-        |> Zkapp_command.read_all_proofs_from_disk
+        let _forest, `Commitment commitment =
+          Bridge_prover.Finalize_cancelled_deposit.precompute_commitments
+            !sequencer.bridge_prover witness
+          |> Or_error.ok_exn
+        in
+        let helper_account_signature =
+          Signature_lib.Schnorr.Chunked.sign
+            ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+            signer.private_key
+            (Random_oracle.Input.Chunked.field commitment)
+        in
+        Bridge_prover.(
+          execute_request ~label:"FinalizeCancelledDeposit" ~logger
+            ~executor:l1_executor !sequencer.bridge_prover
+            (Finalize_cancelled_deposit.f ~t:!sequencer.bridge_prover ~logger
+               witness helper_account_signature ))
+        >>| Or_error.ok_exn
       in
       print_endline "(* Cancel timeouted deposits 7-9 *)" ;
       run (fun () ->
@@ -1342,17 +1309,13 @@ let () =
             Deferred.List.iteri timeout_deposits
               ~f:(fun i (signer, deposit_params) ->
                 printf "(* Canceling deposit %d *)\n%!" i ;
-                let%bind command =
-                  cancel_deposit ~fee:1 signer deposit_params
-                in
-                let%bind _ = Gql_client.send_zkapp gql_uri command in
+                let%bind hash = cancel_deposit signer deposit_params in
                 let%bind _created =
                   Gql_client.For_tests.create_new_block ~logger gql_uri
                 in
                 let%map status =
                   Gql_client.For_tests.get_zkapp_command_status ~logger gql_uri
-                    (Mina_transaction.Transaction_hash.hash_command
-                       (Zkapp_command command) )
+                    hash
                 in
                 [%test_eq: string list list option] status None )
           in

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -1381,12 +1381,25 @@ let () =
               ; increment_nonce = true
               ; preconditions =
                   { Account_update.Preconditions.accept with
-                    account =
-                      Zkapp_precondition.Account.nonce
-                        (Account.Nonce.succ nonce)
+                    account = Zkapp_precondition.Account.nonce nonce
                   }
               }
             ~authorization:(Control.Poly.Signature Signature.dummy)
+        in
+        let _forest, `Commitment tx_commitment =
+          Bridge_prover.Withdrawal_request.precompute_commitments
+            !sequencer.bridge_prover
+            { withdrawal_params; transferrer = transferrer_update }
+          |> Or_error.ok_exn
+        in
+        let transferrer_update =
+          Account_update.with_no_aux ~body:transferrer_update.body
+            ~authorization:
+              (Control.Poly.Signature
+                 (Signature_lib.Schnorr.Chunked.sign
+                    ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+                    signer.private_key
+                    (Random_oracle.Input.Chunked.field tx_commitment) ) )
         in
         Bridge_prover.(
           execute_request ~logger ~executor:l2_executor !sequencer.bridge_prover
@@ -1599,26 +1612,40 @@ let () =
           | None ->
               UInt32.zero
         in
+        let witness : Bridge_prover.Finalize_withdrawal.t_ =
+          { public_key =
+              List.hd_exn Zeko_circuits_config.Inputs.holder_accounts_l1
+          ; commit = last_commit
+          ; before_commit =
+              C.Rollup_state.Outer_action_state.unsafe_value_of_field
+                before_last_commit
+          ; commit_ase_source = fst commit_ase
+          ; commit_ase_elems = snd commit_ase
+          ; before_withdrawal
+          ; withdrawal_ase_source = fst withdrawal_ase
+          ; withdrawal_ase_elems = snd withdrawal_ase
+          ; prev_next_withdrawal =
+              Option.value prev_next_withdrawal ~default:UInt32.zero
+          ; withdrawal_params
+          ; prev_nonce
+          ; helper_account_new = Option.is_none prev_next_withdrawal
+          }
+        in
+        let _forest, `Commitment commitment =
+          Bridge_prover.Finalize_withdrawal.precompute_commitments
+            !sequencer.bridge_prover witness
+          |> Or_error.ok_exn
+        in
+        let helper_account_signature =
+          Signature_lib.Schnorr.Chunked.sign
+            ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+            signer.private_key
+            (Random_oracle.Input.Chunked.field commitment)
+        in
         Bridge_prover.(
-          execute_request ~logger ~executor:l2_executor !sequencer.bridge_prover
-            (Finalize_withdrawal.f ~t:!sequencer.bridge_prover ~logger
-               { public_key =
-                   List.hd_exn Zeko_circuits_config.Inputs.holder_accounts_l1
-               ; commit = last_commit
-               ; before_commit =
-                   C.Rollup_state.Outer_action_state.unsafe_value_of_field
-                     before_last_commit
-               ; commit_ase_source = fst commit_ase
-               ; commit_ase_elems = snd commit_ase
-               ; before_withdrawal
-               ; withdrawal_ase_source = fst withdrawal_ase
-               ; withdrawal_ase_elems = snd withdrawal_ase
-               ; prev_next_withdrawal =
-                   Option.value prev_next_withdrawal ~default:UInt32.zero
-               ; withdrawal_params
-               ; prev_nonce
-               ; helper_account_new = Option.is_none prev_next_withdrawal
-               } ))
+          execute_request ~logger ~executor:l1_executor !sequencer.bridge_prover
+            (Finalize_withdrawal.f ~t:!sequencer.bridge_prover ~logger witness
+               helper_account_signature ))
         >>| Or_error.ok_exn
       in
 

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -793,7 +793,8 @@ let () =
               in
               return () ) ) ;
 
-      let submit_deposit ~fee (signer : Keypair.t) deposit_params =
+      let submit_deposit ~fee (signer : Keypair.t)
+          (deposit_params : C.Bridge_state.Deposit_params_base.t) =
         let%bind nonce =
           Gql_client.fetch_nonce ~logger gql_uri
             (Signature_lib.Public_key.compress signer.public_key)
@@ -810,12 +811,6 @@ let () =
             ; authorization = Signature.dummy
             }
         in
-        let%map transfer_forest =
-          Bridge_prover.(
-            prove !sequencer.bridge_prover
-              (Deposit_request.f ~logger { deposit_params }))
-          >>| Or_error.ok_exn
-        in
         let transferrer_update =
           Account_update.with_no_aux
             ~body:
@@ -829,12 +824,16 @@ let () =
               }
             ~authorization:(Control.Poly.Signature Signature.dummy)
         in
+        let%map transfer_forest =
+          Bridge_prover.(
+            prove !sequencer.bridge_prover
+              (Deposit_request.f ~logger { deposit_params; transferrer = transferrer_update }))
+          >>| Or_error.ok_exn
+        in
         let transfer_cmd : Zkapp_command.t =
           { fee_payer
           ; account_updates =
-              Zkapp_command.Call_forest.cons
-                ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
-                transferrer_update transfer_forest
+              transfer_forest
               |> Zkapp_command.Call_forest.map
                    ~f:(Account_update.write_all_proofs_to_disk ~proof_cache_db)
           ; memo = Signed_command_memo.empty
@@ -1427,7 +1426,8 @@ let () =
 
       print_endline "Started test 'withdrawals'" ;
 
-      let submit_withdrawal ~fee (signer : Keypair.t) withdrawal_params =
+      let submit_withdrawal ~fee (signer : Keypair.t)
+          (withdrawal_params : C.Bridge_state.Withdrawal_params_base.t) =
         let nonce =
           Sequencer.infer_nonce !sequencer
             (Signature_lib.Public_key.compress signer.public_key)
@@ -1443,12 +1443,6 @@ let () =
             ; authorization = Signature.dummy
             }
         in
-        let%map transfer_forest =
-          Bridge_prover.(
-            prove !sequencer.bridge_prover
-              (Withdrawal_request.f ~logger { withdrawal_params }))
-          >>| Or_error.ok_exn
-        in
         let transferrer_update =
           Account_update.with_no_aux
             ~body:
@@ -1462,12 +1456,17 @@ let () =
               }
             ~authorization:(Control.Poly.Signature Signature.dummy)
         in
+        let%map transfer_forest =
+          Bridge_prover.(
+            prove !sequencer.bridge_prover
+              (Withdrawal_request.f ~logger
+                 { withdrawal_params; transferrer = transferrer_update }))
+          >>| Or_error.ok_exn
+        in
         let transfer_cmd : Zkapp_command.t =
           { fee_payer
           ; account_updates =
-              Zkapp_command.Call_forest.cons
-                ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
-                transferrer_update transfer_forest
+              transfer_forest
               |> Zkapp_command.Call_forest.map
                    ~f:(Account_update.write_all_proofs_to_disk ~proof_cache_db)
           ; memo = Signed_command_memo.empty

--- a/src/app/zeko/sequencer/tests/test_spec.ml
+++ b/src/app/zeko/sequencer/tests/test_spec.ml
@@ -367,6 +367,8 @@ module Sequencer_spec = struct
     ; da_keys : Public_key.Compressed.t list
     ; accounts : Keypair.t list
     ; l1_config : Utils.Slot.l1_config
+    ; l1_executor : Executor.t
+    ; l2_executor : Executor.t
     }
 
   let gen ?(delay_deposit = 0) ?(number_of_transactions = 5) ?db_dir
@@ -465,9 +467,7 @@ module Sequencer_spec = struct
 
     print_endline "(* Deploy zkapp *)" ;
     run (fun () ->
-        let sequencer_pk =
-          signer_pk |> Even_PC.create_exn
-        in
+        let sequencer_pk = signer_pk |> Even_PC.create_exn in
         ( print_endline
         @@ Public_key.(
              Compressed.to_base58_check @@ compress outer_kp.public_key) ) ;
@@ -479,8 +479,7 @@ module Sequencer_spec = struct
              Compressed.to_base58_check @@ compress token_holder_kp.public_key)
         ) ;
         let%bind nonce =
-          Gql_client.infer_nonce ~logger gql_uri signer_pk
-          >>| Or_error.ok_exn
+          Gql_client.infer_nonce ~logger gql_uri signer_pk >>| Or_error.ok_exn
         in
         let%bind command =
           let da_key =
@@ -490,8 +489,7 @@ module Sequencer_spec = struct
           printf "Deplying with DA key: %s\n%!" (Field.to_string da_key) ;
           Deploy.deploy_command_exn
             ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
-            ~signer:signer_keypair
-            ~outer_kp ~holder_kp ~token_holder_kp
+            ~signer:signer_keypair ~outer_kp ~holder_kp ~token_holder_kp
             ~fee:(Currency.Fee.of_mina_int_exn 1)
             ~nonce ~initial_ledger:ephemeral_ledger
             ~account_creation_fee:constraint_constants.account_creation_fee
@@ -524,12 +522,23 @@ module Sequencer_spec = struct
       run (fun () ->
           Sequencer.create ~logger ~max_pool_size:10 ~commitment_period_sec:0.
             ~da_config ~da_keys ~da_quorum ~db_dir ~postgres_uri ~l1_uri:gql_uri
-            ~archive_uri:gql_uri
-            ~signer
-            ~deposit_delay_blocks:delay_deposit
+            ~archive_uri:gql_uri ~signer ~deposit_delay_blocks:delay_deposit
             ~mq_host ~fee_modifier:1.0 ~minimum_fee:0.01 ~slot_acceptance
             ~proof_cache_db:(Proof_cache_tag.create_identity_db ())
             ~l1_config ~commit_validity_period ~checkpoints_dir )
+    in
+    let l1_executor =
+      Executor.create ~kind:(`L1 gql_uri)
+        ~signature_kind:Zeko_circuits_config.Inputs.chain_l1 ~signer ()
+    in
+    let l2_executor =
+      Executor.create
+        ~kind:
+          (`L2
+            { infer_nonce = Sequencer.infer_nonce sequencer
+            ; apply_user_command = Sequencer.apply_user_command sequencer
+            } )
+        ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 ~signer ()
     in
     Quickcheck.Generator.return
       { outer_kp
@@ -542,5 +551,7 @@ module Sequencer_spec = struct
       ; da_keys
       ; accounts = Array.map funded_accounts ~f:fst |> Array.to_list
       ; l1_config
+      ; l1_executor
+      ; l2_executor
       }
 end

--- a/src/app/zeko/sequencer/tests/test_spec.ml
+++ b/src/app/zeko/sequencer/tests/test_spec.ml
@@ -527,6 +527,12 @@ module Sequencer_spec = struct
             ~proof_cache_db:(Proof_cache_tag.create_identity_db ())
             ~l1_config ~commit_validity_period ~checkpoints_dir )
     in
+    (* The L2 executor below uses [funded_accounts.(0)] as its signer (since
+       the sequencer's own signer has no balance on L2 in this test setup).
+       Tell the sequencer to use the same key when preverifying L2 commands so
+       preverify reflects what the executor will actually submit. *)
+    Sequencer.set_l2_fee_payer_pk sequencer
+      (Public_key.compress (fst funded_accounts.(0)).public_key) ;
     let l1_executor =
       Executor.create ~kind:(`L1 gql_uri)
         ~signature_kind:Zeko_circuits_config.Inputs.chain_l1 ~signer ()

--- a/src/app/zeko/sequencer/tests/test_spec.ml
+++ b/src/app/zeko/sequencer/tests/test_spec.ml
@@ -538,7 +538,9 @@ module Sequencer_spec = struct
             { infer_nonce = Sequencer.infer_nonce sequencer
             ; apply_user_command = Sequencer.apply_user_command sequencer
             } )
-        ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 ~signer ()
+        ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+        ~signer:(Signer_service.Signer.of_keypair (funded_accounts.(0) |> fst))
+        ()
     in
     Quickcheck.Generator.return
       { outer_kp

--- a/src/app/zeko/sequencer/tests/test_spec.ml
+++ b/src/app/zeko/sequencer/tests/test_spec.ml
@@ -422,11 +422,22 @@ module Sequencer_spec = struct
     let `Inner inner_account, `Holder holder_account =
       run Deploy.Z.Inner.initial_accounts
     in
+    (* Pre-fund the sequencer's signer on L2 so the bridge prover's
+       preverify_l2 (which uses the signer as fee payer) can debit a real
+       account when simulating commands. *)
+    let signer_l2_account =
+      let aid = Account_id.create signer_pk Token_id.default in
+      ( aid
+      , Account.create aid
+          (Currency.Balance.of_uint64
+             (Unsigned.UInt64.of_int64 (Int64.of_float (1000. *. 1e8))) ) )
+    in
     let genesis_accounts =
       ( Account_id.create inner_account.public_key inner_account.token_id
       , inner_account )
       :: ( Account_id.create holder_account.public_key holder_account.token_id
          , holder_account )
+      :: signer_l2_account
       :: ( Array.concat [ init_ledger; funded_accounts ]
          |> Array.map ~f:(fun (keypair, balance) ->
                 let pk = Signature_lib.Public_key.compress keypair.public_key in
@@ -527,12 +538,6 @@ module Sequencer_spec = struct
             ~proof_cache_db:(Proof_cache_tag.create_identity_db ())
             ~l1_config ~commit_validity_period ~checkpoints_dir )
     in
-    (* The L2 executor below uses [funded_accounts.(0)] as its signer (since
-       the sequencer's own signer has no balance on L2 in this test setup).
-       Tell the sequencer to use the same key when preverifying L2 commands so
-       preverify reflects what the executor will actually submit. *)
-    Sequencer.set_l2_fee_payer_pk sequencer
-      (Public_key.compress (fst funded_accounts.(0)).public_key) ;
     let l1_executor =
       Executor.create ~kind:(`L1 gql_uri)
         ~signature_kind:Zeko_circuits_config.Inputs.chain_l1 ~signer ()
@@ -544,9 +549,7 @@ module Sequencer_spec = struct
             { infer_nonce = Sequencer.infer_nonce sequencer
             ; apply_user_command = Sequencer.apply_user_command sequencer
             } )
-        ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
-        ~signer:(Signer_service.Signer.of_keypair (funded_accounts.(0) |> fst))
-        ()
+        ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 ~signer ()
     in
     Quickcheck.Generator.return
       { outer_kp

--- a/src/app/zeko/sequencer/utils/utils.ml
+++ b/src/app/zeko/sequencer/utils/utils.ml
@@ -354,100 +354,72 @@ let attach_proof_to_forest ~signature_kind ~proof_cache_db ~body ~calls ~proof =
       in
       Zkapp_command.Call_forest.cons ~signature_kind ~calls account_update []
 
+module Forest_shape = struct
+  (** add more fields if needed *)
+  type field =
+    | Calls of field list list
+    | Public_key of Public_key.Compressed.t
+    | Token_id of Token_id.t
+
+  let rec check_tree
+      ({ account_update = au; calls; _ } as tree :
+        (Account_update.t, _, _) Zkapp_command.Call_forest.Tree.t ) = function
+    | [] ->
+        true
+    | Public_key pk :: rest ->
+        Public_key.Compressed.equal au.body.public_key pk
+        && check_tree tree rest
+    | Token_id token_id :: rest ->
+        Token_id.equal au.body.token_id token_id && check_tree tree rest
+    | Calls calls_spec :: rest -> (
+        match List.zip calls calls_spec with
+        | List.Or_unequal_lengths.Unequal_lengths ->
+            false
+        | List.Or_unequal_lengths.Ok l ->
+            List.map l ~f:(fun (tree, spec) ->
+                check_tree (With_stack_hash.elt tree) spec )
+            |> List.for_all ~f:Fn.id
+            && check_tree tree rest )
+
+  let matches (forest : (Account_update.t, _, _) Zkapp_command.Call_forest.t)
+      (spec : field list list) =
+    match List.zip forest spec with
+    | List.Or_unequal_lengths.Unequal_lengths ->
+        false
+    | List.Or_unequal_lengths.Ok l ->
+        List.map l ~f:(fun (tree, spec) ->
+            check_tree (With_stack_hash.elt tree) spec )
+        |> List.for_all ~f:Fn.id
+end
+
 let is_deposit_finalization (command : User_command.t) =
+  let open Forest_shape in
+  let holder_token_id =
+    Account_id.derive_token_id
+      ~owner:
+        ( Account_id.of_public_key
+        @@ Public_key.decompress_exn
+             Zeko_circuits_config.Inputs.holder_account_l2 )
+  in
   match command with
   | Signed_command _ ->
       false
-  | Zkapp_command command -> (
-      match command.account_updates with
-      | [ transferrer_forest; deposit_forest ] ->
-          let is_valid_deposit_forest, recipient =
-            let l2_holder_au = deposit_forest.elt.account_update in
-            let is_holder_au_valid =
-              Public_key.Compressed.equal l2_holder_au.body.public_key
-                Zeko_circuits_config.Inputs.holder_account_l2
-            in
-            let are_children_valid, recipient =
-              match deposit_forest.elt.calls with
-              | [ helper_forest; witness_forest ] ->
-                  let is_helper_valid =
-                    List.is_empty helper_forest.elt.calls
-                    && Token_id.equal
-                         helper_forest.elt.account_update.body.token_id
-                         (Account_id.derive_token_id
-                            ~owner:
-                              ( Account_id.of_public_key
-                              @@ Public_key.decompress_exn
-                                   Zeko_circuits_config.Inputs.holder_account_l2
-                              ) )
-                  in
-                  let is_witness_valid =
-                    List.is_empty witness_forest.elt.calls
-                    && Public_key.Compressed.equal
-                         witness_forest.elt.account_update.body.public_key
-                         Zeko_circuits_config.Inputs.zeko_l2
-                    && Token_id.equal
-                         witness_forest.elt.account_update.body.token_id
-                         Token_id.default
-                  in
-                  ( is_helper_valid && is_witness_valid
-                  , Some helper_forest.elt.account_update.body.public_key )
-              | [ helper_forest
-                ; witness_forest
-                ; recipient_payout_forest
-                ; sequencer_fee_forest
-                ] ->
-                  let is_helper_valid =
-                    List.is_empty helper_forest.elt.calls
-                    && Token_id.equal
-                         helper_forest.elt.account_update.body.token_id
-                         (Account_id.derive_token_id
-                            ~owner:
-                              ( Account_id.of_public_key
-                              @@ Public_key.decompress_exn
-                                   Zeko_circuits_config.Inputs.holder_account_l2
-                              ) )
-                  in
-                  let is_witness_valid =
-                    List.is_empty witness_forest.elt.calls
-                    && Public_key.Compressed.equal
-                         witness_forest.elt.account_update.body.public_key
-                         Zeko_circuits_config.Inputs.zeko_l2
-                    && Token_id.equal
-                         witness_forest.elt.account_update.body.token_id
-                         Token_id.default
-                  in
-                  let is_payouts_valid =
-                    List.is_empty recipient_payout_forest.elt.calls
-                    && List.is_empty sequencer_fee_forest.elt.calls
-                    && Token_id.equal
-                         recipient_payout_forest.elt.account_update.body
-                           .token_id Token_id.default
-                    && Token_id.equal
-                         sequencer_fee_forest.elt.account_update.body.token_id
-                         Token_id.default
-                  in
-                  ( is_helper_valid && is_witness_valid && is_payouts_valid
-                  , Some helper_forest.elt.account_update.body.public_key )
-              | _ ->
-                  (false, None)
-            in
-            (is_holder_au_valid && are_children_valid, recipient)
-          in
-          let is_valid_transferrer =
-            List.is_empty transferrer_forest.elt.calls
-            && Option.value ~default:false
-                 (Option.map recipient
-                    ~f:
-                      (Public_key.Compressed.equal
-                         transferrer_forest.elt.account_update.body.public_key ) )
-            && Token_id.equal
-                 transferrer_forest.elt.account_update.body.token_id
-                 Token_id.default
-          in
-          is_valid_deposit_forest && is_valid_transferrer
-      | _ ->
-          false )
+  | Zkapp_command command ->
+      matches command.account_updates
+        [ [ Public_key Zeko_circuits_config.Inputs.holder_account_l2
+          ; Token_id Token_id.default
+          ; Calls
+              [ [ Token_id holder_token_id ]
+              ; [ Public_key Zeko_circuits_config.Inputs.zeko_l2
+                ; Token_id Token_id.default
+                ]
+              ; [ Token_id Token_id.default ]
+              ; [ Public_key Zeko_circuits_config.Inputs.bridge_fee_recipient_l2
+                ; Token_id Token_id.default
+                ]
+              ]
+          ]
+        ]
 
 let sign_fee_payer ~signature_kind (sequencer_signer : Keypair.t)
     (command : User_command.t) : User_command.t =

--- a/src/app/zeko/sequencer/utils/utils.ml
+++ b/src/app/zeko/sequencer/utils/utils.ml
@@ -198,9 +198,9 @@ let get_synced_outer_action_state_exn l =
 
 let sign_zkapp_command ~signature_kind (command : Zkapp_command.t)
     (signers : Keypair.t list) : Zkapp_command.t =
+  let tx_commitment = Zkapp_command.commitment command in
   let full_commitment =
-    Zkapp_command.Transaction_commitment.create_complete
-      (Zkapp_command.commitment command)
+    Zkapp_command.Transaction_commitment.create_complete tx_commitment
       ~memo_hash:(Signed_command_memo.hash command.memo)
       ~fee_payer_hash:
         (Zkapp_command.Digest.Account_update.create ~signature_kind
@@ -231,9 +231,13 @@ let sign_zkapp_command ~signature_kind (command : Zkapp_command.t)
           authorization =
             ( match tree.account_update.body.authorization_kind with
             | Signature ->
-                assert tree.account_update.body.use_full_commitment ;
+                let commitment =
+                  if tree.account_update.body.use_full_commitment then
+                    full_commitment
+                  else tx_commitment
+                in
                 Control.Poly.Signature
-                  (sign_raw tree.account_update.body.public_key full_commitment)
+                  (sign_raw tree.account_update.body.public_key commitment)
             | _ ->
                 tree.account_update.authorization )
         }
@@ -340,11 +344,7 @@ let attach_proof_to_forest ~signature_kind ~proof_cache_db ~body ~calls ~proof =
                   (Type_equal.conv proof_eq proof) ) )
         |> Account_update.read_all_proofs_from_disk
       in
-      Zkapp_command.Call_forest.cons_aux account_update
-        ~digest_account_update:(fun _ ->
-          Zkapp_command.Digest.Account_update.create ~signature_kind
-            account_update )
-        ~calls []
+      Zkapp_command.Call_forest.cons ~signature_kind ~calls account_update []
   | None ->
       let account_update =
         Account_update.with_aux
@@ -352,11 +352,7 @@ let attach_proof_to_forest ~signature_kind ~proof_cache_db ~body ~calls ~proof =
           ~authorization:Control.Poly.None_given
         |> Account_update.read_all_proofs_from_disk
       in
-      Zkapp_command.Call_forest.cons_aux account_update
-        ~digest_account_update:(fun _ ->
-          Zkapp_command.Digest.Account_update.create ~signature_kind
-            account_update )
-        ~calls []
+      Zkapp_command.Call_forest.cons ~signature_kind ~calls account_update []
 
 let is_deposit_finalization (command : User_command.t) =
   match command with
@@ -425,8 +421,8 @@ let is_deposit_finalization (command : User_command.t) =
                     List.is_empty recipient_payout_forest.elt.calls
                     && List.is_empty sequencer_fee_forest.elt.calls
                     && Token_id.equal
-                         recipient_payout_forest.elt.account_update.body.token_id
-                         Token_id.default
+                         recipient_payout_forest.elt.account_update.body
+                           .token_id Token_id.default
                     && Token_id.equal
                          sequencer_fee_forest.elt.account_update.body.token_id
                          Token_id.default

--- a/src/app/zeko/sequencer/utils/utils.ml
+++ b/src/app/zeko/sequencer/utils/utils.ml
@@ -396,6 +396,43 @@ let is_deposit_finalization (command : User_command.t) =
                   in
                   ( is_helper_valid && is_witness_valid
                   , Some helper_forest.elt.account_update.body.public_key )
+              | [ helper_forest
+                ; witness_forest
+                ; recipient_payout_forest
+                ; sequencer_fee_forest
+                ] ->
+                  let is_helper_valid =
+                    List.is_empty helper_forest.elt.calls
+                    && Token_id.equal
+                         helper_forest.elt.account_update.body.token_id
+                         (Account_id.derive_token_id
+                            ~owner:
+                              ( Account_id.of_public_key
+                              @@ Public_key.decompress_exn
+                                   Zeko_circuits_config.Inputs.holder_account_l2
+                              ) )
+                  in
+                  let is_witness_valid =
+                    List.is_empty witness_forest.elt.calls
+                    && Public_key.Compressed.equal
+                         witness_forest.elt.account_update.body.public_key
+                         Zeko_circuits_config.Inputs.zeko_l2
+                    && Token_id.equal
+                         witness_forest.elt.account_update.body.token_id
+                         Token_id.default
+                  in
+                  let is_payouts_valid =
+                    List.is_empty recipient_payout_forest.elt.calls
+                    && List.is_empty sequencer_fee_forest.elt.calls
+                    && Token_id.equal
+                         recipient_payout_forest.elt.account_update.body.token_id
+                         Token_id.default
+                    && Token_id.equal
+                         sequencer_fee_forest.elt.account_update.body.token_id
+                         Token_id.default
+                  in
+                  ( is_helper_valid && is_witness_valid && is_payouts_valid
+                  , Some helper_forest.elt.account_update.body.public_key )
               | _ ->
                   (false, None)
             in

--- a/src/app/zeko/sequencer/utils/utils.ml
+++ b/src/app/zeko/sequencer/utils/utils.ml
@@ -360,6 +360,15 @@ module Forest_shape = struct
     | Calls of field list list
     | Public_key of Public_key.Compressed.t
     | Token_id of Token_id.t
+    | Balance_change of Currency.Amount.Signed.t
+    | Increment_nonce of bool
+    | Use_full_commitment of bool
+    | Authorization_kind of Account_update.Authorization_kind.t
+        (** [Preconditions_constant_nonce_only] passes when the AU has no
+            preconditions other than a single equality nonce check
+            (nonce = Check { lower = n; upper = n } for some n), network is
+            [accept] and valid_while is [Ignore]. *)
+    | Preconditions_constant_nonce_only
 
   let rec check_tree
       ({ account_update = au; calls; _ } as tree :
@@ -371,6 +380,27 @@ module Forest_shape = struct
         && check_tree tree rest
     | Token_id token_id :: rest ->
         Token_id.equal au.body.token_id token_id && check_tree tree rest
+    | Balance_change bc :: rest ->
+        Currency.Amount.Signed.equal au.body.balance_change bc
+        && check_tree tree rest
+    | Increment_nonce b :: rest ->
+        Bool.equal au.body.increment_nonce b && check_tree tree rest
+    | Use_full_commitment b :: rest ->
+        Bool.equal au.body.use_full_commitment b && check_tree tree rest
+    | Authorization_kind kind :: rest ->
+        Account_update.Authorization_kind.equal au.body.authorization_kind
+          kind
+        && check_tree tree rest
+    | Preconditions_constant_nonce_only :: rest ->
+        let { Account_update.Preconditions.network; account; valid_while } =
+          au.body.preconditions
+        in
+        Zkapp_precondition.Protocol_state.(equal network accept)
+        && Zkapp_basic.Or_ignore.equal
+             (fun _ _ -> true)
+             valid_while Zkapp_basic.Or_ignore.Ignore
+        && Zkapp_precondition.Account.is_nonce account
+        && check_tree tree rest
     | Calls calls_spec :: rest -> (
         match List.zip calls calls_spec with
         | List.Or_unequal_lengths.Unequal_lengths ->

--- a/src/app/zeko/signer/signer_service.ml
+++ b/src/app/zeko/signer/signer_service.ml
@@ -130,7 +130,7 @@ module Command_signing = struct
     | None ->
         Ok ()
     | Some max_balance_change ->
-        Zkapp_command.all_account_updates_list command
+        Zkapp_command.account_updates_list command
         |> List.filter ~f:(fun account_update ->
                Public_key.Compressed.equal public_key
                  account_update.body.public_key

--- a/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
+++ b/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
@@ -120,6 +120,13 @@ module Inputs = struct
 
   let withdrawal_delay = t.withdrawal_delay
 
+  let bridge_proof_fee =
+    Currency.Amount.of_fee Zeko_constants.constraint_constants.account_creation_fee
+
+  let bridge_fee_recipient_l1 = t.zeko_l1
+
+  let bridge_fee_recipient_l2 = Zeko_constants.inner_public_key
+
   let holder_account_l1_permissions_enabled : Permissions.t =
     { edit_state = Proof
     ; access = None

--- a/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
+++ b/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
@@ -18,6 +18,8 @@ type t =
   ; zeko_l1 : Public_key.Compressed.t
   ; emergency_da_public_key : Public_key.Compressed.t
   ; withdrawal_delay : Global_slot_span.t
+  ; bridge_fee_recipient_l1 : Public_key.Compressed.t
+  ; bridge_fee_recipient_l2 : Public_key.Compressed.t
   }
 [@@deriving yojson]
 
@@ -27,6 +29,8 @@ module Deploy = struct
     ; helper_token_owner_l1 : Private_key.t
     ; zeko_l1 : Private_key.t
     ; emergency_da : Private_key.t
+    ; bridge_fee_recipient_l1 : Private_key.t
+    ; bridge_fee_recipient_l2 : Private_key.t
     }
   [@@deriving yojson]
 end
@@ -58,6 +62,12 @@ let (t, deploy_config) : t * Deploy.t option =
       let emergency_da =
         keypair_of_b58_sk "EKE9VtD6g4AgoscJdxBbFak6yfBgnQDHTpyj23CfNFT5BxL51Zin"
       in
+      let bridge_fee_recipient_l1 =
+        keypair_of_b58_sk "EKESW6sXA3MA3ugGvEoEHPd6gc9NPB9SRWzuW4VqxBqbNU3W4pFX"
+      in
+      let bridge_fee_recipient_l2 =
+        keypair_of_b58_sk "EKESW6sXA3MA3ugGvEoEHPd6gc9NPB9SRWzuW4VqxBqbNU3W4pFX"
+      in
       ( { chain_l1 = Testnet
         ; chain_l2 = Testnet
         ; max_valid_while_size = Zeko_circuits.Zeko_util.Slot.max_value
@@ -70,12 +80,16 @@ let (t, deploy_config) : t * Deploy.t option =
         ; zeko_l1 = fst zeko_l1
         ; emergency_da_public_key = fst emergency_da
         ; withdrawal_delay = Global_slot_span.of_int 5
+        ; bridge_fee_recipient_l1 = fst bridge_fee_recipient_l1
+        ; bridge_fee_recipient_l2 = fst bridge_fee_recipient_l2
         }
       , Some
           { holder_accounts_l1 = List.map holder_accounts_l1 ~f:snd
           ; helper_token_owner_l1 = snd helper_token_owner_l1
           ; zeko_l1 = snd zeko_l1
           ; emergency_da = snd emergency_da
+          ; bridge_fee_recipient_l1 = snd bridge_fee_recipient_l1
+          ; bridge_fee_recipient_l2 = snd bridge_fee_recipient_l2
           } )
   | Some path -> (
       match Yojson.Safe.from_file path |> of_yojson with
@@ -121,11 +135,12 @@ module Inputs = struct
   let withdrawal_delay = t.withdrawal_delay
 
   let bridge_proof_fee =
-    Currency.Amount.of_fee Zeko_constants.constraint_constants.account_creation_fee
+    Currency.Amount.of_fee
+      Zeko_constants.constraint_constants.account_creation_fee
 
-  let bridge_fee_recipient_l1 = t.zeko_l1
+  let bridge_fee_recipient_l1 = t.bridge_fee_recipient_l1
 
-  let bridge_fee_recipient_l2 = Zeko_constants.inner_public_key
+  let bridge_fee_recipient_l2 = t.bridge_fee_recipient_l2
 
   let holder_account_l1_permissions_enabled : Permissions.t =
     { edit_state = Proof

--- a/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
+++ b/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
@@ -135,8 +135,10 @@ module Inputs = struct
   let withdrawal_delay = t.withdrawal_delay
 
   let bridge_proof_fee =
-    Currency.Amount.of_fee
-      Zeko_constants.constraint_constants.account_creation_fee
+    Currency.Amount.(
+      of_fee Zeko_constants.constraint_constants.account_creation_fee
+      + of_fee Zeko_constants.constraint_constants.account_creation_fee)
+    |> Option.value_exn
 
   let bridge_fee_recipient_l1 = t.bridge_fee_recipient_l1
 

--- a/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
+++ b/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
@@ -69,8 +69,8 @@ let (t, deploy_config) : t * Deploy.t option =
       let bridge_fee_recipient_l2 =
         keypair_of_b58_sk "EKESW6sXA3MA3ugGvEoEHPd6gc9NPB9SRWzuW4VqxBqbNU3W4pFX"
       in
-      ( { chain_l1 = Testnet
-        ; chain_l2 = Testnet
+      ( { chain_l1 = Mainnet
+        ; chain_l2 = Other_network "zeko-testnet"
         ; max_valid_while_size = Zeko_circuits.Zeko_util.Slot.max_value
         ; multisig_key =
             { public_keys = List.map holder_accounts_l1 ~f:fst

--- a/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
+++ b/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
@@ -20,6 +20,7 @@ type t =
   ; withdrawal_delay : Global_slot_span.t
   ; bridge_fee_recipient_l1 : Public_key.Compressed.t
   ; bridge_fee_recipient_l2 : Public_key.Compressed.t
+  ; outer_account_creation_fee : Currency.Fee.t
   }
 [@@deriving yojson]
 
@@ -82,6 +83,8 @@ let (t, deploy_config) : t * Deploy.t option =
         ; withdrawal_delay = Global_slot_span.of_int 5
         ; bridge_fee_recipient_l1 = fst bridge_fee_recipient_l1
         ; bridge_fee_recipient_l2 = fst bridge_fee_recipient_l2
+        ; outer_account_creation_fee =
+            Zeko_constants.constraint_constants.account_creation_fee
         }
       , Some
           { holder_accounts_l1 = List.map holder_accounts_l1 ~f:snd
@@ -143,6 +146,8 @@ module Inputs = struct
   let bridge_fee_recipient_l1 = t.bridge_fee_recipient_l1
 
   let bridge_fee_recipient_l2 = t.bridge_fee_recipient_l2
+
+  let outer_account_creation_fee = t.outer_account_creation_fee
 
   let holder_account_l1_permissions_enabled : Permissions.t =
     { edit_state = Proof

--- a/src/app/zeko/zeko_types/zeko_types.ml
+++ b/src/app/zeko/zeko_types/zeko_types.ml
@@ -1079,6 +1079,8 @@ module Bridge = struct
       ; verify_check_accepted_and_ase :
           Verify_check_accepted_and_ase.serializable
       ; prev_next_cancelled_deposit : Checked32.t
+      ; prev_nonce : Checked32.t
+      ; helper_account_new : bool
       }
     [@@deriving yojson]
 
@@ -1091,6 +1093,8 @@ module Bridge = struct
          ; verify_two_outer_ases
          ; verify_check_accepted_and_ase
          ; prev_next_cancelled_deposit
+         ; prev_nonce
+         ; helper_account_new
          } :
           serializable ) ~vk_hash ~helper_token_owner_l1_vk_hash : t =
       { public_key
@@ -1106,6 +1110,9 @@ module Bridge = struct
             verify_check_accepted_and_ase
       ; prev_next_cancelled_deposit
       ; helper_token_owner_l1_vk_hash
+      ; prev_nonce =
+          Mina_numbers.Account_nonce.of_string (Checked32.to_string prev_nonce)
+      ; helper_account_new
       }
   end
 

--- a/src/app/zeko/zeko_types/zeko_types.ml
+++ b/src/app/zeko/zeko_types/zeko_types.ml
@@ -991,6 +991,7 @@ module Bridge = struct
       ; check_accepted : Check_accepted_mina.serializable
       ; prev_next_deposit : Checked32.t
       ; prev_nonce : Checked32.t
+      ; helper_account_new : bool
       }
     [@@deriving yojson]
 
@@ -1002,6 +1003,7 @@ module Bridge = struct
          ; check_accepted
          ; prev_next_deposit
          ; prev_nonce
+         ; helper_account_new
          } :
           serializable ) ~vk_hash : t =
       { public_key
@@ -1013,6 +1015,7 @@ module Bridge = struct
       ; prev_next_deposit
       ; prev_nonce =
           Mina_numbers.Account_nonce.of_string (Checked32.to_string prev_nonce)
+      ; helper_account_new
       }
   end
 
@@ -1181,6 +1184,7 @@ module Bridge = struct
       ; prev_next_withdrawal : Checked32.t
       ; withdrawal_params : Withdrawal_params_base.serializable
       ; prev_nonce : Checked32.t
+      ; helper_account_new : bool
       }
     [@@deriving yojson]
 
@@ -1196,6 +1200,7 @@ module Bridge = struct
          ; prev_next_withdrawal
          ; withdrawal_params
          ; prev_nonce
+         ; helper_account_new
          } :
           serializable ) ~vk_hash ~helper_token_owner_l1_vk_hash
         ~l2_holder_vk_hash : t =
@@ -1216,6 +1221,7 @@ module Bridge = struct
       ; l2_holder_vk_hash
       ; prev_nonce =
           Mina_numbers.Account_nonce.of_string (Checked32.to_string prev_nonce)
+      ; helper_account_new
       }
   end
 

--- a/src/app/zeko/zeko_types/zeko_types.ml
+++ b/src/app/zeko/zeko_types/zeko_types.ml
@@ -990,6 +990,7 @@ module Bridge = struct
       ; ase : Ase_inst.serializable
       ; check_accepted : Check_accepted_mina.serializable
       ; prev_next_deposit : Checked32.t
+      ; prev_nonce : Checked32.t
       }
     [@@deriving yojson]
 
@@ -1000,6 +1001,7 @@ module Bridge = struct
          ; ase
          ; check_accepted
          ; prev_next_deposit
+         ; prev_nonce
          } :
           serializable ) ~vk_hash : t =
       { public_key
@@ -1009,6 +1011,8 @@ module Bridge = struct
       ; ase = Ase_inst.of_serializable ase
       ; check_accepted = Check_accepted_mina.of_serializable check_accepted
       ; prev_next_deposit
+      ; prev_nonce =
+          Mina_numbers.Account_nonce.of_string (Checked32.to_string prev_nonce)
       }
   end
 
@@ -1176,6 +1180,7 @@ module Bridge = struct
       ; withdrawal_ase : Ase_inner_inst.serializable
       ; prev_next_withdrawal : Checked32.t
       ; withdrawal_params : Withdrawal_params_base.serializable
+      ; prev_nonce : Checked32.t
       }
     [@@deriving yojson]
 
@@ -1190,6 +1195,7 @@ module Bridge = struct
          ; withdrawal_ase
          ; prev_next_withdrawal
          ; withdrawal_params
+         ; prev_nonce
          } :
           serializable ) ~vk_hash ~helper_token_owner_l1_vk_hash
         ~l2_holder_vk_hash : t =
@@ -1208,6 +1214,8 @@ module Bridge = struct
             ~proof_cache_db
       ; helper_token_owner_l1_vk_hash
       ; l2_holder_vk_hash
+      ; prev_nonce =
+          Mina_numbers.Account_nonce.of_string (Checked32.to_string prev_nonce)
       }
   end
 


### PR DESCRIPTION
# Pre-prove validation + bridge-fee circuits

## Circuits

Each bridging request now pays a fixed `bridge_proof_fee` to compensate the sequencer for proving:
- **submitDeposit** / **submitWithdrawal** (`bridge_state.ml`): the `Witness` action gets a sibling `(bridge_fee_recipient, default_token, +bridge_proof_fee, Parents_own_token)` AU. Transferrer must cover `amount + bridge_proof_fee`.
- **finalize*** (`rule_bridge_finalize_{deposit,cancelled_deposit,withdrawal}.ml`): two child AUs are appended to the action update — recipient payout for `amount - bridge_proof_fee` (further - `account_creation_fee` if the helper is new) and a fixed `bridge_proof_fee` payout to the bridge fee recipient.
- Helper update on finalize* now uses `use_full_commitment = false` + `increment_nonce = true` + `is_new` and constant-nonce preconditions, so users can pre-sign without knowing the fee_payer and the signature is single-use.

## Pre-prove validation

Before invoking the prover, each `Bridge_prover.f` now:
1. Re-runs `precompute_commitments` to obtain forest + commitment.
2. Verifies the signature — `transferrer` for submit*, `helper_account_signature` for finalize*.
3. Calls `t.preverify_l{1,2}` on the forest. Failures short-circuit before the prover runs.

`Zeko_transaction_logic.preverify_user_command` (new) applies a `User_command.t` against a sparse ledger built from a caller-supplied `get_account` and returns `Ok ()` iff the command would succeed on chain. Authorization isn't verified.
