### PR TITLE
Update BUSL licensing framework

### DIFF
--- a/COMMERCIAL-TERMS.md
+++ b/COMMERCIAL-TERMS.md
@@ -13,9 +13,17 @@ is free only when expressly permitted by the Zeko Additional Use Grant.
 A commercial deployment license is required for:
 
 - Independent Production Deployments of protected Zeko protocol-layer code.
-- Agent Bundle Production Deployments.
+- Independent Agent Protocol Deployments.
 - Production deployments of protected protocol/product-layer code that are not
   covered by the Additional Free Uses in the Zeko Additional Use Grant.
+
+Using the Official Zeko Network or official Zeko-operated or Zeko-authorized
+Agent Protocol Bundle applications, services, APIs, relays, facilitators,
+verifiers, marketplaces, payment rails, authorization rails, coordination rails,
+or settlement endpoints does not require a separate commercial deployment
+license. Users and integrators may still pay the ordinary network, gas,
+transaction, bridge, prover, marketplace, service, or usage fees applicable to
+those official deployments.
 
 ## Production And Non-Production
 

--- a/COMMERCIAL-TERMS.md
+++ b/COMMERCIAL-TERMS.md
@@ -1,0 +1,57 @@
+# Zeko Commercial Terms
+
+This document summarizes the self-serve commercial deployment terms for
+protected Zeko protocol/product-layer code licensed under BUSL-1.1 with the
+Zeko Additional Use Grant. The controlling license terms are in `LICENSE` and
+`LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md`.
+
+## Commercial Trigger
+
+Non-production use is free under the Zeko Additional Use Grant. Production use
+is free only when expressly permitted by the Zeko Additional Use Grant.
+
+A commercial deployment license is required for:
+
+- Independent Production Deployments of protected Zeko protocol-layer code.
+- Agent Bundle Production Deployments.
+- Production deployments of protected protocol/product-layer code that are not
+  covered by the Additional Free Uses in the Zeko Additional Use Grant.
+
+## Production And Non-Production
+
+Production means deployment or operation on mainnet or in any
+production-equivalent environment involving real users, customer workflows, real
+assets, payment activity, revenue-generating activity, external third-party
+use, or production settlement.
+
+Non-production means local, devnet, testnet, staging, internal evaluation,
+research, audit, educational, demo, hackathon, or proof-of-concept use that
+does not involve real assets, customer workflows, paid services, external
+production users, or material interaction with mainnet state.
+
+A deployment is not non-production merely because it is labeled "testnet,"
+"pilot," "beta," "sandbox," "staging," or "proof of concept." A deployment is
+production if it uses, controls, settles, routes, verifies, authorizes, gates
+access to, or materially affects real assets, real payments, customer
+workflows, paid services, external users, or mainnet state on any Deployment
+Network.
+
+## Payment
+
+Commercial deployment fees are payable to Zeko Labs, Inc. or its successor or
+assigns.
+
+The self-serve commercial deployment fee is pro-rated for the first calendar
+year of a new production deployment. Fees renew annually on a calendar-year
+basis. Payment is due within the first 30 days of each calendar year, or within
+30 days after a new production deployment first goes live, whichever applies.
+
+For payment, billing, commercial licensing, ecosystem agreements, or other
+inquiries, contact partnerships@zeko.io.
+
+## Separate Commercial Services
+
+The self-serve commercial deployment license covers license rights only.
+Managed deployment, enterprise support, compliance review, SLAs, custom
+integrations, dedicated infrastructure, hosted services, and professional
+services are separate commercial services.

--- a/COMMERCIAL-TERMS.md
+++ b/COMMERCIAL-TERMS.md
@@ -1,25 +1,32 @@
 # Zeko Commercial Terms
 
 This document summarizes the self-serve commercial deployment terms for
-protected Zeko protocol-layer code licensed under BUSL-1.1 with the
-Zeko Additional Use Grant. The controlling license terms are in `LICENSE` and
-`LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md`.
+protected Zeko protocol-layer code and protected Agent Protocol Bundle repos or
+components that reference these terms. The controlling license terms are in
+`LICENSE` and `LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md`, or in the corresponding
+license files for the protected repo or component.
 
 ## Commercial Trigger
 
 Non-production use is free under the Zeko Additional Use Grant. Production use
 is free only when expressly permitted by the Zeko Additional Use Grant.
 
-A commercial deployment license is required for:
+The self-serve commercial deployment license covers production deployments
+outside the Additional Free Uses, including:
 
 - Independent Production Deployments of protected Zeko protocol-layer code.
+- Independent Agent Protocol Bundle production deployments.
 - Production deployments of protected Zeko protocol-layer code that are not
   covered by the Additional Free Uses in the Zeko Additional Use Grant.
 
-Using or building on the Official Zeko Network does not require a separate
+The current published self-serve fee is $0/year, subject to the pricing
+schedule in `PRICING.md`.
+
+Using or building on the Official Zeko Network or official Zeko-operated or
+Zeko-authorized Agent Protocol Bundle services does not require a separate
 commercial deployment license. Users and integrators may still pay the ordinary
-network, gas, transaction, bridge, prover, marketplace, service, or usage fees
-applicable to the official network and services.
+network, gas, transaction, bridge, prover, marketplace, service, usage, or
+similar fees applicable to the official network and services.
 
 ## Production And Non-Production
 
@@ -46,8 +53,8 @@ Commercial deployment fees, if any, are payable to Zeko Labs, Inc. or its
 successor or assigns.
 
 The current standard self-serve commercial deployment fee for Protocol Layer
-Production Deployments is $0/year per production rollup. No payment is due
-under the current pricing schedule.
+Production Deployments and Independent Agent Protocol Bundle production
+deployments is $0/year. No payment is due under the current pricing schedule.
 
 If Zeko Labs publishes a successor pricing schedule or separate written
 authorization with a non-zero fee, payment timing will be specified in that

--- a/COMMERCIAL-TERMS.md
+++ b/COMMERCIAL-TERMS.md
@@ -1,7 +1,7 @@
 # Zeko Commercial Terms
 
 This document summarizes the self-serve commercial deployment terms for
-protected Zeko protocol/product-layer code licensed under BUSL-1.1 with the
+protected Zeko protocol-layer code licensed under BUSL-1.1 with the
 Zeko Additional Use Grant. The controlling license terms are in `LICENSE` and
 `LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md`.
 
@@ -13,17 +13,13 @@ is free only when expressly permitted by the Zeko Additional Use Grant.
 A commercial deployment license is required for:
 
 - Independent Production Deployments of protected Zeko protocol-layer code.
-- Independent Agent Protocol Deployments.
-- Production deployments of protected protocol/product-layer code that are not
+- Production deployments of protected Zeko protocol-layer code that are not
   covered by the Additional Free Uses in the Zeko Additional Use Grant.
 
-Using the Official Zeko Network or official Zeko-operated or Zeko-authorized
-Agent Protocol Bundle applications, services, APIs, relays, facilitators,
-verifiers, marketplaces, payment rails, authorization rails, coordination rails,
-or settlement endpoints does not require a separate commercial deployment
-license. Users and integrators may still pay the ordinary network, gas,
-transaction, bridge, prover, marketplace, service, or usage fees applicable to
-those official deployments.
+Using or building on the Official Zeko Network does not require a separate
+commercial deployment license. Users and integrators may still pay the ordinary
+network, gas, transaction, bridge, prover, marketplace, service, or usage fees
+applicable to the official network and services.
 
 ## Production And Non-Production
 

--- a/COMMERCIAL-TERMS.md
+++ b/COMMERCIAL-TERMS.md
@@ -42,13 +42,16 @@ Network.
 
 ## Payment
 
-Commercial deployment fees are payable to Zeko Labs, Inc. or its successor or
-assigns.
+Commercial deployment fees, if any, are payable to Zeko Labs, Inc. or its
+successor or assigns.
 
-The self-serve commercial deployment fee is pro-rated for the first calendar
-year of a new production deployment. Fees renew annually on a calendar-year
-basis. Payment is due within the first 30 days of each calendar year, or within
-30 days after a new production deployment first goes live, whichever applies.
+The current standard self-serve commercial deployment fee for Protocol Layer
+Production Deployments is $0/year per production rollup. No payment is due
+under the current pricing schedule.
+
+If Zeko Labs publishes a successor pricing schedule or separate written
+authorization with a non-zero fee, payment timing will be specified in that
+successor schedule or written authorization.
 
 For payment, billing, commercial licensing, ecosystem agreements, or other
 inquiries, contact partnerships@zeko.io.

--- a/ECOSYSTEM-EXCEPTIONS.md
+++ b/ECOSYSTEM-EXCEPTIONS.md
@@ -1,0 +1,15 @@
+# Zeko Ecosystem Exceptions
+
+This file may list ecosystem-specific pricing, exemptions, expanded rights, or
+preferred terms published by Zeko Labs for a named ecosystem, Deployment
+Network, entity, scope, and effective date range.
+
+Unless an exception is expressly listed here, the standard Zeko Additional Use
+Grant, commercial terms, and pricing schedule apply.
+
+For ecosystem, foundation, enterprise, or partner terms, contact
+partnerships@zeko.io.
+
+## Published Exceptions
+
+No ecosystem exceptions are currently published.

--- a/LICENSES/APACHE-2.0.txt
+++ b/LICENSES/APACHE-2.0.txt
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2024. Mina Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSES/BUSL-1.1.txt
+++ b/LICENSES/BUSL-1.1.txt
@@ -1,0 +1,78 @@
+Business Source License 1.1
+
+License text copyright (c) 2024 MariaDB plc, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB plc.
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited production
+use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under the
+terms of the Change License, and the rights granted in the paragraph above
+terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works of
+the Licensed Work, are subject to this License. This License applies separately
+for each version of the Licensed Work and the Change Date may vary for each
+version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or modified
+form from a third party, the terms and conditions set forth in this License
+apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other versions
+of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of Licensor
+or its affiliates (provided that you may use a trademark or logo of Licensor as
+expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
+"AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
+OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+
+MariaDB hereby grants you permission to use this License's text to license your
+works, and to refer to it using the trademark "Business Source License", as
+long as you comply with the Covenants of Licensor below.
+
+Covenants of Licensor
+
+In consideration of the right to use this License's text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
+
+To specify as the Change License the GPL Version 2.0 or any later version, or a
+license that is compatible with GPL Version 2.0 or a later version, where
+"compatible" means that software provided under the Change License can be
+included in a program with software provided under GPL Version 2.0 or a later
+version. Licensor may specify additional Change Licenses without limitation.
+
+To either: (a) specify an additional grant of rights to use that does not
+impose any additional restriction on the right granted in this License, as the
+Additional Use Grant; or (b) insert the text "None".
+
+To specify a Change Date.
+
+Not to modify this License in any other way.
+
+Notice
+
+The Business Source License (this document, or the "License") is not an Open
+Source license. However, the Licensed Work will eventually be made available
+under an Open Source License, as stated in this License.
+
+For more information on the use of the Business Source License, please visit
+https://mariadb.com/bsl11/.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md
+++ b/LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md
@@ -1,0 +1,131 @@
+# Zeko Additional Use Grant
+
+This Zeko Additional Use Grant applies to the Licensed Work identified as
+subject to the Business Source License 1.1 and this Additional Use Grant.
+
+## 1. Additional Free Uses
+
+In addition to the non-production rights granted under the Business Source
+License 1.1, Zeko Labs grants you the right to use, copy, modify, distribute,
+and operate the Licensed Work for the following purposes:
+
+1. Development, testing, benchmarking, research, education, security review,
+   audit, internal evaluation, demonstrations, hackathons, local deployments,
+   devnet deployments, testnet deployments, staging deployments, and
+   proof-of-concept deployments.
+2. Building, deploying, operating, or interacting with applications, zkApps,
+   agents, wallets, indexers, relayers, dashboards, clients, contracts, bridges,
+   adapters, or settlement integrations that submit to, interoperate with, or
+   otherwise use the Official Zeko Network.
+3. Commercially operating applications that use the Official Zeko Network,
+   provided that you do not operate an Independent Production Deployment of the
+   Licensed Work.
+4. Operating infrastructure as an authorized participant, operator, prover,
+   sequencer, validator, relayer, settlement operator, or service provider for
+   the Official Zeko Network, where such role has been approved, authorized, or
+   designated by Zeko Labs or the applicable Zeko governance process.
+5. Using any file, package, directory, SDK, specification, example, interface,
+   ABI, documentation, test vector, or template that is expressly marked as
+   licensed under Apache-2.0, MIT, or another permissive license, subject to
+   that separate license.
+
+## 2. Commercial Deployment License Required
+
+Except as expressly permitted above, a commercial deployment license is required
+for:
+
+1. an Independent Production Deployment of the Zeko protocol layer;
+2. an Agent Bundle Production Deployment; or
+3. any other production deployment of protected protocol/product-layer code that
+   is not covered by the Additional Free Uses above.
+
+Commercial deployment fees are payable to Zeko Labs, Inc. or its successor or
+assigns. For payment, billing, commercial licensing, ecosystem agreements, or
+other inquiries, contact partnerships@zeko.io.
+
+## 3. Definitions
+
+### Official Zeko Network
+
+Official Zeko Network means any Zeko network, rollup lane, prover network,
+sequencer network, settlement endpoint, bridge, or related infrastructure
+operated by Zeko Labs, authorized by Zeko Labs, or designated by the applicable
+Zeko governance process as part of the official Zeko ecosystem.
+
+### Independent Production Deployment
+
+Independent Production Deployment means a production deployment or operation of
+the Licensed Work, or a modified version or derivative work of the Licensed
+Work, outside the Official Zeko Network.
+
+Independent Production Deployments include production rollups, sovereign
+rollups, appchains, L2s, L3s, sequencer networks, prover networks, settlement
+networks, hosted proof services, bridges, protocol deployments, or substantially
+similar production infrastructure using protected Zeko protocol-layer code.
+
+### Agent Bundle
+
+Agent Bundle means the protected Zeko product/protocol components for
+agent-native coordination, authorization, payments, and commerce, including
+SantaClawz, ZK x402, Mission-Bound Auth, Magic City when designated by Zeko
+Labs, and related protected orchestration, verifier, authorization, payment,
+settlement, and coordination components.
+
+### Agent Bundle Production Deployment
+
+Agent Bundle Production Deployment means a production deployment or operation
+of one or more protected Agent Bundle components, or modified versions or
+derivative works of those components, by or on behalf of a legal entity on a
+Deployment Network.
+
+The Agent Bundle fee applies only to production deployment or operation of
+protected Agent Bundle code, or modified versions or derivative works of that
+code. It does not apply to independently developed implementations that do not
+copy, modify, derive from, or substantially incorporate protected Agent Bundle
+code, even if they implement similar concepts, protocols, or workflows.
+
+### Deployment Network
+
+Deployment Network means any L1, L2, L3, sovereign rollup, appchain,
+application-specific chain, private or permissioned network, synchronizer,
+domain, settlement environment, execution environment, or substantially similar
+production execution or settlement environment.
+
+### Production
+
+Production means deployment or operation on mainnet or in any
+production-equivalent environment involving real users, customer workflows, real
+assets, payment activity, revenue-generating activity, external third-party
+use, or production settlement.
+
+A deployment is not non-production merely because it is labeled "testnet,"
+"pilot," "beta," "sandbox," "staging," or "proof of concept." A deployment is
+production if it uses, controls, settles, routes, verifies, authorizes, gates
+access to, or materially affects real assets, real payments, customer
+workflows, paid services, external users, or mainnet state on any Deployment
+Network.
+
+### Non-Production
+
+Non-Production means local, devnet, testnet, staging, internal evaluation,
+research, audit, educational, demo, hackathon, or proof-of-concept use that
+does not involve real assets, customer workflows, paid services, external
+production users, or material interaction with mainnet state.
+
+## 4. No Trademark Rights
+
+This Additional Use Grant does not grant any right to use the names, logos, or
+trademarks of Zeko Labs, Zeko, SantaClawz, Magic City, or any related brand,
+except as separately authorized in writing.
+
+## 5. Separate Commercial Services
+
+The self-serve commercial deployment license covers license rights only.
+Managed deployment, enterprise support, compliance review, SLAs, custom
+integrations, dedicated infrastructure, hosted services, and professional
+services are separate commercial services.
+
+## 6. Separate Licenses Control
+
+If a file, package, directory, or component contains a separate license notice,
+that notice controls for that file, package, directory, or component.

--- a/LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md
+++ b/LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md
@@ -15,19 +15,31 @@ and operate the Licensed Work for the following purposes:
    proof-of-concept deployments.
 2. Building, deploying, operating, or interacting with applications, zkApps,
    agents, wallets, indexers, relayers, dashboards, clients, contracts, bridges,
-   adapters, or settlement integrations that submit to, interoperate with, or
-   otherwise use the Official Zeko Network.
-3. Commercially operating applications that use the Official Zeko Network,
+   SDKs, adapters, connectors, workflows, or settlement integrations that submit
+   to, interoperate with, or otherwise use the Official Zeko Network or an
+   Official Agent Protocol Deployment.
+3. Commercially operating applications, agents, workflows, or integrations that
+   use the Official Zeko Network or an Official Agent Protocol Deployment,
    provided that you do not operate an Independent Production Deployment of the
-   Licensed Work.
+   Licensed Work or an Independent Agent Protocol Deployment.
 4. Operating infrastructure as an authorized participant, operator, prover,
    sequencer, validator, relayer, settlement operator, or service provider for
    the Official Zeko Network, where such role has been approved, authorized, or
    designated by Zeko Labs or the applicable Zeko governance process.
-5. Using any file, package, directory, SDK, specification, example, interface,
+5. Using official hosted or public Zeko applications, services, APIs, relays,
+   facilitators, verifiers, marketplaces, payment rails, authorization rails,
+   coordination rails, or settlement endpoints powered by an Official Agent
+   Protocol Deployment.
+6. Using any file, package, directory, SDK, specification, example, interface,
    ABI, documentation, test vector, or template that is expressly marked as
    licensed under Apache-2.0, MIT, or another permissive license, subject to
    that separate license.
+
+These Additional Free Uses do not waive ordinary network, gas, transaction,
+bridge, prover, marketplace, service, or usage fees charged by the Official
+Zeko Network or Official Agent Protocol Deployments. They only clarify that no
+separate commercial deployment license is required for that official-network or
+official-service use.
 
 ## 2. Commercial Deployment License Required
 
@@ -35,7 +47,7 @@ Except as expressly permitted above, a commercial deployment license is required
 for:
 
 1. an Independent Production Deployment of the Zeko protocol layer;
-2. an Agent Bundle Production Deployment; or
+2. an Independent Agent Protocol Deployment; or
 3. any other production deployment of protected protocol/product-layer code that
    is not covered by the Additional Free Uses above.
 
@@ -63,26 +75,40 @@ rollups, appchains, L2s, L3s, sequencer networks, prover networks, settlement
 networks, hosted proof services, bridges, protocol deployments, or substantially
 similar production infrastructure using protected Zeko protocol-layer code.
 
-### Agent Bundle
+### Agent Protocol Bundle
 
-Agent Bundle means the protected Zeko product/protocol components for
+Agent Protocol Bundle means the protected Zeko product/protocol components for
 agent-native coordination, authorization, payments, and commerce, including
 SantaClawz, ZK x402, Mission-Bound Auth, Magic City when designated by Zeko
 Labs, and related protected orchestration, verifier, authorization, payment,
-settlement, and coordination components.
+settlement, coordination, marketplace, relay, facilitator, application, API, and
+service components.
 
-### Agent Bundle Production Deployment
+### Official Agent Protocol Deployment
 
-Agent Bundle Production Deployment means a production deployment or operation
-of one or more protected Agent Bundle components, or modified versions or
-derivative works of those components, by or on behalf of a legal entity on a
-Deployment Network.
+Official Agent Protocol Deployment means any Agent Protocol Bundle deployment,
+hosted service, application, API, relay, verifier, facilitator, marketplace,
+authorization layer, payment layer, coordination layer, settlement endpoint, or
+related infrastructure operated by Zeko Labs, authorized by Zeko Labs, or
+designated by the applicable Zeko governance process as part of the official
+Zeko ecosystem.
 
-The Agent Bundle fee applies only to production deployment or operation of
-protected Agent Bundle code, or modified versions or derivative works of that
-code. It does not apply to independently developed implementations that do not
-copy, modify, derive from, or substantially incorporate protected Agent Bundle
-code, even if they implement similar concepts, protocols, or workflows.
+### Independent Agent Protocol Deployment
+
+Independent Agent Protocol Deployment means a production deployment or operation
+of one or more protected Agent Protocol Bundle components, or modified versions
+or derivative works of those components, by or on behalf of a legal entity on a
+Deployment Network, outside an Official Agent Protocol Deployment.
+
+The Agent Protocol Bundle fee applies only to production deployment or operation
+of protected Agent Protocol Bundle code, or modified versions or derivative
+works of that code, outside an Official Agent Protocol Deployment. It does not
+apply to use of official Zeko-operated or Zeko-authorized applications,
+services, APIs, relays, facilitators, verifiers, marketplaces, payment rails,
+authorization rails, coordination rails, or settlement endpoints. It also does
+not apply to independently developed implementations that do not copy, modify,
+derive from, or substantially incorporate protected Agent Protocol Bundle code,
+even if they implement similar concepts, protocols, or workflows.
 
 ### Deployment Network
 

--- a/LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md
+++ b/LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md
@@ -16,32 +16,43 @@ and operate the Licensed Work for the following purposes:
 2. Building, deploying, operating, or interacting with applications, zkApps,
    agents, wallets, indexers, relayers, dashboards, clients, contracts, bridges,
    SDKs, adapters, connectors, workflows, or settlement integrations that submit
-   to, interoperate with, or otherwise use the Official Zeko Network.
+   to, interoperate with, or otherwise use the Official Zeko Network or an
+   Official Agent Protocol Deployment.
 3. Commercially operating applications, agents, workflows, or integrations that
-   use the Official Zeko Network, provided that you do not operate an
-   Independent Production Deployment of the Licensed Work.
+   use the Official Zeko Network or an Official Agent Protocol Deployment,
+   provided that you do not operate an Independent Production Deployment of the
+   Licensed Work or an Independent Agent Protocol Bundle production deployment.
 4. Operating infrastructure as an authorized participant, operator, prover,
    sequencer, validator, relayer, settlement operator, or service provider for
    the Official Zeko Network, where such role has been approved, authorized, or
    designated by Zeko Labs or the applicable Zeko governance process.
-5. Using any file, package, directory, SDK, specification, example, interface,
+5. Using official hosted or public Zeko applications, services, APIs, relays,
+   facilitators, verifiers, marketplaces, payment rails, authorization rails,
+   coordination rails, or settlement endpoints powered by an Official Agent
+   Protocol Deployment.
+6. Using any file, package, directory, SDK, specification, example, interface,
    ABI, documentation, test vector, or template that is expressly marked as
    licensed under Apache-2.0, MIT, or another permissive license, subject to
    that separate license.
 
 These Additional Free Uses do not waive ordinary network, gas, transaction,
 bridge, prover, marketplace, service, or usage fees charged by the Official
-Zeko Network. They only clarify that no separate commercial deployment license
-is required for that official-network use.
+Zeko Network or Official Agent Protocol Deployments. They only clarify that no
+separate commercial deployment license is required for that official-network or
+official-service use.
 
-## 2. Commercial Deployment License Required
+## 2. Commercial Deployment License Coverage
 
-Except as expressly permitted above, a commercial deployment license is required
-for:
+Except as expressly permitted above, the following production deployments are
+covered by the self-serve commercial deployment license:
 
 1. an Independent Production Deployment of the Zeko protocol layer;
-2. any other production deployment of protected Zeko protocol-layer code that
+2. an Independent Agent Protocol Bundle production deployment; or
+3. any other production deployment of protected protocol/product-layer code that
    is not covered by the Additional Free Uses above.
+
+The current published self-serve fee is $0/year, subject to the pricing
+schedule in `PRICING.md`.
 
 Commercial deployment fees, if any, are payable to Zeko Labs, Inc. or its
 successor or assigns. For payment, billing, commercial licensing, ecosystem
@@ -66,6 +77,43 @@ Independent Production Deployments include production rollups, sovereign
 rollups, appchains, L2s, L3s, sequencer networks, prover networks, settlement
 networks, hosted proof services, bridges, protocol deployments, or substantially
 similar production infrastructure using protected Zeko protocol-layer code.
+
+### Agent Protocol Bundle
+
+Agent Protocol Bundle means the protected Zeko product/protocol components for
+agent-native coordination, authorization, payments, and commerce, including
+SantaClawz, ZK x402, Mission-Bound Auth, Magic City when designated by Zeko
+Labs, and related protected orchestration, verifier, authorization, payment,
+settlement, coordination, marketplace, relay, facilitator, application, API, and
+service components.
+
+### Official Agent Protocol Deployment
+
+Official Agent Protocol Deployment means any Agent Protocol Bundle deployment,
+hosted service, application, API, relay, verifier, facilitator, marketplace,
+authorization layer, payment layer, coordination layer, settlement endpoint, or
+related infrastructure operated by Zeko Labs, authorized by Zeko Labs, or
+designated by the applicable Zeko governance process as part of the official
+Zeko ecosystem.
+
+### Independent Agent Protocol Bundle Production Deployment
+
+Independent Agent Protocol Bundle production deployment means a production
+deployment or operation of one or more protected Agent Protocol Bundle
+components, or modified versions or derivative works of those components, by or
+on behalf of a legal entity on a Deployment Network, outside an Official Agent
+Protocol Deployment.
+
+Independent Agent Protocol Bundle production deployments are covered by the
+self-serve commercial deployment license. The current published self-serve fee
+is $0/year, subject to the pricing schedule in `PRICING.md`.
+
+This does not apply to use of official Zeko-operated or Zeko-authorized
+applications, services, APIs, relays, facilitators, verifiers, marketplaces,
+payment rails, authorization rails, coordination rails, or settlement endpoints.
+It also does not apply to independently developed implementations that do not
+copy, modify, derive from, or substantially incorporate protected Agent Protocol
+Bundle code, even if they implement similar concepts, protocols, or workflows.
 
 ### Deployment Network
 
@@ -98,8 +146,8 @@ production users, or material interaction with mainnet state.
 ## 4. No Trademark Rights
 
 This Additional Use Grant does not grant any right to use the names, logos, or
-trademarks of Zeko Labs, Zeko, or any related brand, except as separately
-authorized in writing.
+trademarks of Zeko Labs, Zeko, SantaClawz, Magic City, or any related brand,
+except as separately authorized in writing.
 
 ## 5. Separate Commercial Services
 

--- a/LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md
+++ b/LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md
@@ -43,9 +43,9 @@ for:
 2. any other production deployment of protected Zeko protocol-layer code that
    is not covered by the Additional Free Uses above.
 
-Commercial deployment fees are payable to Zeko Labs, Inc. or its successor or
-assigns. For payment, billing, commercial licensing, ecosystem agreements, or
-other inquiries, contact partnerships@zeko.io.
+Commercial deployment fees, if any, are payable to Zeko Labs, Inc. or its
+successor or assigns. For payment, billing, commercial licensing, ecosystem
+agreements, or other inquiries, contact partnerships@zeko.io.
 
 ## 3. Definitions
 

--- a/LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md
+++ b/LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md
@@ -16,30 +16,23 @@ and operate the Licensed Work for the following purposes:
 2. Building, deploying, operating, or interacting with applications, zkApps,
    agents, wallets, indexers, relayers, dashboards, clients, contracts, bridges,
    SDKs, adapters, connectors, workflows, or settlement integrations that submit
-   to, interoperate with, or otherwise use the Official Zeko Network or an
-   Official Agent Protocol Deployment.
+   to, interoperate with, or otherwise use the Official Zeko Network.
 3. Commercially operating applications, agents, workflows, or integrations that
-   use the Official Zeko Network or an Official Agent Protocol Deployment,
-   provided that you do not operate an Independent Production Deployment of the
-   Licensed Work or an Independent Agent Protocol Deployment.
+   use the Official Zeko Network, provided that you do not operate an
+   Independent Production Deployment of the Licensed Work.
 4. Operating infrastructure as an authorized participant, operator, prover,
    sequencer, validator, relayer, settlement operator, or service provider for
    the Official Zeko Network, where such role has been approved, authorized, or
    designated by Zeko Labs or the applicable Zeko governance process.
-5. Using official hosted or public Zeko applications, services, APIs, relays,
-   facilitators, verifiers, marketplaces, payment rails, authorization rails,
-   coordination rails, or settlement endpoints powered by an Official Agent
-   Protocol Deployment.
-6. Using any file, package, directory, SDK, specification, example, interface,
+5. Using any file, package, directory, SDK, specification, example, interface,
    ABI, documentation, test vector, or template that is expressly marked as
    licensed under Apache-2.0, MIT, or another permissive license, subject to
    that separate license.
 
 These Additional Free Uses do not waive ordinary network, gas, transaction,
 bridge, prover, marketplace, service, or usage fees charged by the Official
-Zeko Network or Official Agent Protocol Deployments. They only clarify that no
-separate commercial deployment license is required for that official-network or
-official-service use.
+Zeko Network. They only clarify that no separate commercial deployment license
+is required for that official-network use.
 
 ## 2. Commercial Deployment License Required
 
@@ -47,8 +40,7 @@ Except as expressly permitted above, a commercial deployment license is required
 for:
 
 1. an Independent Production Deployment of the Zeko protocol layer;
-2. an Independent Agent Protocol Deployment; or
-3. any other production deployment of protected protocol/product-layer code that
+2. any other production deployment of protected Zeko protocol-layer code that
    is not covered by the Additional Free Uses above.
 
 Commercial deployment fees are payable to Zeko Labs, Inc. or its successor or
@@ -74,41 +66,6 @@ Independent Production Deployments include production rollups, sovereign
 rollups, appchains, L2s, L3s, sequencer networks, prover networks, settlement
 networks, hosted proof services, bridges, protocol deployments, or substantially
 similar production infrastructure using protected Zeko protocol-layer code.
-
-### Agent Protocol Bundle
-
-Agent Protocol Bundle means the protected Zeko product/protocol components for
-agent-native coordination, authorization, payments, and commerce, including
-SantaClawz, ZK x402, Mission-Bound Auth, Magic City when designated by Zeko
-Labs, and related protected orchestration, verifier, authorization, payment,
-settlement, coordination, marketplace, relay, facilitator, application, API, and
-service components.
-
-### Official Agent Protocol Deployment
-
-Official Agent Protocol Deployment means any Agent Protocol Bundle deployment,
-hosted service, application, API, relay, verifier, facilitator, marketplace,
-authorization layer, payment layer, coordination layer, settlement endpoint, or
-related infrastructure operated by Zeko Labs, authorized by Zeko Labs, or
-designated by the applicable Zeko governance process as part of the official
-Zeko ecosystem.
-
-### Independent Agent Protocol Deployment
-
-Independent Agent Protocol Deployment means a production deployment or operation
-of one or more protected Agent Protocol Bundle components, or modified versions
-or derivative works of those components, by or on behalf of a legal entity on a
-Deployment Network, outside an Official Agent Protocol Deployment.
-
-The Agent Protocol Bundle fee applies only to production deployment or operation
-of protected Agent Protocol Bundle code, or modified versions or derivative
-works of that code, outside an Official Agent Protocol Deployment. It does not
-apply to use of official Zeko-operated or Zeko-authorized applications,
-services, APIs, relays, facilitators, verifiers, marketplaces, payment rails,
-authorization rails, coordination rails, or settlement endpoints. It also does
-not apply to independently developed implementations that do not copy, modify,
-derive from, or substantially incorporate protected Agent Protocol Bundle code,
-even if they implement similar concepts, protocols, or workflows.
 
 ### Deployment Network
 
@@ -141,8 +98,8 @@ production users, or material interaction with mainnet state.
 ## 4. No Trademark Rights
 
 This Additional Use Grant does not grant any right to use the names, logos, or
-trademarks of Zeko Labs, Zeko, SantaClawz, Magic City, or any related brand,
-except as separately authorized in writing.
+trademarks of Zeko Labs, Zeko, or any related brand, except as separately
+authorized in writing.
 
 ## 5. Separate Commercial Services
 

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,27 @@
+# Licensing
+
+This repository is a fork of the Mina codebase and contains code under multiple
+licenses.
+
+Original Mina-derived code remains under its existing Apache-2.0 license. The
+root [LICENSE](./LICENSE) continues to apply to that upstream-derived code.
+
+Zeko-owned protocol-layer code under [src/app/zeko](./src/app/zeko) is licensed
+under BUSL-1.1 with the Zeko Additional Use Grant. The current Change Date is
+2030-07-17, and the Change License is Apache License, Version 2.0.
+
+Adoption-layer materials may be licensed under Apache-2.0 or MIT where
+expressly marked. This includes files, packages, directories, SDK interfaces,
+specifications, examples, documentation, schemas, test vectors, templates, or
+third-party components that contain a separate license notice.
+
+If a file, package, or directory has a more specific license notice, that
+notice controls. Otherwise, Zeko-owned protocol/product-layer code under
+[src/app/zeko](./src/app/zeko) is governed by
+[src/app/zeko/LICENSE.md](./src/app/zeko/LICENSE.md) and the Zeko Additional Use
+Grant in [LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md](./LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md).
+
+Commercial deployment pricing is published in [PRICING.md](./PRICING.md).
+Commercial terms are summarized in [COMMERCIAL-TERMS.md](./COMMERCIAL-TERMS.md).
+Published ecosystem exceptions, if any, are listed in
+[ECOSYSTEM-EXCEPTIONS.md](./ECOSYSTEM-EXCEPTIONS.md).

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,7 @@
+Zeko
+Copyright (c) Zeko Labs, Inc. All rights reserved.
+
+This repository may include Zeko-owned source-available components licensed
+under BUSL-1.1 with the Zeko Additional Use Grant, permissively licensed
+adoption-layer materials, and third-party or upstream-derived components under
+their original licenses.

--- a/PRICING.md
+++ b/PRICING.md
@@ -1,0 +1,47 @@
+# Zeko Self-Serve Commercial Deployment Pricing
+
+This pricing schedule applies to protected Zeko protocol/product-layer code
+licensed under BUSL-1.1 with the Zeko Additional Use Grant, unless a more
+specific pricing schedule, ecosystem exception, or written authorization applies.
+
+## Protocol Layer Production Deployments
+
+- 1-10 production rollups: $1,000/year per production rollup.
+- 11+ production rollups: custom pricing available by contacting
+  partnerships@zeko.io.
+
+A production rollup includes each production L2, L3, sovereign rollup,
+appchain, application-specific chain, or substantially similar production
+rollup deployment using protected Zeko protocol-layer code. This applies
+whether those rollups settle to the same settlement layer, different settlement
+layers, or are structured as L3s on top of a Zeko L2.
+
+## Agent Bundle Production Deployments
+
+- $1,000/year per deploying legal entity per Deployment Network.
+- Custom ecosystem, foundation, or enterprise pricing available by contacting
+  partnerships@zeko.io.
+
+If one legal entity deploys one or more Agent Bundle components on one
+Deployment Network, the fee is $1,000/year for that Deployment Network. If the
+same legal entity deploys the Agent Bundle on five Deployment Networks, the fee
+is $5,000/year. Separate legal entities operating separate production
+deployments each require their own commercial deployment license.
+
+## Payment Timing
+
+The self-serve commercial deployment fee is pro-rated for the first calendar
+year of a new production deployment. Fees renew annually on a calendar-year
+basis. Payment is due to Zeko Labs, Inc. or its successor or assigns within the
+first 30 days of each calendar year, or within 30 days after a new production
+deployment first goes live, whichever applies.
+
+For payment, billing, commercial licensing, ecosystem agreements, or other
+inquiries, contact partnerships@zeko.io.
+
+## License Rights Only
+
+The self-serve commercial deployment license covers license rights only.
+Managed deployment, enterprise support, compliance review, SLAs, custom
+integrations, dedicated infrastructure, hosted services, and professional
+services are separate commercial services.

--- a/PRICING.md
+++ b/PRICING.md
@@ -16,17 +16,26 @@ rollup deployment using protected Zeko protocol-layer code. This applies
 whether those rollups settle to the same settlement layer, different settlement
 layers, or are structured as L3s on top of a Zeko L2.
 
-## Agent Bundle Production Deployments
+## Independent Agent Protocol Deployments
 
 - $1,000/year per deploying legal entity per Deployment Network.
 - Custom ecosystem, foundation, or enterprise pricing available by contacting
   partnerships@zeko.io.
 
-If one legal entity deploys one or more Agent Bundle components on one
-Deployment Network, the fee is $1,000/year for that Deployment Network. If the
-same legal entity deploys the Agent Bundle on five Deployment Networks, the fee
-is $5,000/year. Separate legal entities operating separate production
+If one legal entity independently deploys one or more protected Agent Protocol
+Bundle components on one Deployment Network outside an Official Agent Protocol
+Deployment, the fee is $1,000/year for that Deployment Network. If the same
+legal entity deploys the Agent Protocol Bundle on five Deployment Networks, the
+fee is $5,000/year. Separate legal entities operating separate production
 deployments each require their own commercial deployment license.
+
+Using official Zeko-operated or Zeko-authorized Agent Protocol Bundle
+applications, services, APIs, relays, facilitators, verifiers, marketplaces,
+payment rails, authorization rails, coordination rails, or settlement endpoints
+does not require a separate commercial deployment license. Users and
+integrators may still pay the ordinary service, usage, transaction, marketplace,
+network, gas, prover, bridge, or other fees applicable to those official
+deployments.
 
 ## Payment Timing
 

--- a/PRICING.md
+++ b/PRICING.md
@@ -1,6 +1,6 @@
 # Zeko Self-Serve Commercial Deployment Pricing
 
-This pricing schedule applies to protected Zeko protocol/product-layer code
+This pricing schedule applies to protected Zeko protocol-layer code
 licensed under BUSL-1.1 with the Zeko Additional Use Grant, unless a more
 specific pricing schedule, ecosystem exception, or written authorization applies.
 
@@ -15,27 +15,6 @@ appchain, application-specific chain, or substantially similar production
 rollup deployment using protected Zeko protocol-layer code. This applies
 whether those rollups settle to the same settlement layer, different settlement
 layers, or are structured as L3s on top of a Zeko L2.
-
-## Independent Agent Protocol Deployments
-
-- $1,000/year per deploying legal entity per Deployment Network.
-- Custom ecosystem, foundation, or enterprise pricing available by contacting
-  partnerships@zeko.io.
-
-If one legal entity independently deploys one or more protected Agent Protocol
-Bundle components on one Deployment Network outside an Official Agent Protocol
-Deployment, the fee is $1,000/year for that Deployment Network. If the same
-legal entity deploys the Agent Protocol Bundle on five Deployment Networks, the
-fee is $5,000/year. Separate legal entities operating separate production
-deployments each require their own commercial deployment license.
-
-Using official Zeko-operated or Zeko-authorized Agent Protocol Bundle
-applications, services, APIs, relays, facilitators, verifiers, marketplaces,
-payment rails, authorization rails, coordination rails, or settlement endpoints
-does not require a separate commercial deployment license. Users and
-integrators may still pay the ordinary service, usage, transaction, marketplace,
-network, gas, prover, bridge, or other fees applicable to those official
-deployments.
 
 ## Payment Timing
 

--- a/PRICING.md
+++ b/PRICING.md
@@ -6,9 +6,7 @@ specific pricing schedule, ecosystem exception, or written authorization applies
 
 ## Protocol Layer Production Deployments
 
-- 1-10 production rollups: $1,000/year per production rollup.
-- 11+ production rollups: custom pricing available by contacting
-  partnerships@zeko.io.
+- Current standard self-serve fee: $0/year per production rollup.
 
 A production rollup includes each production L2, L3, sovereign rollup,
 appchain, application-specific chain, or substantially similar production
@@ -18,11 +16,12 @@ layers, or are structured as L3s on top of a Zeko L2.
 
 ## Payment Timing
 
-The self-serve commercial deployment fee is pro-rated for the first calendar
-year of a new production deployment. Fees renew annually on a calendar-year
-basis. Payment is due to Zeko Labs, Inc. or its successor or assigns within the
-first 30 days of each calendar year, or within 30 days after a new production
-deployment first goes live, whichever applies.
+Because the current standard self-serve fee is $0/year, no payment is due under
+this pricing schedule.
+
+If Zeko Labs publishes a successor pricing schedule or separate written
+authorization with a non-zero fee, payment timing will be specified in that
+successor schedule or written authorization.
 
 For payment, billing, commercial licensing, ecosystem agreements, or other
 inquiries, contact partnerships@zeko.io.

--- a/PRICING.md
+++ b/PRICING.md
@@ -1,8 +1,9 @@
 # Zeko Self-Serve Commercial Deployment Pricing
 
-This pricing schedule applies to protected Zeko protocol-layer code
-licensed under BUSL-1.1 with the Zeko Additional Use Grant, unless a more
-specific pricing schedule, ecosystem exception, or written authorization applies.
+This pricing schedule applies to protected Zeko protocol-layer code and
+protected Agent Protocol Bundle repos or components that reference this
+schedule, unless a more specific pricing schedule, ecosystem exception, or
+written authorization applies.
 
 ## Protocol Layer Production Deployments
 
@@ -13,6 +14,26 @@ appchain, application-specific chain, or substantially similar production
 rollup deployment using protected Zeko protocol-layer code. This applies
 whether those rollups settle to the same settlement layer, different settlement
 layers, or are structured as L3s on top of a Zeko L2.
+
+## Independent Agent Protocol Bundle Production Deployments
+
+Independent Agent Protocol Bundle production deployments are covered by the
+self-serve commercial deployment license. The current published self-serve fee
+is $0/year, subject to this pricing schedule.
+
+- Current standard self-serve fee: $0/year per deploying legal entity per
+  Deployment Network.
+
+If one legal entity independently deploys one or more protected Agent Protocol
+Bundle components on one Deployment Network outside an Official Agent Protocol
+Deployment, the current standard self-serve fee is $0/year for that Deployment
+Network. Separate legal entities operating separate production deployments are
+each covered by their own self-serve commercial deployment license.
+
+Current self-serve pricing is subject to change by a successor pricing schedule,
+ecosystem exception, enterprise agreement, foundation agreement, or other
+written authorization published or approved by Zeko Labs. Any successor pricing
+applies as stated in that successor schedule or written authorization.
 
 ## Payment Timing
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,17 @@ is free under the Additional Use Grant. Independent Production Deployments of
 the Zeko protocol layer require the self-serve commercial deployment license
 unless an Additional Free Use applies.
 
+Using the Official Zeko Network or official Zeko-operated or Zeko-authorized
+Agent Protocol Bundle services does not require a separate commercial
+deployment license; users and integrators pay the ordinary network, service,
+usage, transaction, marketplace, gas, prover, bridge, or similar fees applicable
+to those official deployments.
+
 Standard self-serve pricing is published in [PRICING.md](./PRICING.md):
 
 - Protocol Layer Production Deployments: $1,000/year per production rollup for
   1-10 production rollups; 11+ production rollups use custom pricing.
-- Agent Bundle Production Deployments: $1,000/year per deploying legal entity
+- Independent Agent Protocol Deployments: $1,000/year per deploying legal entity
   per Deployment Network.
 
 The self-serve commercial deployment license covers license rights only.

--- a/README.md
+++ b/README.md
@@ -6,5 +6,30 @@ We support recursion in smart contracts natively. Ethereum deployment is under d
 This repository is a fork of the [Mina codebase](https://github.com/MinaProtocol/mina).
 The Zeko related code is in the [`zeko`](./src/app/zeko) directory.
 
-The license for code under the `zeko` subdirectory is [custom](./src/app/zeko/LICENSE.md)
-though it will be soon updated to the same Apache license at the root of the repository.
+## Licensing And Commercial Terms
+
+Original Mina-derived code remains under the Apache License, Version 2.0, at
+the root of this repository. Zeko-owned protocol-layer code under
+[`src/app/zeko`](./src/app/zeko) is licensed under BUSL-1.1 with the Zeko
+Additional Use Grant.
+
+The current Change Date for Zeko-owned protocol-layer code is 2030-07-17, and
+the Change License is Apache License, Version 2.0. Non-production/testnet use
+is free under the Additional Use Grant. Independent Production Deployments of
+the Zeko protocol layer require the self-serve commercial deployment license
+unless an Additional Free Use applies.
+
+Standard self-serve pricing is published in [PRICING.md](./PRICING.md):
+
+- Protocol Layer Production Deployments: $1,000/year per production rollup for
+  1-10 production rollups; 11+ production rollups use custom pricing.
+- Agent Bundle Production Deployments: $1,000/year per deploying legal entity
+  per Deployment Network.
+
+The self-serve commercial deployment license covers license rights only.
+Managed deployment, enterprise support, compliance review, SLAs, custom
+integrations, and dedicated infrastructure are separate commercial services.
+
+See [LICENSING.md](./LICENSING.md), [src/app/zeko/LICENSE.md](./src/app/zeko/LICENSE.md),
+[LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md](./LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md),
+[COMMERCIAL-TERMS.md](./COMMERCIAL-TERMS.md), and [PRICING.md](./PRICING.md).

--- a/README.md
+++ b/README.md
@@ -19,18 +19,15 @@ is free under the Additional Use Grant. Independent Production Deployments of
 the Zeko protocol layer require the self-serve commercial deployment license
 unless an Additional Free Use applies.
 
-Using the Official Zeko Network or official Zeko-operated or Zeko-authorized
-Agent Protocol Bundle services does not require a separate commercial
-deployment license; users and integrators pay the ordinary network, service,
-usage, transaction, marketplace, gas, prover, bridge, or similar fees applicable
-to those official deployments.
+Using or building on the Official Zeko Network does not require a separate
+commercial deployment license; users and integrators pay the ordinary network,
+gas, transaction, prover, bridge, service, or usage fees applicable to the
+official network and services.
 
 Standard self-serve pricing is published in [PRICING.md](./PRICING.md):
 
 - Protocol Layer Production Deployments: $1,000/year per production rollup for
   1-10 production rollups; 11+ production rollups use custom pricing.
-- Independent Agent Protocol Deployments: $1,000/year per deploying legal entity
-  per Deployment Network.
 
 The self-serve commercial deployment license covers license rights only.
 Managed deployment, enterprise support, compliance review, SLAs, custom

--- a/README.md
+++ b/README.md
@@ -19,15 +19,29 @@ is free under the Additional Use Grant. Independent Production Deployments of
 the Zeko protocol layer require the self-serve commercial deployment license
 unless an Additional Free Use applies.
 
-Using or building on the Official Zeko Network does not require a separate
+This repository also publishes the shared self-serve framework used by protected
+Zeko Agent Protocol Bundle repos and components that reference these terms.
+Independent Agent Protocol Bundle production deployments are covered by the
+self-serve commercial deployment license. The current published self-serve fee
+is $0/year, subject to the pricing schedule in [PRICING.md](./PRICING.md).
+
+Using or building on the Official Zeko Network or official Zeko-operated or
+Zeko-authorized Agent Protocol Bundle services does not require a separate
 commercial deployment license; users and integrators pay the ordinary network,
-gas, transaction, prover, bridge, service, or usage fees applicable to the
-official network and services.
+gas, transaction, prover, bridge, service, usage, marketplace, or similar fees
+applicable to the official network and services.
 
 Standard self-serve pricing is published in [PRICING.md](./PRICING.md):
 
 - Protocol Layer Production Deployments: $0/year per production rollup under
   the current published self-serve pricing.
+- Independent Agent Protocol Bundle Production Deployments: $0/year per
+  deploying legal entity per Deployment Network under the current published
+  self-serve pricing.
+
+Current self-serve pricing is subject to change by a successor pricing schedule,
+ecosystem exception, enterprise agreement, foundation agreement, or other
+written authorization published or approved by Zeko Labs.
 
 The self-serve commercial deployment license covers license rights only.
 Managed deployment, enterprise support, compliance review, SLAs, custom

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ official network and services.
 
 Standard self-serve pricing is published in [PRICING.md](./PRICING.md):
 
-- Protocol Layer Production Deployments: $1,000/year per production rollup for
-  1-10 production rollups; 11+ production rollups use custom pricing.
+- Protocol Layer Production Deployments: $0/year per production rollup under
+  the current published self-serve pricing.
 
 The self-serve commercial deployment license covers license rights only.
 Managed deployment, enterprise support, compliance review, SLAs, custom

--- a/src/app/zeko/LICENSE.md
+++ b/src/app/zeko/LICENSE.md
@@ -1,179 +1,24 @@
-\--------------------README BELOW-------------------------------------
+Business Source License 1.1
 
-Zeko Software Components and Software Libraries Tesnet License
+Licensor: Zeko Labs, Inc.
 
-In order to provide a licensing framework for this testnet release of Zeko software components and software libraries for testnet purposes, we are using a modified version of the Reciprocal Community License 1.50. If you wish to evaluate or use the Zeko software components and software libraries (i) in a NON-COMMERCIAL Manner (defined below), or (ii) for any purpose *other than* a NON-COMMERCIAL Manner and contribute to the Zeko community by making available the source code of any extensions you implement, you may download and access the source and/or binaries under the ZEKO Modified Reciprocal Public License 1.5 (RPL-1.5) (the “ZRPL”) below.
+Licensed Work: Zeko-owned protocol-layer components in this directory and
+related Zeko protocol/product-layer code, including source code, circuits,
+sequencer components, prover/operator components, rollup infrastructure,
+services, scripts, tests, and related artifacts, except any file, package,
+directory, SDK, specification, example, interface, ABI, documentation, test
+vector, template, upstream-derived component, or third-party component that
+contains an express different license notice.
 
-**NON-COMMERCIAL** **Manner** – consistent with the Reciprocal Public License 1.5 (RPL-1.5)  – means any use of the Zeko software components and software libraries by: (i) an individual (as opposed to a business entity) solely for their personal, private, and non-commercial purposes; or (ii) an individual or business entity in an experimental manner to understand its nature, limits, and potential uses. The use, including business internal uses, of the Zeko software components and software libraries for any purpose *other than* a NON-COMMERCIAL Manner under ZRPL requires that you make available to the Zeko community the source code and any modifications, bug fixes, extensions, text, programs, scripts, schema, interface definitions, control files, or other works created by You (which are required by a third party of average skill to successfully install and run the Zeko software components and software libraries containing your modifications, or to install and run your derivative works), in accordance with the definitions, manner, terms and scope stated in the ZRPL license terms.
+Additional Use Grant: The Zeko Additional Use Grant published in
+LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md.
 
-**Modification to the RPL** –The two modifications to the Reciprocal Public License 1.5 (RPL-1.5) contained in the ZRPL are as follows: 
+Change Date: 2030-07-17
 
-1) We wanted to capture limited revenue to support our development objectives in the likely few instances where the Zeko software components and software libraries are utilized or deployed on a network that is not the Zeko network.  Hence, we added Section 13.9 “Certain Transaction Fees”, which imposes a two and one half percent (2.5%) transaction fee against the gas fees associated with transactions completed: A) whereby any Zeko software components and software libraries  are utilized or deployed on a network that is not the Zeko network; and/or B) Zeko open sourced or centralized sequencer components are utilized or deployed on a network that is not the Zeko network (NOTE: the original Section 13.9 was renumbered to 13.10); and   
-2) The choice of law in Section 13.8 was changed from Colorado to Delaware and the Venue was changed from binding arbitration under the American Arbitration Association rules in Colorado state to binding arbitration under the Jams, Inc. rules in Wilmington County Delaware state.
+Change License: Apache License, Version 2.0.
 
-\--------------------LICENSE BELOW-------------------------------------
+The Business Source License 1.1 terms are published in
+LICENSES/BUSL-1.1.txt and are incorporated into this License by reference.
 
-**Zeko Modified Reciprocal Public License Version 1.5** 
-
-LICENSE TERMS
-
-1.0 General; Applicability & Definitions.
-
-This Zeko Modified Reciprocal Public License Version 1.5 (“License”) applies to any programs or other works as well as any and all updates or maintenance releases of said programs or works (“Software”) not already covered by this License which the Software copyright holder (“Licensor”) makes available containing a License Notice (hereinafter defined) from the Licensor specifying or allowing use or distribution under the terms of this License.
-
-As used in this License:
-
-1.1 “Contributor” means any person or entity who created or contributed to the creation of an Extension.
-
-1.2 “Deploy” means to use, Serve, sublicense or distribute Licensed Software other than for Your internal Research and/or Personal Use, and includes without limitation, any and all internal use or distribution of Licensed Software within Your business or organization other than for Research and/or Personal Use, as well as direct or indirect sublicensing or distribution of Licensed Software by You to any third party in any form or manner.
-
-1.3 “Derivative Works” as used in this License is defined under U.S. copyright law.
-
-1.4 “Electronic Distribution Mechanism” means a mechanism generally accepted in the software development community for the electronic transfer of data such as download from an FTP server or web site, where such mechanism is publicly accessible.
-
-1.5 “Extensions” means any Modifications, Derivative Works, or Required Components as those terms are defined in this License.
-
-1.6 “License” means this Reciprocal Public License.
-
-1.7 “License Notice” means any notice contained in EXHIBIT A.
-
-1.8 “Licensed Software” means any Software licensed pursuant to this License. Licensed Software also includes all previous Extensions from any Contributor that You receive.
-
-1.9 “Licensor” means the copyright holder of any Software previously not covered by this License who releases the Software under the terms of this License.
-
-1.10 “Modifications” means any additions to or deletions from the substance or structure of (i) a file or other storage containing Licensed Software, or (ii) any new file or storage that contains any part of Licensed Software, or (iii) any file or storage which replaces or otherwise alters the original functionality of Licensed Software at runtime.
-
-1.11 “Personal Use” means use of Licensed Software by an individual solely for his or her personal, private and non-commercial purposes. An individual’s use of Licensed Software in his or her capacity as an officer, employee, member, independent contractor or agent of a corporation, business or organization (commercial or non-commercial) does not qualify as Personal Use.
-
-1.12 “Required Components” means any text, programs, scripts, schema, interface definitions, control files, or other works created by You which are required by a third party of average skill to successfully install and run Licensed Software containing Your Modifications, or to install and run Your Derivative Works.
-
-1.13 “Research” means investigation or experimentation for the purpose of understanding the nature and limits of the Licensed Software and its potential uses.
-
-1.14 “Serve” means to deliver Licensed Software and/or Your Extensions by means of a computer network to one or more computers for purposes of execution of Licensed Software and/or Your Extensions.
-
-1.15 “Software” means any computer programs or other works as well as any updates or maintenance releases of those programs or works which are distributed publicly by Licensor.
-
-1.16 “Source Code” means the preferred form for making modifications to the Licensed Software and/or Your Extensions, including all modules contained therein, plus any associated text, interface definition files, scripts used to control compilation and installation of an executable program or other components required by a third party of average skill to build a running version of the Licensed Software or Your Extensions.
-
-1.17 “User-Visible Attribution Notice” means any notice contained in EXHIBIT B.
-
-1.18 “You” or “Your” means an individual or a legal entity exercising rights under this License. For legal entities, “You” or “Your” includes any entity which controls, is controlled by, or is under common control with, You, where “control” means (a) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (b) ownership of fifty percent (50%) or more of the outstanding shares or beneficial ownership of such entity.
-
-2.0 Acceptance Of License.
-
-You are not required to accept this License since you have not signed it, however nothing else grants you permission to use, copy, distribute, modify, or create derivatives of either the Software or any Extensions created by a Contributor. These actions are prohibited by law if you do not accept this License. Therefore, by performing any of these actions You indicate Your acceptance of this License and Your agreement to be bound by all its terms and conditions.
-
-IF YOU DO NOT AGREE WITH ALL THE TERMS AND CONDITIONS OF THIS LICENSE DO NOT USE, MODIFY, CREATE DERIVATIVES, OR DISTRIBUTE THE SOFTWARE. IF IT IS IMPOSSIBLE FOR YOU TO COMPLY WITH ALL THE TERMS AND CONDITIONS OF THIS LICENSE THEN YOU CAN NOT USE, MODIFY, CREATE DERIVATIVES, OR DISTRIBUTE THE SOFTWARE.
-
-3.0 Grant of License From Licensor.
-
-Subject to the terms and conditions of this License, Licensor hereby grants You a world-wide, royalty-free, non- exclusive license, subject to Licensor’s intellectual property rights, and any third party intellectual property claims derived from the Licensed Software under this License, to do the following:
-
-3.1 Use, reproduce, modify, display, perform, sublicense and distribute Licensed Software and Your Extensions in both Source Code form or as an executable program.
-
-3.2 Create Derivative Works (as that term is defined under U.S. copyright law) of Licensed Software by adding to or deleting from the substance or structure of said Licensed Software.
-
-3.3 Under claims of patents now or hereafter owned or controlled by Licensor, to make, use, have made, and/or otherwise dispose of Licensed Software or portions thereof, but solely to the extent that any such claim is necessary to enable You to make, use, have made, and/or otherwise dispose of Licensed Software or portions thereof.
-
-3.4 Licensor reserves the right to release new versions of the Software with different features, specifications, capabilities, functions, licensing terms, general availability or other characteristics. Title, ownership rights, and intellectual property rights in and to the Licensed Software shall remain in Licensor and/or its Contributors.
-
-4.0 Grant of License From Contributor.
-
-By application of the provisions in Section 6 below, each Contributor hereby grants You a world-wide, royalty- free, non-exclusive license, subject to said Contributor’s intellectual property rights, and any third party intellectual property claims derived from the Licensed Software under this License, to do the following:
-
-4.1 Use, reproduce, modify, display, perform, sublicense and distribute any Extensions Deployed by such Contributor or portions thereof, in both Source Code form or as an executable program, either on an unmodified basis or as part of Derivative Works.
-
-4.2 Under claims of patents now or hereafter owned or controlled by Contributor, to make, use, have made, and/or otherwise dispose of Extensions or portions thereof, but solely to the extent that any such claim is necessary to enable You to make, use, have made, and/or otherwise dispose of Licensed Software or portions thereof.
-
-5.0 Exclusions From License Grant. Nothing in this License shall be deemed to grant any rights to trademarks, copyrights, patents, trade secrets or any other intellectual property of Licensor or any Contributor except as expressly stated herein. Except as expressly stated in Sections 3 and 4, no other patent rights, express or implied, are granted herein. Your Extensions may require additional patent licenses from Licensor or Contributors which each may grant in its sole discretion. No right is granted to the trademarks of Licensor or any Contributor even if such marks are included in the Licensed Software. Nothing in this License shall be interpreted to prohibit Licensor from licensing under different terms from this License any code that Licensor otherwise would have a right to license.
-
-5.1 You expressly acknowledge and agree that although Licensor and each Contributor grants the licenses to their respective portions of the Licensed Software set forth herein, no assurances are provided by Licensor or any Contributor that the Licensed Software does not infringe the patent or other intellectual property rights of any other entity. Licensor and each Contributor disclaim any liability to You for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, You hereby assume sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow You to distribute the Licensed Software, it is Your responsibility to acquire that license before distributing the Licensed Software.
-
-6.0 Your Obligations And Grants.
-
-In consideration of, and as an express condition to, the licenses granted to You under this License You hereby agree that any Modifications, Derivative Works, or Required Components (collectively Extensions) that You create or to which You contribute are governed by the terms of this License including, without limitation, Section 4\. Any Extensions that You create or to which You contribute must be Deployed under the terms of this License or a future version of this License released under Section 7\. You hereby grant to Licensor and all third parties a world-wide, non-exclusive, royalty-free license under those intellectual property rights You own or control to use, reproduce, display, perform, modify, create derivatives, sublicense, and distribute Licensed Software, in any form. Any Extensions You make and Deploy must have a distinct title so as to readily tell any subsequent user or Contributor that the Extensions are by You. You must include a copy of this License or directions on how to obtain a copy with every copy of the Extensions You distribute. You agree not to offer or impose any terms on any Source Code or executable version of the Licensed Software, or its Extensions that alter or restrict the applicable version of this License or the recipients’ rights hereunder.
-
-6.1 Availability of Source Code. You must make available, under the terms of this License, the Source Code of any Extensions that You Deploy, via an Electronic Distribution Mechanism. The Source Code for any version that You Deploy must be made available within one (1) month of when you Deploy and must remain available for no less than twelve (12) months after the date You cease to Deploy. You are responsible for ensuring that the Source Code to each version You Deploy remains available even if the Electronic Distribution Mechanism is maintained by a third party. You may not charge a fee for any copy of the Source Code distributed under this Section in excess of Your actual cost of duplication and distribution of said copy.
-
-6.2 Description of Modifications. You must cause any Modifications that You create or to which You contribute to be documented in the Source Code, clearly describing the additions, changes or deletions You made. You must include a prominent statement that the Modifications are derived, directly or indirectly, from the Licensed Software and include the names of the Licensor and any Contributor to the Licensed Software in (i) the Source Code and (ii) in any notice displayed by the Licensed Software You distribute or in related documentation in which You describe the origin or ownership of the Licensed Software. You may not modify or delete any pre-existing copyright notices, change notices or License text in the Licensed Software without written permission of the respective Licensor or Contributor.
-
-6.3 Intellectual Property Matters. a. Third Party Claims. If You have knowledge that a license to a third party’s intellectual property right is required to exercise the rights granted by this License, You must include a human-readable file with Your distribution that describes the claim and the party making the claim in sufficient detail that a recipient will know whom to contact. b. Contributor APIs. If Your Extensions include an application programming interface (“API”) and You have knowledge of patent licenses that are reasonably necessary to implement that API, You must also include this information in a human-readable file supplied with Your distribution. c. Representations. You represent that, except as disclosed pursuant to 6.3(a) above, You believe that any Extensions You distribute are Your original creations and that You have sufficient rights to grant the rights conveyed by this License.
-
-6.4 Required Notices. a. License Text. You must duplicate this License or instructions on how to acquire a copy in any documentation You provide along with the Source Code of any Extensions You create or to which You contribute, wherever You describe recipients’ rights relating to Licensed Software. b. License Notice. You must duplicate any notice contained in EXHIBIT A (the “License Notice”) in each file of the Source Code of any copy You distribute of the Licensed Software and Your Extensions. If You create an Extension, You may add Your name as a Contributor to the Source Code and accompanying documentation along with a description of the contribution. If it is not possible to put the License Notice in a particular Source Code file due to its structure, then You must include such License Notice in a location where a user would be likely to look for such a notice. c. Source Code Availability. You must notify the software community of the availability of Source Code to Your Extensions within one (1) month of the date You initially Deploy and include in such notification a description of the Extensions, and instructions on how to acquire the Source Code. Should such instructions change you must notify the software community of revised instructions within one (1) month of the date of change. You must provide notification by posting to appropriate news groups, mailing lists, weblogs, or other sites where a publicly accessible search engine would reasonably be expected to index your post in relationship to queries regarding the Licensed Software and/or Your Extensions. d. User-Visible Attribution. You must duplicate any notice contained in EXHIBIT B (the “User-Visible Attribution Notice”) in each user-visible display of the Licensed Software and Your Extensions which delineates copyright, ownership, or similar attribution information. If You create an Extension, You may add Your name as a Contributor, and add Your attribution notice, as an equally visible and functional element of any User-Visible Attribution Notice content. To ensure proper attribution, You must also include such User-Visible Attribution Notice in at least one location in the Software documentation where a user would be likely to look for such notice.
-
-6.5 Additional Terms. You may choose to offer, and charge a fee for, warranty, support, indemnity or liability obligations to one or more recipients of Licensed Software. However, You may do so only on Your own behalf, and not on behalf of the Licensor or any Contributor except as permitted under other agreements between you and Licensor or Contributor. You must make it clear that any such warranty, support, indemnity or liability obligation is offered by You alone, and You hereby agree to indemnify the Licensor and every Contributor for any liability plus attorney fees, costs, and related expenses due to any such action or claim incurred by the Licensor or such Contributor as a result of warranty, support, indemnity or liability terms You offer.
-
-6.6 Conflicts With Other Licenses. Where any portion of Your Extensions, by virtue of being Derivative Works of another product or similar circumstance, fall under the terms of another license, the terms of that license should be honored however You must also make Your Extensions available under this License. If the terms of this License continue to conflict with the terms of the other license you may write the Licensor for permission to resolve the conflict in a fashion that remains consistent with the intent of this License. Such permission will be granted at the sole discretion of the Licensor.
-
-7.0 Versions of This License.
-
-Licensor may publish from time to time revised versions of the License. Once Licensed Software has been published under a particular version of the License, You may always continue to use it under the terms of that version. You may also choose to use such Licensed Software under the terms of any subsequent version of the License published by Licensor. No one other than Licensor has the right to modify the terms applicable to Licensed Software created under this License.
-
-7.1 If You create or use a modified version of this License, which You may do only in order to apply it to software that is not already Licensed Software under this License, You must rename Your license so that it is not confusingly similar to this License, and must make it clear that Your license contains terms that differ from this License. In so naming Your license, You may not use any trademark of Licensor or of any Contributor. Should Your modifications to this License be limited to alteration of a) Section 13.8 solely to modify the legal Jurisdiction or Venue for disputes, b) EXHIBIT A solely to define License Notice text, or c) to EXHIBIT B solely to define a User-Visible Attribution Notice, You may continue to refer to Your License as the Reciprocal Public License or simply the RPL.
-
-8.0 Disclaimer of Warranty.
-
-LICENSED SOFTWARE IS PROVIDED UNDER THIS LICENSE ON AN “AS IS” BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE LICENSED SOFTWARE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING. FURTHER THERE IS NO WARRANTY MADE AND ALL IMPLIED WARRANTIES ARE DISCLAIMED THAT THE LICENSED SOFTWARE MEETS OR COMPLIES WITH ANY DESCRIPTION OF PERFORMANCE OR OPERATION, SAID COMPATIBILITY AND SUITABILITY BEING YOUR RESPONSIBILITY. LICENSOR DISCLAIMS ANY WARRANTY, IMPLIED OR EXPRESSED, THAT ANY CONTRIBUTOR’S EXTENSIONS MEET ANY STANDARD OF COMPATIBILITY OR DESCRIPTION OF PERFORMANCE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE LICENSED SOFTWARE IS WITH YOU. SHOULD LICENSED SOFTWARE PROVE DEFECTIVE IN ANY RESPECT, YOU (AND NOT THE LICENSOR OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY SERVICING, REPAIR OR CORRECTION. UNDER THE TERMS OF THIS LICENSOR WILL NOT SUPPORT THIS SOFTWARE AND IS UNDER NO OBLIGATION TO ISSUE UPDATES TO THIS SOFTWARE. LICENSOR HAS NO KNOWLEDGE OF ERRANT CODE OR VIRUS IN THIS SOFTWARE, BUT DOES NOT WARRANT THAT THE SOFTWARE IS FREE FROM SUCH ERRORS OR VIRUSES. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF LICENSED SOFTWARE IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS DISCLAIMER.
-
-9.0 Limitation of Liability.
-
-UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL THE LICENSOR, ANY CONTRIBUTOR, OR ANY DISTRIBUTOR OF LICENSED SOFTWARE, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO ANY PERSON FOR ANY INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF GOODWILL, WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGES. THIS LIMITATION OF LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL INJURY RESULTING FROM SUCH PARTY’S NEGLIGENCE TO THE EXTENT APPLICABLE LAW PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THIS EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
-
-10.0 High Risk Activities.
-
-THE LICENSED SOFTWARE IS NOT FAULT-TOLERANT AND IS NOT DESIGNED, MANUFACTURED, OR INTENDED FOR USE OR DISTRIBUTION AS ON-LINE CONTROL EQUIPMENT IN HAZARDOUS ENVIRONMENTS REQUIRING FAIL-SAFE PERFORMANCE, SUCH AS IN THE OPERATION OF NUCLEAR FACILITIES, AIRCRAFT NAVIGATION OR COMMUNICATIONS SYSTEMS, AIR TRAFFIC CONTROL, DIRECT LIFE SUPPORT MACHINES, OR WEAPONS SYSTEMS, IN WHICH THE FAILURE OF THE LICENSED SOFTWARE COULD LEAD DIRECTLY TO DEATH, PERSONAL INJURY, OR SEVERE PHYSICAL OR ENVIRONMENTAL DAMAGE (“HIGH RISK ACTIVITIES”). LICENSOR AND CONTRIBUTORS SPECIFICALLY DISCLAIM ANY EXPRESS OR IMPLIED WARRANTY OF FITNESS FOR HIGH RISK ACTIVITIES.
-
-11.0 Responsibility for Claims.
-
-As between Licensor and Contributors, each party is responsible for claims and damages arising, directly or indirectly, out of its utilization of rights under this License which specifically disclaims warranties and limits any liability of the Licensor. This paragraph is to be used in conjunction with and controlled by the Disclaimer Of Warranties of Section 8, the Limitation Of Damages in Section 9, and the disclaimer against use for High Risk Activities in Section 10\. The Licensor has thereby disclaimed all warranties and limited any damages that it is or may be liable for. You agree to work with Licensor and Contributors to distribute such responsibility on an equitable basis consistent with the terms of this License including Sections 8, 9, and 10\. Nothing herein is intended or shall be deemed to constitute any admission of liability.
-
-12.0 Termination.
-
-This License and all rights granted hereunder will terminate immediately in the event of the circumstances described in Section 13.6 or if applicable law prohibits or restricts You from fully and or specifically complying with Sections 3, 4 and/or 6, or prevents the enforceability of any of those Sections, and You must immediately discontinue any use of Licensed Software.
-
-12.1 Automatic Termination Upon Breach. This License and the rights granted hereunder will terminate automatically if You fail to comply with the terms herein and fail to cure such breach within thirty (30) days of becoming aware of the breach. All sublicenses to the Licensed Software that are properly granted shall survive any termination of this License. Provisions that, by their nature, must remain in effect beyond the termination of this License, shall survive.
-
-12.2 Termination Upon Assertion of Patent Infringement. If You initiate litigation by asserting a patent infringement claim (excluding declaratory judgment actions) against Licensor or a Contributor (Licensor or Contributor against whom You file such an action is referred to herein as “Respondent”) alleging that Licensed Software directly or indirectly infringes any patent, then any and all rights granted by such Respondent to You under Sections 3 or 4 of this License shall terminate prospectively upon sixty (60) days notice from Respondent (the “Notice Period”) unless within that Notice Period You either agree in writing (i) to pay Respondent a mutually agreeable reasonably royalty for Your past or future use of Licensed Software made by such Respondent, or (ii) withdraw Your litigation claim with respect to Licensed Software against such Respondent. If within said Notice Period a reasonable royalty and payment arrangement are not mutually agreed upon in writing by the parties or the litigation claim is not withdrawn, the rights granted by Licensor to You under Sections 3 and 4 automatically terminate at the expiration of said Notice Period.
-
-12.3 Reasonable Value of This License. If You assert a patent infringement claim against Respondent alleging that Licensed Software directly or indirectly infringes any patent where such claim is resolved (such as by license or settlement) prior to the initiation of patent infringement litigation, then the reasonable value of the licenses granted by said Respondent under Sections 3 and 4 shall be taken into account in determining the amount or value of any payment or license.
-
-12.4 No Retroactive Effect of Termination. In the event of termination under this Section all end user license agreements (excluding licenses to distributors and resellers) that have been validly granted by You or any distributor hereunder prior to termination shall survive termination.
-
-13.0 Miscellaneous.
-
-13.1 U.S. Government End Users.
-
-The Licensed Software is a “commercial item,” as that term is defined in 48 C.F.R. 2.101 (Oct. 1995), consisting of “commercial computer software” and “commercial computer software documentation,” as such terms are used in 48 C.F.R. 12.212 (Sept. 1995). Consistent with 48 C.F.R. 12.212 and 48 C.F.R. 227.7202-1 through 227.7202-4 (June 1995), all U.S. Government End Users acquire Licensed Software with only those rights set forth herein.
-
-13.2 Relationship of Parties. This License will not be construed as creating an agency, partnership, joint venture, or any other form of legal association between or among You, Licensor, or any Contributor, and You will not represent to the contrary, whether expressly, by implication, appearance, or otherwise.
-
-13.3 Independent Development. Nothing in this License will impair Licensor’s right to acquire, license, develop, subcontract, market, or distribute technology or products that perform the same or similar functions as, or otherwise compete with, Extensions that You may develop, produce, market, or distribute.
-
-13.4 Consent To Breach Not Waiver. Failure by Licensor or Contributor to enforce any provision of this License will not be deemed a waiver of future enforcement of that or any other provision.
-
-13.5 Severability. This License represents the complete agreement concerning the subject matter hereof. If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable.
-
-13.6 Inability to Comply Due to Statute or Regulation. If it is impossible for You to comply with any of the terms of this License with respect to some or all of the Licensed Software due to statute, judicial order, or regulation, then You cannot use, modify, or distribute the software.
-
-13.7 Export Restrictions. You may be restricted with respect to downloading or otherwise acquiring, exporting, or reexporting the Licensed Software or any underlying information or technology by United States and other applicable laws and regulations. By downloading or by otherwise obtaining the Licensed Software, You are agreeing to be responsible for compliance with all applicable laws and regulations.
-
-13.8 Arbitration, Jurisdiction & Venue. This License shall be governed by Delaware law provisions (except to the extent applicable law, if any, provides otherwise), excluding its conflict-of-law provisions. You expressly agree that any dispute relating to this License shall be submitted to binding arbitration conducted by JAMS, Inc. (“JAMS”) under the then applicable JAMS rules. You further agree that the City of Wilmington, New Castle County, Delaware is proper venue and grant such arbitration proceeding jurisdiction as may be appropriate for purposes of resolving any dispute under this License. Judgement upon any award made in arbitration may be entered and enforced in any court of competent jurisdiction. The arbitrator shall award attorney’s fees and costs of arbitration to the prevailing party. Should either party find it necessary to enforce its arbitration award or seek specific performance of such award in a civil court of competent jurisdiction, the prevailing party shall be entitled to reasonable attorney’s fees and costs. The application of the United Nations Convention on Contracts for the International Sale of Goods is expressly excluded. You and Licensor expressly waive any rights to a jury trial in any litigation concerning Licensed Software or this License. Any law or regulation that provides that the language of a contract shall be construed against the drafter shall not apply to this License.
-
-13.9 Certain Transaction Fees and Gas Fees.  Blockchain transactions require the payment of transaction fees to the appropriate network ("Gas Fees") and except as otherwise expressly set forth in herein, You will be solely responsible to pay the Gas Fees for any transaction that You initiate by, though, or via any of the Licensed Software.  In addition, to the extent that You engage in any “Paid Deployment”, (defined below), you shall be responsible to pay the Licensor, for each transaction completed on, by, or through any Paid Deployment (each a “Paid Transaction”), a transaction fee for each Paid Transaction of two and one half percent (2.5%) against the Gas Fees associated (the “Transaction Fee”). For purposes of this Section 13.9 “Paid Deployment” means (A) to use, Serve, sublicense or distribute Licensed Software on, by, or through any blockchain or protocol other than the “Zeko” blockchain or protocol; and/or B) to use, Serve, sublicense or distribute any “circuits” or “sequencer” components that are made part of the Licensed Software (irrespective of whether such sequencer components are marked or designated as “open source” or any equivalent of the phrase “open source”) on, by, or through a network that is not the “Zeko” blockchain or protocol.
-
-1) Monthly Reporting and Notice. No later than the 15th day of each calendar month, Licensee shall provide Licensor with a written report or onchain explorer data detailing the number and nature of all Paid Transactions conducted in the preceding month, along with a calculation of the total aggregate Transaction Fee due. The report shall be provided in a format reasonably acceptable to Licensor.  
-2) Payment and Remittance. Licensor may issue an invoice for the total Transaction Fees due, and Licensee shall remit payment within 15 days of receipt of such invoice. Payment shall be made via automated clearing house (ACH) transfer, wire transfer, blockchain-based remittance, or another method as designated by Licensor in writing. In lieu of an invoice, Licensee may be requested to automatically remit payment to a preapproved onchain Zeko protocol treasury address.    
-3) Audit Rights. If Licensee does not provide a reliable written report or onchain explorer data, Licensor shall have the right, upon reasonable prior written notice and at its own expense, to publicly audit Licensee’s records related to Paid Transactions no more than 2 times per year to ensure compliance with this provision. If an audit reveals underpayment of 15% or more, Licensee shall reimburse Licensor for the cost of the audit and remit all unpaid amounts with interest at 15% per annum.  
-4) Late Payments. Any late payment shall accrue interest at the rate of 15% per month or the maximum rate permitted by law, whichever is lower. Licensor reserves the right to suspend or terminate Licensee’s rights under this Agreement if payments remain outstanding for more than 15 days following written notice of delinquency.
-
-13.10 Entire Agreement. This License constitutes the entire agreement between the parties with respect to the subject matter hereof. 
-
-EXHIBIT A 
-
-The License Notice below must appear in each file of the Source Code of any copy You distribute of the Licensed Software or any Extensions thereto: Unless explicitly acquired and licensed from Licensor under another license, the contents of this file are subject to the Zeko Modified Reciprocal Public License (“ZRPL”) Version 1.5, or subsequent versions as allowed by the RPL, and You may not copy or use this file in either source code or executable form, except in compliance with the terms and conditions of the ZRPL.
-
-All software distributed under the ZRPL is provided strictly on an “AS IS” basis, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, AND LICENSOR HEREBY DISCLAIMS ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT, OR NON-INFRINGEMENT. See the ZRPL for specific language governing rights and limitations under the ZRPL. 
-
-EXHIBIT B 
-
-The User-Visible Attribution Notice below, when provided, must appear in each user-visible display as defined in Section 6.4: Portions copyright (c) by Zeko Labs, Inc. and licensed under the Zeko Modified Reciprocal Public License (ZRPL)”.
+For payment, billing, commercial licensing, ecosystem agreements, or other
+inquiries, contact partnerships@zeko.io.

--- a/src/app/zeko/LICENSES/APACHE-2.0.txt
+++ b/src/app/zeko/LICENSES/APACHE-2.0.txt
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2024. Mina Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/src/app/zeko/LICENSES/BUSL-1.1.txt
+++ b/src/app/zeko/LICENSES/BUSL-1.1.txt
@@ -1,0 +1,78 @@
+Business Source License 1.1
+
+License text copyright (c) 2024 MariaDB plc, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB plc.
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited production
+use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under the
+terms of the Change License, and the rights granted in the paragraph above
+terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works of
+the Licensed Work, are subject to this License. This License applies separately
+for each version of the Licensed Work and the Change Date may vary for each
+version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or modified
+form from a third party, the terms and conditions set forth in this License
+apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other versions
+of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of Licensor
+or its affiliates (provided that you may use a trademark or logo of Licensor as
+expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
+"AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
+OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+
+MariaDB hereby grants you permission to use this License's text to license your
+works, and to refer to it using the trademark "Business Source License", as
+long as you comply with the Covenants of Licensor below.
+
+Covenants of Licensor
+
+In consideration of the right to use this License's text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
+
+To specify as the Change License the GPL Version 2.0 or any later version, or a
+license that is compatible with GPL Version 2.0 or a later version, where
+"compatible" means that software provided under the Change License can be
+included in a program with software provided under GPL Version 2.0 or a later
+version. Licensor may specify additional Change Licenses without limitation.
+
+To either: (a) specify an additional grant of rights to use that does not
+impose any additional restriction on the right granted in this License, as the
+Additional Use Grant; or (b) insert the text "None".
+
+To specify a Change Date.
+
+Not to modify this License in any other way.
+
+Notice
+
+The Business Source License (this document, or the "License") is not an Open
+Source license. However, the Licensed Work will eventually be made available
+under an Open Source License, as stated in this License.
+
+For more information on the use of the Business Source License, please visit
+https://mariadb.com/bsl11/.

--- a/src/app/zeko/LICENSES/MIT.txt
+++ b/src/app/zeko/LICENSES/MIT.txt
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/app/zeko/LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md
+++ b/src/app/zeko/LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md
@@ -1,0 +1,131 @@
+# Zeko Additional Use Grant
+
+This Zeko Additional Use Grant applies to the Licensed Work identified as
+subject to the Business Source License 1.1 and this Additional Use Grant.
+
+## 1. Additional Free Uses
+
+In addition to the non-production rights granted under the Business Source
+License 1.1, Zeko Labs grants you the right to use, copy, modify, distribute,
+and operate the Licensed Work for the following purposes:
+
+1. Development, testing, benchmarking, research, education, security review,
+   audit, internal evaluation, demonstrations, hackathons, local deployments,
+   devnet deployments, testnet deployments, staging deployments, and
+   proof-of-concept deployments.
+2. Building, deploying, operating, or interacting with applications, zkApps,
+   agents, wallets, indexers, relayers, dashboards, clients, contracts, bridges,
+   adapters, or settlement integrations that submit to, interoperate with, or
+   otherwise use the Official Zeko Network.
+3. Commercially operating applications that use the Official Zeko Network,
+   provided that you do not operate an Independent Production Deployment of the
+   Licensed Work.
+4. Operating infrastructure as an authorized participant, operator, prover,
+   sequencer, validator, relayer, settlement operator, or service provider for
+   the Official Zeko Network, where such role has been approved, authorized, or
+   designated by Zeko Labs or the applicable Zeko governance process.
+5. Using any file, package, directory, SDK, specification, example, interface,
+   ABI, documentation, test vector, or template that is expressly marked as
+   licensed under Apache-2.0, MIT, or another permissive license, subject to
+   that separate license.
+
+## 2. Commercial Deployment License Required
+
+Except as expressly permitted above, a commercial deployment license is required
+for:
+
+1. an Independent Production Deployment of the Zeko protocol layer;
+2. an Agent Bundle Production Deployment; or
+3. any other production deployment of protected protocol/product-layer code that
+   is not covered by the Additional Free Uses above.
+
+Commercial deployment fees are payable to Zeko Labs, Inc. or its successor or
+assigns. For payment, billing, commercial licensing, ecosystem agreements, or
+other inquiries, contact partnerships@zeko.io.
+
+## 3. Definitions
+
+### Official Zeko Network
+
+Official Zeko Network means any Zeko network, rollup lane, prover network,
+sequencer network, settlement endpoint, bridge, or related infrastructure
+operated by Zeko Labs, authorized by Zeko Labs, or designated by the applicable
+Zeko governance process as part of the official Zeko ecosystem.
+
+### Independent Production Deployment
+
+Independent Production Deployment means a production deployment or operation of
+the Licensed Work, or a modified version or derivative work of the Licensed
+Work, outside the Official Zeko Network.
+
+Independent Production Deployments include production rollups, sovereign
+rollups, appchains, L2s, L3s, sequencer networks, prover networks, settlement
+networks, hosted proof services, bridges, protocol deployments, or substantially
+similar production infrastructure using protected Zeko protocol-layer code.
+
+### Agent Bundle
+
+Agent Bundle means the protected Zeko product/protocol components for
+agent-native coordination, authorization, payments, and commerce, including
+SantaClawz, ZK x402, Mission-Bound Auth, Magic City when designated by Zeko
+Labs, and related protected orchestration, verifier, authorization, payment,
+settlement, and coordination components.
+
+### Agent Bundle Production Deployment
+
+Agent Bundle Production Deployment means a production deployment or operation
+of one or more protected Agent Bundle components, or modified versions or
+derivative works of those components, by or on behalf of a legal entity on a
+Deployment Network.
+
+The Agent Bundle fee applies only to production deployment or operation of
+protected Agent Bundle code, or modified versions or derivative works of that
+code. It does not apply to independently developed implementations that do not
+copy, modify, derive from, or substantially incorporate protected Agent Bundle
+code, even if they implement similar concepts, protocols, or workflows.
+
+### Deployment Network
+
+Deployment Network means any L1, L2, L3, sovereign rollup, appchain,
+application-specific chain, private or permissioned network, synchronizer,
+domain, settlement environment, execution environment, or substantially similar
+production execution or settlement environment.
+
+### Production
+
+Production means deployment or operation on mainnet or in any
+production-equivalent environment involving real users, customer workflows, real
+assets, payment activity, revenue-generating activity, external third-party
+use, or production settlement.
+
+A deployment is not non-production merely because it is labeled "testnet,"
+"pilot," "beta," "sandbox," "staging," or "proof of concept." A deployment is
+production if it uses, controls, settles, routes, verifies, authorizes, gates
+access to, or materially affects real assets, real payments, customer
+workflows, paid services, external users, or mainnet state on any Deployment
+Network.
+
+### Non-Production
+
+Non-Production means local, devnet, testnet, staging, internal evaluation,
+research, audit, educational, demo, hackathon, or proof-of-concept use that
+does not involve real assets, customer workflows, paid services, external
+production users, or material interaction with mainnet state.
+
+## 4. No Trademark Rights
+
+This Additional Use Grant does not grant any right to use the names, logos, or
+trademarks of Zeko Labs, Zeko, SantaClawz, Magic City, or any related brand,
+except as separately authorized in writing.
+
+## 5. Separate Commercial Services
+
+The self-serve commercial deployment license covers license rights only.
+Managed deployment, enterprise support, compliance review, SLAs, custom
+integrations, dedicated infrastructure, hosted services, and professional
+services are separate commercial services.
+
+## 6. Separate Licenses Control
+
+If a file, package, directory, or component contains a separate license notice,
+that notice controls for that file, package, directory, or component.

--- a/src/app/zeko/LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md
+++ b/src/app/zeko/LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md
@@ -15,19 +15,31 @@ and operate the Licensed Work for the following purposes:
    proof-of-concept deployments.
 2. Building, deploying, operating, or interacting with applications, zkApps,
    agents, wallets, indexers, relayers, dashboards, clients, contracts, bridges,
-   adapters, or settlement integrations that submit to, interoperate with, or
-   otherwise use the Official Zeko Network.
-3. Commercially operating applications that use the Official Zeko Network,
+   SDKs, adapters, connectors, workflows, or settlement integrations that submit
+   to, interoperate with, or otherwise use the Official Zeko Network or an
+   Official Agent Protocol Deployment.
+3. Commercially operating applications, agents, workflows, or integrations that
+   use the Official Zeko Network or an Official Agent Protocol Deployment,
    provided that you do not operate an Independent Production Deployment of the
-   Licensed Work.
+   Licensed Work or an Independent Agent Protocol Deployment.
 4. Operating infrastructure as an authorized participant, operator, prover,
    sequencer, validator, relayer, settlement operator, or service provider for
    the Official Zeko Network, where such role has been approved, authorized, or
    designated by Zeko Labs or the applicable Zeko governance process.
-5. Using any file, package, directory, SDK, specification, example, interface,
+5. Using official hosted or public Zeko applications, services, APIs, relays,
+   facilitators, verifiers, marketplaces, payment rails, authorization rails,
+   coordination rails, or settlement endpoints powered by an Official Agent
+   Protocol Deployment.
+6. Using any file, package, directory, SDK, specification, example, interface,
    ABI, documentation, test vector, or template that is expressly marked as
    licensed under Apache-2.0, MIT, or another permissive license, subject to
    that separate license.
+
+These Additional Free Uses do not waive ordinary network, gas, transaction,
+bridge, prover, marketplace, service, or usage fees charged by the Official
+Zeko Network or Official Agent Protocol Deployments. They only clarify that no
+separate commercial deployment license is required for that official-network or
+official-service use.
 
 ## 2. Commercial Deployment License Required
 
@@ -35,7 +47,7 @@ Except as expressly permitted above, a commercial deployment license is required
 for:
 
 1. an Independent Production Deployment of the Zeko protocol layer;
-2. an Agent Bundle Production Deployment; or
+2. an Independent Agent Protocol Deployment; or
 3. any other production deployment of protected protocol/product-layer code that
    is not covered by the Additional Free Uses above.
 
@@ -63,26 +75,40 @@ rollups, appchains, L2s, L3s, sequencer networks, prover networks, settlement
 networks, hosted proof services, bridges, protocol deployments, or substantially
 similar production infrastructure using protected Zeko protocol-layer code.
 
-### Agent Bundle
+### Agent Protocol Bundle
 
-Agent Bundle means the protected Zeko product/protocol components for
+Agent Protocol Bundle means the protected Zeko product/protocol components for
 agent-native coordination, authorization, payments, and commerce, including
 SantaClawz, ZK x402, Mission-Bound Auth, Magic City when designated by Zeko
 Labs, and related protected orchestration, verifier, authorization, payment,
-settlement, and coordination components.
+settlement, coordination, marketplace, relay, facilitator, application, API, and
+service components.
 
-### Agent Bundle Production Deployment
+### Official Agent Protocol Deployment
 
-Agent Bundle Production Deployment means a production deployment or operation
-of one or more protected Agent Bundle components, or modified versions or
-derivative works of those components, by or on behalf of a legal entity on a
-Deployment Network.
+Official Agent Protocol Deployment means any Agent Protocol Bundle deployment,
+hosted service, application, API, relay, verifier, facilitator, marketplace,
+authorization layer, payment layer, coordination layer, settlement endpoint, or
+related infrastructure operated by Zeko Labs, authorized by Zeko Labs, or
+designated by the applicable Zeko governance process as part of the official
+Zeko ecosystem.
 
-The Agent Bundle fee applies only to production deployment or operation of
-protected Agent Bundle code, or modified versions or derivative works of that
-code. It does not apply to independently developed implementations that do not
-copy, modify, derive from, or substantially incorporate protected Agent Bundle
-code, even if they implement similar concepts, protocols, or workflows.
+### Independent Agent Protocol Deployment
+
+Independent Agent Protocol Deployment means a production deployment or operation
+of one or more protected Agent Protocol Bundle components, or modified versions
+or derivative works of those components, by or on behalf of a legal entity on a
+Deployment Network, outside an Official Agent Protocol Deployment.
+
+The Agent Protocol Bundle fee applies only to production deployment or operation
+of protected Agent Protocol Bundle code, or modified versions or derivative
+works of that code, outside an Official Agent Protocol Deployment. It does not
+apply to use of official Zeko-operated or Zeko-authorized applications,
+services, APIs, relays, facilitators, verifiers, marketplaces, payment rails,
+authorization rails, coordination rails, or settlement endpoints. It also does
+not apply to independently developed implementations that do not copy, modify,
+derive from, or substantially incorporate protected Agent Protocol Bundle code,
+even if they implement similar concepts, protocols, or workflows.
 
 ### Deployment Network
 

--- a/src/app/zeko/LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md
+++ b/src/app/zeko/LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md
@@ -16,32 +16,43 @@ and operate the Licensed Work for the following purposes:
 2. Building, deploying, operating, or interacting with applications, zkApps,
    agents, wallets, indexers, relayers, dashboards, clients, contracts, bridges,
    SDKs, adapters, connectors, workflows, or settlement integrations that submit
-   to, interoperate with, or otherwise use the Official Zeko Network.
+   to, interoperate with, or otherwise use the Official Zeko Network or an
+   Official Agent Protocol Deployment.
 3. Commercially operating applications, agents, workflows, or integrations that
-   use the Official Zeko Network, provided that you do not operate an
-   Independent Production Deployment of the Licensed Work.
+   use the Official Zeko Network or an Official Agent Protocol Deployment,
+   provided that you do not operate an Independent Production Deployment of the
+   Licensed Work or an Independent Agent Protocol Bundle production deployment.
 4. Operating infrastructure as an authorized participant, operator, prover,
    sequencer, validator, relayer, settlement operator, or service provider for
    the Official Zeko Network, where such role has been approved, authorized, or
    designated by Zeko Labs or the applicable Zeko governance process.
-5. Using any file, package, directory, SDK, specification, example, interface,
+5. Using official hosted or public Zeko applications, services, APIs, relays,
+   facilitators, verifiers, marketplaces, payment rails, authorization rails,
+   coordination rails, or settlement endpoints powered by an Official Agent
+   Protocol Deployment.
+6. Using any file, package, directory, SDK, specification, example, interface,
    ABI, documentation, test vector, or template that is expressly marked as
    licensed under Apache-2.0, MIT, or another permissive license, subject to
    that separate license.
 
 These Additional Free Uses do not waive ordinary network, gas, transaction,
 bridge, prover, marketplace, service, or usage fees charged by the Official
-Zeko Network. They only clarify that no separate commercial deployment license
-is required for that official-network use.
+Zeko Network or Official Agent Protocol Deployments. They only clarify that no
+separate commercial deployment license is required for that official-network or
+official-service use.
 
-## 2. Commercial Deployment License Required
+## 2. Commercial Deployment License Coverage
 
-Except as expressly permitted above, a commercial deployment license is required
-for:
+Except as expressly permitted above, the following production deployments are
+covered by the self-serve commercial deployment license:
 
 1. an Independent Production Deployment of the Zeko protocol layer;
-2. any other production deployment of protected Zeko protocol-layer code that
+2. an Independent Agent Protocol Bundle production deployment; or
+3. any other production deployment of protected protocol/product-layer code that
    is not covered by the Additional Free Uses above.
+
+The current published self-serve fee is $0/year, subject to the pricing
+schedule in `PRICING.md`.
 
 Commercial deployment fees, if any, are payable to Zeko Labs, Inc. or its
 successor or assigns. For payment, billing, commercial licensing, ecosystem
@@ -66,6 +77,43 @@ Independent Production Deployments include production rollups, sovereign
 rollups, appchains, L2s, L3s, sequencer networks, prover networks, settlement
 networks, hosted proof services, bridges, protocol deployments, or substantially
 similar production infrastructure using protected Zeko protocol-layer code.
+
+### Agent Protocol Bundle
+
+Agent Protocol Bundle means the protected Zeko product/protocol components for
+agent-native coordination, authorization, payments, and commerce, including
+SantaClawz, ZK x402, Mission-Bound Auth, Magic City when designated by Zeko
+Labs, and related protected orchestration, verifier, authorization, payment,
+settlement, coordination, marketplace, relay, facilitator, application, API, and
+service components.
+
+### Official Agent Protocol Deployment
+
+Official Agent Protocol Deployment means any Agent Protocol Bundle deployment,
+hosted service, application, API, relay, verifier, facilitator, marketplace,
+authorization layer, payment layer, coordination layer, settlement endpoint, or
+related infrastructure operated by Zeko Labs, authorized by Zeko Labs, or
+designated by the applicable Zeko governance process as part of the official
+Zeko ecosystem.
+
+### Independent Agent Protocol Bundle Production Deployment
+
+Independent Agent Protocol Bundle production deployment means a production
+deployment or operation of one or more protected Agent Protocol Bundle
+components, or modified versions or derivative works of those components, by or
+on behalf of a legal entity on a Deployment Network, outside an Official Agent
+Protocol Deployment.
+
+Independent Agent Protocol Bundle production deployments are covered by the
+self-serve commercial deployment license. The current published self-serve fee
+is $0/year, subject to the pricing schedule in `PRICING.md`.
+
+This does not apply to use of official Zeko-operated or Zeko-authorized
+applications, services, APIs, relays, facilitators, verifiers, marketplaces,
+payment rails, authorization rails, coordination rails, or settlement endpoints.
+It also does not apply to independently developed implementations that do not
+copy, modify, derive from, or substantially incorporate protected Agent Protocol
+Bundle code, even if they implement similar concepts, protocols, or workflows.
 
 ### Deployment Network
 
@@ -98,8 +146,8 @@ production users, or material interaction with mainnet state.
 ## 4. No Trademark Rights
 
 This Additional Use Grant does not grant any right to use the names, logos, or
-trademarks of Zeko Labs, Zeko, or any related brand, except as separately
-authorized in writing.
+trademarks of Zeko Labs, Zeko, SantaClawz, Magic City, or any related brand,
+except as separately authorized in writing.
 
 ## 5. Separate Commercial Services
 

--- a/src/app/zeko/LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md
+++ b/src/app/zeko/LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md
@@ -43,9 +43,9 @@ for:
 2. any other production deployment of protected Zeko protocol-layer code that
    is not covered by the Additional Free Uses above.
 
-Commercial deployment fees are payable to Zeko Labs, Inc. or its successor or
-assigns. For payment, billing, commercial licensing, ecosystem agreements, or
-other inquiries, contact partnerships@zeko.io.
+Commercial deployment fees, if any, are payable to Zeko Labs, Inc. or its
+successor or assigns. For payment, billing, commercial licensing, ecosystem
+agreements, or other inquiries, contact partnerships@zeko.io.
 
 ## 3. Definitions
 

--- a/src/app/zeko/LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md
+++ b/src/app/zeko/LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md
@@ -16,30 +16,23 @@ and operate the Licensed Work for the following purposes:
 2. Building, deploying, operating, or interacting with applications, zkApps,
    agents, wallets, indexers, relayers, dashboards, clients, contracts, bridges,
    SDKs, adapters, connectors, workflows, or settlement integrations that submit
-   to, interoperate with, or otherwise use the Official Zeko Network or an
-   Official Agent Protocol Deployment.
+   to, interoperate with, or otherwise use the Official Zeko Network.
 3. Commercially operating applications, agents, workflows, or integrations that
-   use the Official Zeko Network or an Official Agent Protocol Deployment,
-   provided that you do not operate an Independent Production Deployment of the
-   Licensed Work or an Independent Agent Protocol Deployment.
+   use the Official Zeko Network, provided that you do not operate an
+   Independent Production Deployment of the Licensed Work.
 4. Operating infrastructure as an authorized participant, operator, prover,
    sequencer, validator, relayer, settlement operator, or service provider for
    the Official Zeko Network, where such role has been approved, authorized, or
    designated by Zeko Labs or the applicable Zeko governance process.
-5. Using official hosted or public Zeko applications, services, APIs, relays,
-   facilitators, verifiers, marketplaces, payment rails, authorization rails,
-   coordination rails, or settlement endpoints powered by an Official Agent
-   Protocol Deployment.
-6. Using any file, package, directory, SDK, specification, example, interface,
+5. Using any file, package, directory, SDK, specification, example, interface,
    ABI, documentation, test vector, or template that is expressly marked as
    licensed under Apache-2.0, MIT, or another permissive license, subject to
    that separate license.
 
 These Additional Free Uses do not waive ordinary network, gas, transaction,
 bridge, prover, marketplace, service, or usage fees charged by the Official
-Zeko Network or Official Agent Protocol Deployments. They only clarify that no
-separate commercial deployment license is required for that official-network or
-official-service use.
+Zeko Network. They only clarify that no separate commercial deployment license
+is required for that official-network use.
 
 ## 2. Commercial Deployment License Required
 
@@ -47,8 +40,7 @@ Except as expressly permitted above, a commercial deployment license is required
 for:
 
 1. an Independent Production Deployment of the Zeko protocol layer;
-2. an Independent Agent Protocol Deployment; or
-3. any other production deployment of protected protocol/product-layer code that
+2. any other production deployment of protected Zeko protocol-layer code that
    is not covered by the Additional Free Uses above.
 
 Commercial deployment fees are payable to Zeko Labs, Inc. or its successor or
@@ -74,41 +66,6 @@ Independent Production Deployments include production rollups, sovereign
 rollups, appchains, L2s, L3s, sequencer networks, prover networks, settlement
 networks, hosted proof services, bridges, protocol deployments, or substantially
 similar production infrastructure using protected Zeko protocol-layer code.
-
-### Agent Protocol Bundle
-
-Agent Protocol Bundle means the protected Zeko product/protocol components for
-agent-native coordination, authorization, payments, and commerce, including
-SantaClawz, ZK x402, Mission-Bound Auth, Magic City when designated by Zeko
-Labs, and related protected orchestration, verifier, authorization, payment,
-settlement, coordination, marketplace, relay, facilitator, application, API, and
-service components.
-
-### Official Agent Protocol Deployment
-
-Official Agent Protocol Deployment means any Agent Protocol Bundle deployment,
-hosted service, application, API, relay, verifier, facilitator, marketplace,
-authorization layer, payment layer, coordination layer, settlement endpoint, or
-related infrastructure operated by Zeko Labs, authorized by Zeko Labs, or
-designated by the applicable Zeko governance process as part of the official
-Zeko ecosystem.
-
-### Independent Agent Protocol Deployment
-
-Independent Agent Protocol Deployment means a production deployment or operation
-of one or more protected Agent Protocol Bundle components, or modified versions
-or derivative works of those components, by or on behalf of a legal entity on a
-Deployment Network, outside an Official Agent Protocol Deployment.
-
-The Agent Protocol Bundle fee applies only to production deployment or operation
-of protected Agent Protocol Bundle code, or modified versions or derivative
-works of that code, outside an Official Agent Protocol Deployment. It does not
-apply to use of official Zeko-operated or Zeko-authorized applications,
-services, APIs, relays, facilitators, verifiers, marketplaces, payment rails,
-authorization rails, coordination rails, or settlement endpoints. It also does
-not apply to independently developed implementations that do not copy, modify,
-derive from, or substantially incorporate protected Agent Protocol Bundle code,
-even if they implement similar concepts, protocols, or workflows.
 
 ### Deployment Network
 
@@ -141,8 +98,8 @@ production users, or material interaction with mainnet state.
 ## 4. No Trademark Rights
 
 This Additional Use Grant does not grant any right to use the names, logos, or
-trademarks of Zeko Labs, Zeko, SantaClawz, Magic City, or any related brand,
-except as separately authorized in writing.
+trademarks of Zeko Labs, Zeko, or any related brand, except as separately
+authorized in writing.
 
 ## 5. Separate Commercial Services
 

--- a/src/app/zeko/README.md
+++ b/src/app/zeko/README.md
@@ -1,3 +1,11 @@
-The code under here is under the RPL-1.5 license with modifications. A copy is included in https://github.com/zeko-labs/zeko/blob/compatible/src/app/zeko/LICENSE.md
+Zeko-owned protocol-layer code under this directory is licensed under BUSL-1.1
+with the Zeko Additional Use Grant. The current Change Date is 2030-07-17, and
+the Change License is Apache License, Version 2.0.
 
-You can also find the original license at https://opensource.org/license/rpl-1-5
+Non-production/testnet use is free under the Additional Use Grant. Independent
+Production Deployments of the Zeko protocol layer require the self-serve
+commercial deployment license unless an Additional Free Use applies.
+
+See [LICENSE.md](./LICENSE.md), [LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md](./LICENSES/ZEKO-ADDITIONAL-USE-GRANT.md),
+and the repository-level [LICENSING.md](../../../LICENSING.md), [PRICING.md](../../../PRICING.md),
+and [COMMERCIAL-TERMS.md](../../../COMMERCIAL-TERMS.md).


### PR DESCRIPTION
## Summary

- Adds BUSL-1.1 + Zeko Additional Use Grant docs for Zeko-owned protocol-layer code under `src/app/zeko`.
- Defines the canonical boundary: using or building on the Official Zeko Network does not require a separate commercial deployment license.
- Restores Agent Protocol Bundle as a protected product/protocol category in the shared self-serve licensing framework.
- Clarifies that Independent Agent Protocol Bundle production deployments are covered by the self-serve commercial deployment license, with the current published self-serve fee set to $0/year subject to `PRICING.md`.
- Adds commercial terms, current self-serve pricing, ecosystem exceptions, and notices at the repo level.
- Updates README licensing context to keep Mina-derived root code under Apache-2.0 while clarifying the protected Zeko protocol-layer and Agent Protocol Bundle boundaries.

## Pricing

- Protocol Layer Production Deployments: $0/year per production rollup under the current published self-serve pricing.
- Independent Agent Protocol Bundle Production Deployments: $0/year per deploying legal entity per Deployment Network under the current published self-serve pricing.
- No payment is due under the current pricing schedule.

## Notes

The current Change Date is 2030-07-17 and the Change License is Apache License, Version 2.0. The self-serve commercial deployment license covers license rights only; managed deployment, enterprise support, compliance review, SLAs, custom integrations, dedicated infrastructure, hosted services, and professional services are separate commercial services.

Official Zeko Network use and official Zeko-operated or Zeko-authorized Agent Protocol Bundle services may still involve ordinary network, gas, transaction, bridge, prover, marketplace, service, usage, or similar fees. The commercial deployment license is for independent production deployments of protected Zeko protocol-layer code or protected Agent Protocol Bundle code outside official Zeko-authorized deployments, with the current standard self-serve fee set to $0/year.

## Validation

- Ran `git diff --check` across the core Zeko repo.
- Confirmed the root and `src/app/zeko` copies of `ZEKO-ADDITIONAL-USE-GRANT.md` match.
- Confirmed no stale `$1,000` / `$5,000` license pricing references remain in the core Zeko licensing docs.
- Reviewed legal/readme surfaces for stale `Independent Agent Protocol Deployment` wording.