### PR TITLE
Finalize Ethereum deposits after inner sync

### DIFF
--- a/src/app/zeko/circuits/dune
+++ b/src/app/zeko/circuits/dune
@@ -36,6 +36,7 @@
   rule_bridge_finalize_withdrawal
   rule_bridge_finalize_cancelled_deposit
   rule_bridge_finalize_deposit
+  rule_bridge_finalize_deposit_ethereum
   rule_bridge_inner_receive
   rule_bridge_outer_token_owner
   rule_multisig_update

--- a/src/app/zeko/circuits/rule_bridge_finalize_deposit_ethereum.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_deposit_ethereum.ml
@@ -1,0 +1,288 @@
+open Core_kernel
+open Mina_base
+open Snark_params.Tick
+module PC = Signature_lib.Public_key.Compressed
+open Bridge_state
+open Zeko_util
+
+module A = struct
+  include Account_update.Authorization_kind
+
+  type var = Checked.t
+end
+
+module Make (Inputs : sig
+  val token_owner_l1 : Account_id.t option
+
+  val token_owner_l2 : Account_id.t option
+
+  val holder_accounts_l1 : PC.t list
+
+  val ethereum_holder_account_l1 : PC.t option
+
+  module Deposit_params : DEPOSIT_PARAMS
+
+  val zeko_l2 : PC.t
+
+  val bridge_proof_fee : Currency.Amount.t
+
+  val bridge_fee_recipient_l1 : PC.t
+
+  val bridge_fee_recipient_l2 : PC.t
+
+  val chain_l1 : Mina_signature_kind.t
+
+  val chain_l2 : Mina_signature_kind.t
+end) =
+struct
+  open Inputs
+
+  let token_id_l2 = token_owner_id token_owner_l2
+
+  module Token_id = struct
+    include Token_id
+
+    type var = Checked.t
+  end
+
+  module May_use_token = struct
+    include Account_update.May_use_token
+
+    type var = Checked.t
+  end
+
+  module Ase_inst = Ase.With_length.Make (struct
+    module Action_state = Rollup_state.Outer_action_state
+
+    let get_iterations =
+      Zeko_constants.Max_excess_actions.Finalize_deposit.outer
+  end)
+
+  module Witness = struct
+    type t =
+      { public_key : PC.t
+      ; vk_hash : F.t
+      ; may_use_token : May_use_token.t
+      ; inner_authorization_kind : A.t
+      ; ase : Ase_inst.t
+      ; params : Deposit_params.t
+      ; original_action_state : Rollup_state.Outer_action_state.t
+      ; deposit_index : Checked32.t
+      ; prev_next_deposit : Checked32.t
+      ; prev_nonce : Checked32.t
+      ; helper_account_new : Boolean.t
+      }
+    [@@deriving snarky]
+  end
+
+  (** Prove that an Ethereum deposit is part of the outer-action prefix already
+      synchronized into the inner account. Canonical Ethereum deposits have no
+      cancellation path, so neither a later commit nor the deposit timeout is
+      relevant to their L2 finalization. *)
+  let main (w : Witness.t V.t) =
+    let@ () = with_label ("main " ^ __LOC__) in
+    let* Witness.
+           { public_key
+           ; vk_hash
+           ; may_use_token
+           ; inner_authorization_kind
+           ; ase
+           ; params
+           ; original_action_state
+           ; deposit_index
+           ; prev_next_deposit
+           ; prev_nonce
+           ; helper_account_new
+           } =
+      exists Witness.typ ~compute:(V.get w)
+    in
+    let* ( { source = deposit_action_state; target = outer_action_state }
+         , verify_ase ) =
+      Ase_inst.get ase
+    in
+    let ethereum_holder_account_l1 =
+      match ethereum_holder_account_l1 with
+      | Some holder ->
+          Some holder
+      | None ->
+          failwith
+            "the Ethereum deposit-finalization circuit requires an Ethereum \
+             holder account"
+    in
+    let* deposit =
+      Bridge_state.deposit_action ~chain_l1
+        ~bridge_fee_recipient_l1:(constant PC.typ bridge_fee_recipient_l1)
+        ~bridge_proof_fee:(constant Currency.Amount.typ bridge_proof_fee)
+        ~holder_accounts_l1 ~token_owner_l1 ~ethereum_holder_account_l1
+        (module Deposit_params)
+        params
+    in
+    let* expected_deposit_action_state =
+      Rollup_state.Outer_action.push_witness_var deposit original_action_state
+    in
+    let* () =
+      assert_equal ~label:__LOC__ Rollup_state.Outer_action_state.typ
+        (Rollup_state.Outer_action_state.With_length.state_var
+           deposit_action_state )
+        expected_deposit_action_state
+    in
+    let* next_deposit = Checked32.Checked.succ deposit_index in
+    let* () =
+      assert_equal ~label:__LOC__ Checked32.typ
+        (Rollup_state.Outer_action_state.With_length.length_var
+           deposit_action_state )
+        next_deposit
+    in
+    let* () =
+      assert_var __LOC__
+        Checked32.Checked.(fun () -> prev_next_deposit < next_deposit)
+    in
+    let* helper_token_id =
+      make_checked
+      @@ fun () ->
+      let account_id =
+        Account_id.Checked.create public_key (constant Token_id.typ token_id_l2)
+      in
+      Account_id.Checked.derive_token_id ~owner:account_id
+    in
+    let base_params = Deposit_params.base params in
+    let prev_nonce =
+      Mina_numbers.Account_nonce.Checked.Unsafe.of_field
+        (Checked32.Checked.to_field prev_nonce)
+    in
+    let helper_account =
+      { default_account_update with
+        public_key = base_params.recipient
+      ; token_id = helper_token_id
+      ; authorization_kind = authorization_signed ()
+      ; use_full_commitment = Boolean.false_
+      ; increment_nonce = Boolean.true_
+      ; may_use_token = constant May_use_token.typ Parents_own_token
+      ; implicit_account_creation_fee = constant Boolean.typ false
+      ; update =
+          { default_account_update.update with
+            app_state =
+              Inner_user_state.fine { next_deposit = Some next_deposit }
+              |> var_to_app_state_fine
+          }
+      ; preconditions =
+          { default_account_update.preconditions with
+            account =
+              { default_account_update.preconditions.account with
+                is_new =
+                  Zkapp_basic.Or_ignore.Checked.make_unsafe Boolean.true_
+                    helper_account_new
+              ; state =
+                  Inner_user_state.fine
+                    { next_deposit = Some prev_next_deposit }
+                  |> var_to_precondition_fine
+              ; nonce =
+                  Zkapp_basic.Or_ignore.Checked.make_unsafe Boolean.true_
+                    { Zkapp_precondition.Closed_interval.lower = prev_nonce
+                    ; upper = prev_nonce
+                    }
+              }
+          }
+      }
+    in
+    let witness_inner =
+      { default_account_update with
+        public_key = constant PC.typ zeko_l2
+      ; authorization_kind = inner_authorization_kind
+      ; preconditions =
+          { default_account_update.preconditions with
+            account =
+              { default_account_update.preconditions.account with
+                state =
+                  Rollup_state.Inner_state.fine
+                    { outer_action_state =
+                        { state =
+                            Some
+                              (Rollup_state.Outer_action_state.With_length
+                               .state_var outer_action_state )
+                        ; length =
+                            Some
+                              (Rollup_state.Outer_action_state.With_length
+                               .length_var outer_action_state )
+                        }
+                    }
+                  |> var_to_precondition_fine
+              }
+          }
+      }
+    in
+    let* events =
+      var_to_events
+        Typ.(Checked32.typ * Deposit_params.typ)
+        (deposit_index, params)
+    in
+    let account_update =
+      { default_account_update with
+        public_key
+      ; token_id = constant Token_id.typ token_id_l2
+      ; may_use_token
+      ; authorization_kind = authorization_vk_hash vk_hash
+      ; balance_change =
+          Currency.Amount.Signed.Checked.(
+            of_unsigned base_params.amount |> negate)
+      ; events
+      }
+    in
+    let bridge_proof_fee = constant Currency.Amount.typ bridge_proof_fee in
+    let* recipient_payout =
+      let* recipient_payout, `Underflow underflow =
+        Currency.Amount.Checked.sub_flagged base_params.amount bridge_proof_fee
+      in
+      let* () = Boolean.Assert.is_true (Boolean.not underflow) in
+      let account_creation_fee =
+        constant Currency.Amount.typ
+          (Currency.Amount.of_fee
+             Zeko_constants.constraint_constants.account_creation_fee )
+      in
+      let* paid_for_helper_account_creation, `Underflow underflow =
+        Currency.Amount.Checked.sub_flagged recipient_payout
+          account_creation_fee
+      in
+      let* () = Boolean.Assert.is_true (Boolean.not underflow) in
+      if_ ~typ:Currency.Amount.typ helper_account_new
+        ~then_:paid_for_helper_account_creation ~else_:recipient_payout
+    in
+    let recipient_payout =
+      { default_account_update with
+        public_key = base_params.recipient
+      ; token_id = constant Token_id.typ token_id_l2
+      ; may_use_token = constant May_use_token.typ Parents_own_token
+      ; authorization_kind = constant A.typ None_given
+      ; balance_change =
+          Currency.Amount.Signed.Checked.of_unsigned recipient_payout
+      ; implicit_account_creation_fee = constant Boolean.typ true
+      }
+    in
+    let sequencer_fee_payout =
+      { default_account_update with
+        public_key = constant PC.typ bridge_fee_recipient_l2
+      ; token_id = constant Token_id.typ token_id_l2
+      ; may_use_token = constant May_use_token.typ Parents_own_token
+      ; authorization_kind = constant A.typ None_given
+      ; balance_change =
+          Currency.Amount.Signed.Checked.of_unsigned bridge_proof_fee
+      ; implicit_account_creation_fee = constant Boolean.typ true
+      }
+    in
+    let*| out =
+      make_outputs ~chain:chain_l2 account_update
+        [ (helper_account, [])
+        ; (witness_inner, [])
+        ; (recipient_payout, [])
+        ; (sequencer_fee_payout, [])
+        ]
+    in
+    Compile_simple.{ prevs = One_prev verify_ase; out }
+
+  let rule : _ Compile_simple.branch lazy_t =
+    lazy
+      { branch_name = "finalize ethereum deposit"
+      ; tags = One_tag (Lazy.force Ase.With_length.tag)
+      ; main
+      }
+end

--- a/src/app/zeko/sequencer/cli.ml
+++ b/src/app/zeko/sequencer/cli.ml
@@ -509,8 +509,14 @@ let update_inner_verification_keys =
            Lazy.force Inner_rules_inst.tag
            |> Compile_simple.Verification_key.of_tag |> Promise.to_deferred
          and bridge_holder_vk =
-           Lazy.force Bridge_inst_mina.System_L2.tag
-           |> Compile_simple.Verification_key.of_tag |> Promise.to_deferred
+           ( match Zeko_circuits_config.Inputs.ethereum_holder_account_l1 with
+           | None ->
+               Compile_simple.Verification_key.of_tag
+                 (Lazy.force Bridge_inst_mina.System_L2.tag)
+           | Some _ ->
+               Compile_simple.Verification_key.of_tag
+                 (Lazy.force Bridge_inst_ethereum.System_L2.tag) )
+           |> Promise.to_deferred
          in
          let inner =
            ( inner_vk

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -97,6 +97,10 @@ let create ~provers ~proof_cache_db ~preverify_l1 ~preverify_l2 ~bridge_txn_fee
   ; bridge_txn_fee
   }
 
+let l2_holder_vk_hash t =
+  Option.value t.verification_keys.bridge_ethereum_l2
+    ~default:t.verification_keys.bridge_mina_l2
+
 (** For [Finalize_cancelled_deposit] and [Finalize_withdrawal] the helper
     account update lives at [forest[0].calls[0].calls[0]] (nested inside the
     helper_token_owner). [precompute_commitments] returns it with
@@ -439,8 +443,7 @@ module Withdrawal_request = struct
 
   let make_inner_receive_witness t
       (withdrawal_params : Bridge_state.Withdrawal_params_base.t) =
-    Bridge.Inner_receive.of_serializable
-      ~vk_hash:t.verification_keys.bridge_mina_l2
+    Bridge.Inner_receive.of_serializable ~vk_hash:(l2_holder_vk_hash t)
       { public_key = Zeko_circuits_config.Inputs.holder_account_l2
       ; amount = withdrawal_params.amount
       }
@@ -706,7 +709,7 @@ module Finalize_deposit = struct
         ~proof_source:source ~proof_target:target check_accepted_init []
     in
     let witness : Bridge.Finalize_deposit.t =
-      { vk_hash = t.verification_keys.bridge_mina_l2
+      { vk_hash = l2_holder_vk_hash t
       ; public_key = Zeko_circuits_config.Inputs.holder_account_l2
       ; may_use_token =
           Bridge_inst_mina.Rule_bridge_finalize_deposit.May_use_token.No
@@ -869,6 +872,229 @@ module Finalize_deposit = struct
                     Error.raise e
                 | Ok ((body, _, calls), proof) ->
                     (* Attach helper account signature *)
+                    let calls =
+                      match calls with
+                      | helper_account :: remaining_calls ->
+                          Zkapp_command.Call_forest.cons
+                            ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+                            ~calls:helper_account.elt.calls
+                            { helper_account.elt.account_update with
+                              authorization =
+                                Control.Poly.Signature helper_account_signature
+                            }
+                            remaining_calls
+                      | _ ->
+                          failwith "shouldn't be reachable"
+                    in
+                    Utils.attach_proof_to_forest
+                      ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+                      ~proof_cache_db:t.proof_cache_db ~body ~calls ~proof
+                    |> Utils.rehash_forest
+                         ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 )
+            >>| Result.map_error ~f:(fun e -> Exn.to_string e)
+          in
+          match result with
+          | Error e ->
+              [%log warn] "prove failed %s" e ;
+              Error (Error.of_string e)
+          | Ok forest ->
+              Ok forest ) )
+end
+
+module Finalize_deposit_ethereum = struct
+  type t =
+    { ase_source : Ase.With_length.Stmt.t
+    ; params : Bridge_state.Deposit_params_base.t
+    ; original_action_state : Rollup_state.Outer_action_state.t
+    ; deposit_index : Zeko_util.Checked32.t
+    ; prev_next_deposit : Zeko_util.Checked32.t
+    ; prev_nonce : Zeko_util.Checked32.t
+    ; helper_account_new : Zeko_util.Boolean.t
+    }
+  [@@deriving snarky]
+
+  type t_ =
+    { ase_source : Ase.With_length.Stmt.t
+    ; params : Bridge_state.Deposit_params_base.t
+    ; original_action_state : Rollup_state.Outer_action_state.t
+    ; deposit_index : Zeko_util.Checked32.t
+    ; prev_next_deposit : Zeko_util.Checked32.t
+    ; prev_nonce : Zeko_util.Checked32.t
+    ; helper_account_new : Zeko_util.Boolean.t
+    ; ase_elems : Field.t list
+    }
+
+  let precompute_commitments t
+      ({ ase_source
+       ; ase_elems
+       ; params
+       ; original_action_state
+       ; deposit_index
+       ; prev_next_deposit
+       ; prev_nonce
+       ; helper_account_new
+       } :
+        t_ ) =
+    let ase =
+      let target =
+        fold
+          ~init_fn:(Ase.M_with_length.init ~check:None)
+          ~step_fn:Ase.M_with_length.step ~init_typ:Ase.M_with_length.Init.typ
+          ~stmt_typ:Ase.M_with_length.Stmt.typ ~elm_typ:F.typ ase_source
+          ase_elems
+      in
+      Bridge_inst_ethereum.Rule_bridge_finalize_deposit_ethereum.Ase_inst.make
+        ~proof:
+          (Compile_simple.Proof.of_pickles
+             Pickles_types.Nat.(Pickles.Proof.dummy N2.n N2.n ~domain_log2:14) )
+        ~proof_source:ase_source ~proof_target:target ase_source []
+    in
+    let witness : Bridge.Finalize_deposit_ethereum.t =
+      { vk_hash = l2_holder_vk_hash t
+      ; public_key = Zeko_circuits_config.Inputs.holder_account_l2
+      ; may_use_token =
+          Bridge_inst_ethereum.Rule_bridge_finalize_deposit_ethereum
+          .May_use_token
+          .No
+      ; inner_authorization_kind =
+          Zeko_circuits.Rule_bridge_finalize_deposit_ethereum.A.None_given
+      ; ase
+      ; params
+      ; original_action_state
+      ; deposit_index
+      ; prev_next_deposit
+      ; prev_nonce
+      ; helper_account_new
+      }
+    in
+    try
+      let _stmt, (body, _, calls) =
+        run_and_check_exn witness
+          Snark_params.Tick.Typ.(Mina_base.Zkapp_statement.typ * V.typ)
+          Bridge_inst_ethereum.Rule_bridge_finalize_deposit_ethereum.main
+      in
+      let account_update =
+        Account_update.with_aux
+          ~body:
+            ( match Is_compile_simple_real.is_compile_simple_real with
+            | Some _ ->
+                body
+            | None ->
+                { body with authorization_kind = None_given } )
+          ~authorization:Control.Poly.None_given
+      in
+      let forest =
+        Zkapp_command.Call_forest.cons
+          ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 ~calls
+          account_update []
+        |> Zkapp_command.Call_forest.map
+             ~f:Account_update.read_all_proofs_from_disk
+        |> Utils.rehash_forest
+             ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+      in
+      let tx_commitment =
+        Zkapp_command.Transaction_commitment.create
+          ~account_updates_hash:(Zkapp_command.Call_forest.hash forest)
+      in
+      Ok (forest, `Commitment tx_commitment)
+    with exn -> Error (Error.of_exn exn)
+
+  let key
+      ({ ase_source
+       ; params
+       ; original_action_state
+       ; deposit_index
+       ; prev_next_deposit
+       ; prev_nonce
+       ; helper_account_new
+       ; ase_elems
+       } :
+        t_ ) =
+    let (Typ typ) = typ in
+    let t =
+      typ.value_to_fields
+        { ase_source
+        ; params
+        ; original_action_state
+        ; deposit_index
+        ; prev_next_deposit
+        ; prev_nonce
+        ; helper_account_new
+        }
+      |> fst
+    in
+    Array.append t (Array.of_list ase_elems)
+    |> Random_oracle.hash
+         ~init:(Hash_prefix_create.salt Zeko_constants.bridge_prover_cache)
+    |> Field.to_string
+
+  let f ~t ~logger
+      ({ ase_source
+       ; ase_elems
+       ; params
+       ; original_action_state
+       ; deposit_index
+       ; prev_next_deposit
+       ; prev_nonce
+       ; helper_account_new
+       } as request :
+        t_ ) (helper_account_signature : Signature.t) =
+    let%bind.Result forest, `Commitment commitment =
+      precompute_commitments t request
+    in
+    let top_tree, helper, rest_calls =
+      match forest with
+      | [ ({ elt = { calls = helper :: rest; _ }; _ } as top) ] ->
+          (top, helper, rest)
+      | _ ->
+          failwith
+            "Finalize_deposit_ethereum: unexpected precomputed forest layout"
+    in
+    let helper_pk = helper.elt.account_update.body.public_key in
+    let%map.Result () =
+      verify_signature ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+        ~tx_commitment:commitment ~public_key:helper_pk helper_account_signature
+    in
+    let key = key request in
+    ( key
+    , Proofs_memory.prove t.proofs_memory key ~f:(fun () ->
+          let%map result =
+            try_with (fun () ->
+                let forest =
+                  let new_calls =
+                    Zkapp_command.Call_forest.cons
+                      ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+                      ~calls:helper.elt.calls
+                      { helper.elt.account_update with
+                        authorization =
+                          Control.Poly.Signature helper_account_signature
+                      }
+                      rest_calls
+                  in
+                  [ { top_tree with
+                      elt = { top_tree.elt with calls = new_calls }
+                    }
+                  ]
+                  |> Utils.rehash_forest
+                       ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+                in
+                let%bind () = t.preverify_l2 forest >>| Or_error.ok_exn in
+                match%map
+                  Zeko_prover.Client.finalize_deposit_ethereum t.provers
+                    ~public_key:Zeko_circuits_config.Inputs.holder_account_l2
+                    ~may_use_token:
+                      Bridge_inst_ethereum.Rule_bridge_finalize_deposit_ethereum
+                      .May_use_token
+                      .No
+                    ~inner_authorization_kind:
+                      Zeko_circuits.Rule_bridge_finalize_deposit_ethereum.A
+                      .None_given ~ase:(ase_source, ase_elems) ~params
+                    ~original_action_state ~deposit_index ~prev_next_deposit
+                    ~prev_nonce ~helper_account_new
+                with
+                | Error e ->
+                    Error.raise e
+                | Ok ((body, _, calls), proof) ->
                     let calls =
                       match calls with
                       | helper_account :: remaining_calls ->
@@ -1487,7 +1713,7 @@ module Finalize_withdrawal = struct
       ; withdrawal_params
       ; helper_token_owner_l1_vk_hash =
           t.verification_keys.bridge_mina_token_owner
-      ; l2_holder_vk_hash = t.verification_keys.bridge_mina_l2
+      ; l2_holder_vk_hash = l2_holder_vk_hash t
       ; prev_nonce
       ; helper_account_new
       }

--- a/src/app/zeko/sequencer/lib/deploy.ml
+++ b/src/app/zeko/sequencer/lib/deploy.ml
@@ -57,8 +57,13 @@ module Z = struct
         |> Promise.to_deferred
       in
       let%map holder_vk =
-        Compile_simple.Verification_key.of_tag
-          (Lazy.force Bridge_inst_mina.System_L2.tag)
+        ( match Zeko_circuits_config.Inputs.ethereum_holder_account_l1 with
+        | None ->
+            Compile_simple.Verification_key.of_tag
+              (Lazy.force Bridge_inst_mina.System_L2.tag)
+        | Some _ ->
+            Compile_simple.Verification_key.of_tag
+              (Lazy.force Bridge_inst_ethereum.System_L2.tag) )
         |> Promise.to_deferred
       in
       let inner_account =

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -1878,6 +1878,74 @@ module Types = struct
               ]
       end
 
+      module Finalize_deposit_ethereum = struct
+        module Deposit = struct
+          type input =
+            { params : Zeko_circuits.Bridge_state.Deposit_params_base.t
+            ; original_action_state :
+                Zeko_circuits.Rollup_state.Outer_action_state.t
+            ; deposit_index : Zeko_circuits.Zeko_util.Checked32.t
+            }
+
+          let arg_typ ~proof_cache_db =
+            obj "EthereumDepositFinalizationWitnessInput"
+              ~coerce:(fun params original_action_state deposit_index ->
+                { params
+                ; original_action_state =
+                    Zeko_circuits.Rollup_state.Outer_action_state
+                    .unsafe_value_of_field
+                    @@ Field.of_string original_action_state
+                ; deposit_index
+                } )
+              ~split:(fun f (x : input) ->
+                f x.params
+                  ( Field.to_string
+                  @@ Zeko_circuits.Rollup_state.Outer_action_state.raw
+                       x.original_action_state )
+                  x.deposit_index )
+              ~fields:
+                [ arg "params"
+                    ~typ:(non_null @@ Deposit_params.arg_typ ~proof_cache_db)
+                ; arg "originalActionState" ~typ:(non_null string)
+                ; arg "depositIndex" ~typ:(non_null UInt32.arg_typ)
+                ]
+        end
+
+        type input =
+          { ase : Ase.With_length.Stmt.t * Field.t list
+          ; deposit : Deposit.input
+          ; prev_next_deposit : Unsigned.uint32
+          ; prev_nonce : Unsigned.uint32
+          ; helper_account_new : bool
+          ; helper_account_signature : Signature.t
+          }
+
+        let arg_typ ~proof_cache_db =
+          obj "FinalizeEthereumDepositInput"
+            ~coerce:(fun ase deposit prev_next_deposit prev_nonce
+                         helper_account_new helper_account_signature ->
+              { ase
+              ; deposit
+              ; prev_next_deposit
+              ; prev_nonce
+              ; helper_account_new
+              ; helper_account_signature =
+                  Result.ok_or_failwith helper_account_signature
+              } )
+            ~split:(fun f (x : input) ->
+              f x.ase x.deposit x.prev_next_deposit x.prev_nonce
+                x.helper_account_new (Raw x.helper_account_signature) )
+            ~fields:
+              [ arg "ase" ~typ:(non_null Folder.Ase_with_length.arg_typ)
+              ; arg "deposit" ~typ:(non_null @@ Deposit.arg_typ ~proof_cache_db)
+              ; arg "prevNextDeposit" ~typ:(non_null UInt32.arg_typ)
+              ; arg "prevNonce" ~typ:(non_null UInt32.arg_typ)
+              ; arg "helperAccountNew" ~typ:(non_null bool)
+              ; arg "helperAccountSignature"
+                  ~typ:(non_null SignatureInput.arg_typ)
+              ]
+      end
+
       module Finalize_cancelled_deposit = struct
         type input =
           { public_key : Public_key.Compressed.t
@@ -2507,6 +2575,66 @@ module Mutations = struct
              in
              don't_wait_for d ; Ok key ) )
 
+    let finalize_deposit_ethereum ~proof_cache_db =
+      io_field "finalizeEthereumDeposit"
+        ~doc:"Finalize an Ethereum deposit after inner synchronization"
+        ~typ:(non_null Types.Payload.proof_key)
+        ~args:
+          Arg.
+            [ arg "input"
+                ~typ:
+                  ( non_null
+                  @@ Types.Input.Provers.Finalize_deposit_ethereum.arg_typ
+                       ~proof_cache_db )
+            ]
+        ~resolve:(fun { ctx = Context.{ sequencer; l2_executor; _ }; _ } ()
+                      witness ->
+          let { Types.Input.Provers.Finalize_deposit_ethereum.ase =
+                  ase_source, ase_elems
+              ; deposit = { params; original_action_state; deposit_index }
+              ; prev_next_deposit
+              ; prev_nonce
+              ; helper_account_new
+              ; helper_account_signature
+              } =
+            witness
+          in
+          let%bind.Deferred.Result () =
+            return
+              ( match Zeko_circuits_config.Inputs.ethereum_holder_account_l1 with
+              | Some _ ->
+                  Ok ()
+              | None ->
+                  Error
+                    "Ethereum deposit finalization is not enabled in the \
+                     circuit configuration" )
+          in
+          let logger = Zeko_sequencer.(sequencer.logger) in
+          let t = Zeko_sequencer.(sequencer.bridge_prover) in
+          return
+            (let%bind.Result key, d =
+               Bridge_prover.Finalize_deposit_ethereum.f
+                 ~t:Zeko_sequencer.(sequencer.bridge_prover)
+                 ~logger:Zeko_sequencer.(sequencer.logger)
+                 { ase_source
+                 ; ase_elems
+                 ; params
+                 ; original_action_state
+                 ; deposit_index
+                 ; prev_next_deposit
+                 ; prev_nonce
+                 ; helper_account_new
+                 }
+                 helper_account_signature
+               |> Result.map_error ~f:Error.to_string_hum
+             in
+             let d =
+               Bridge_prover.execute_request t ~logger ~executor:l2_executor
+                 (key, d)
+               >>| ignore
+             in
+             don't_wait_for d ; Ok key ) )
+
     let finalize_withdrawal ~proof_cache_db =
       io_field "finalizeWithdrawal" ~doc:"Finalize a withdrawal"
         ~typ:(non_null Types.Payload.proof_key)
@@ -2633,6 +2761,7 @@ module Mutations = struct
       [ deposit_request ~proof_cache_db
       ; withdrawal_request ~proof_cache_db
       ; finalize_deposit ~proof_cache_db
+      ; finalize_deposit_ethereum ~proof_cache_db
       ; finalize_withdrawal ~proof_cache_db
       ; cancel_deposit ~proof_cache_db
       ]

--- a/src/app/zeko/sequencer/prover/lib/client.ml
+++ b/src/app/zeko/sequencer/prover/lib/client.ml
@@ -568,6 +568,43 @@ let finalize_deposit t ~public_key ~may_use_token ~inner_authorization_kind
   | _ ->
       failwith "Unexpected response from prover"
 
+let finalize_deposit_ethereum t ~public_key ~may_use_token
+    ~inner_authorization_kind ~(ase : Ase.With_length.Stmt.t * Field.t list)
+    ~params ~original_action_state ~deposit_index ~prev_next_deposit ~prev_nonce
+    ~helper_account_new =
+  let%bind.Deferred.Result ase =
+    let ase_source, ase_elms = ase in
+    let%map.Deferred.Result proof, target, excess =
+      ase_cached_folder_with_length t ~source:ase_source ~elems:ase_elms
+        ~max_excess:Zeko_constants.Max_excess_actions.Finalize_deposit.outer
+        (ase_with_length ~sendfn:send)
+    in
+    Bridge.Finalize_deposit_ethereum.Ase_inst.
+      { proof; proof_target = target; init = ase_source; excess }
+  in
+  send t
+    Prover.Input.(
+      Bridge
+        (Finalize_deposit_ethereum
+           { public_key
+           ; may_use_token
+           ; inner_authorization_kind
+           ; ase
+           ; params
+           ; original_action_state
+           ; deposit_index
+           ; prev_next_deposit
+           ; prev_nonce
+           ; helper_account_new
+           } ))
+  >>| function
+  | Prover.Output.Call_forest (parent_with_calls, proof) ->
+      Ok (parent_with_calls, proof)
+  | Prover.Output.Error err ->
+      Error (Error.of_string err)
+  | _ ->
+      failwith "Unexpected response from prover"
+
 let finalize_cancelled_deposit t ~public_key ~may_use_token
     ~outer_authorization_kind ~commit ~before_commit
     ~(commit_ase : Ase.Without_length.Stmt.t * Field.t list)

--- a/src/app/zeko/sequencer/prover/lib/compile_circuits.ml
+++ b/src/app/zeko/sequencer/prover/lib/compile_circuits.ml
@@ -39,6 +39,13 @@ let compile_all ~logger () =
   in
   let%bind () = compile_tag (Lazy.force Bridge_inst_mina.System_L2.tag) in
   let%bind () =
+    match Zeko_circuits_config.Inputs.ethereum_holder_account_l1 with
+    | None ->
+        return ()
+    | Some _ ->
+        compile_tag (Lazy.force Bridge_inst_ethereum.System_L2.tag)
+  in
+  let%bind () =
     compile_tag (Lazy.force Bridge_inst_mina.System_L1_token_owner.tag)
   in
   [%log info] "Compiled circuits in %s"

--- a/src/app/zeko/sequencer/prover/lib/prover.ml
+++ b/src/app/zeko/sequencer/prover/lib/prover.ml
@@ -171,6 +171,8 @@ module Input = struct
       | Outer_action_witness of Bridge.Outer_action_witness.serializable
       | Inner_action_witness of Bridge.Inner_action_witness.serializable
       | Finalize_deposit of Bridge.Finalize_deposit.serializable
+      | Finalize_deposit_ethereum of
+          Bridge.Finalize_deposit_ethereum.serializable
       | Finalize_cancelled_deposit of
           Bridge.Finalize_cancelled_deposit.serializable
       | Inner_receive of Bridge.Inner_receive.serializable
@@ -211,6 +213,7 @@ module Verification_key_hashes = struct
     ; bridge_mina_l1 : F.t
     ; bridge_mina_token_owner : F.t
     ; bridge_mina_l2 : F.t
+    ; bridge_ethereum_l2 : F.t option
     }
   [@@deriving yojson]
 end
@@ -454,20 +457,75 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
               (Zkapp_command.Call_forest.map
                  ~f:Account_update.read_all_proofs_from_disk )
         , proof )
-  | Bridge (Finalize_deposit input) ->
-      let Compile_simple.[ prove; _; _ ] =
-        Lazy.force Bridge_inst_mina.System_L2.provers
+  | Bridge (Finalize_deposit input) -> (
+      match Zeko_circuits_config.Inputs.ethereum_holder_account_l1 with
+      | None ->
+          let Compile_simple.[ prove; _; _ ] =
+            Lazy.force Bridge_inst_mina.System_L2.provers
+          in
+          let%bind vk_hash =
+            Compile_simple.Verification_key.of_tag
+              (Lazy.force Bridge_inst_mina.System_L2.tag)
+            |> Promise.to_deferred
+            (* To make fake tests work *)
+            >>| Compile_simple.Verification_key.hash
+          in
+          let%map (_stmt, parent_with_calls), proof =
+            time ?fake_proving_time ~logger
+              "Bridge_mina.System_L2.finalize_deposit"
+              ( prove (Bridge.Finalize_deposit.of_serializable ~vk_hash input)
+              |> Promise.to_deferred )
+          in
+          Output.Call_forest
+            ( Tuple3.map_trd parent_with_calls
+                ~f:
+                  (Zkapp_command.Call_forest.map
+                     ~f:Account_update.read_all_proofs_from_disk )
+            , proof )
+      | Some _ ->
+          let Compile_simple.[ prove; _; _; _ ] =
+            Lazy.force Bridge_inst_ethereum.System_L2.provers
+          in
+          let%bind vk_hash =
+            Compile_simple.Verification_key.of_tag
+              (Lazy.force Bridge_inst_ethereum.System_L2.tag)
+            |> Promise.to_deferred
+            (* To make fake tests work *)
+            >>| Compile_simple.Verification_key.hash
+          in
+          let%map (_stmt, parent_with_calls), proof =
+            time ?fake_proving_time ~logger
+              "Bridge_ethereum.System_L2.finalize_deposit"
+              ( prove (Bridge.Finalize_deposit.of_serializable ~vk_hash input)
+              |> Promise.to_deferred )
+          in
+          Output.Call_forest
+            ( Tuple3.map_trd parent_with_calls
+                ~f:
+                  (Zkapp_command.Call_forest.map
+                     ~f:Account_update.read_all_proofs_from_disk )
+            , proof ) )
+  | Bridge (Finalize_deposit_ethereum input) ->
+      let (_ : Signature_lib.Public_key.Compressed.t) =
+        Option.value_exn Zeko_circuits_config.Inputs.ethereum_holder_account_l1
+          ~message:
+            "Ethereum deposit finalization requires an Ethereum bridge holder"
+      in
+      let Compile_simple.[ _; prove; _; _ ] =
+        Lazy.force Bridge_inst_ethereum.System_L2.provers
       in
       let%bind vk_hash =
         Compile_simple.Verification_key.of_tag
-          (Lazy.force Bridge_inst_mina.System_L2.tag)
+          (Lazy.force Bridge_inst_ethereum.System_L2.tag)
         |> Promise.to_deferred
         (* To make fake tests work *)
         >>| Compile_simple.Verification_key.hash
       in
       let%map (_stmt, parent_with_calls), proof =
-        time ?fake_proving_time ~logger "Bridge_mina.System_L2.finalize_deposit"
-          ( prove (Bridge.Finalize_deposit.of_serializable ~vk_hash input)
+        time ?fake_proving_time ~logger
+          "Bridge_ethereum.System_L2.finalize_deposit"
+          ( prove
+              (Bridge.Finalize_deposit_ethereum.of_serializable ~vk_hash input)
           |> Promise.to_deferred )
       in
       Output.Call_forest
@@ -508,28 +566,54 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
               (Zkapp_command.Call_forest.map
                  ~f:Account_update.read_all_proofs_from_disk )
         , proof )
-  | Bridge (Inner_receive input) ->
-      let Compile_simple.[ _; prove; _ ] =
-        Lazy.force Bridge_inst_mina.System_L2.provers
-      in
-      let%bind vk_hash =
-        Compile_simple.Verification_key.of_tag
-          (Lazy.force Bridge_inst_mina.System_L2.tag)
-        |> Promise.to_deferred
-        (* To make fake tests work *)
-        >>| Compile_simple.Verification_key.hash
-      in
-      let%map (_stmt, parent_with_calls), proof =
-        time ?fake_proving_time ~logger "Bridge_mina.System_L2.inner_receive"
-          ( prove (Bridge.Inner_receive.of_serializable ~vk_hash input)
-          |> Promise.to_deferred )
-      in
-      Output.Call_forest
-        ( Tuple3.map_trd parent_with_calls
-            ~f:
-              (Zkapp_command.Call_forest.map
-                 ~f:Account_update.read_all_proofs_from_disk )
-        , proof )
+  | Bridge (Inner_receive input) -> (
+      match Zeko_circuits_config.Inputs.ethereum_holder_account_l1 with
+      | None ->
+          let Compile_simple.[ _; prove; _ ] =
+            Lazy.force Bridge_inst_mina.System_L2.provers
+          in
+          let%bind vk_hash =
+            Compile_simple.Verification_key.of_tag
+              (Lazy.force Bridge_inst_mina.System_L2.tag)
+            |> Promise.to_deferred
+            (* To make fake tests work *)
+            >>| Compile_simple.Verification_key.hash
+          in
+          let%map (_stmt, parent_with_calls), proof =
+            time ?fake_proving_time ~logger
+              "Bridge_mina.System_L2.inner_receive"
+              ( prove (Bridge.Inner_receive.of_serializable ~vk_hash input)
+              |> Promise.to_deferred )
+          in
+          Output.Call_forest
+            ( Tuple3.map_trd parent_with_calls
+                ~f:
+                  (Zkapp_command.Call_forest.map
+                     ~f:Account_update.read_all_proofs_from_disk )
+            , proof )
+      | Some _ ->
+          let Compile_simple.[ _; _; prove; _ ] =
+            Lazy.force Bridge_inst_ethereum.System_L2.provers
+          in
+          let%bind vk_hash =
+            Compile_simple.Verification_key.of_tag
+              (Lazy.force Bridge_inst_ethereum.System_L2.tag)
+            |> Promise.to_deferred
+            (* To make fake tests work *)
+            >>| Compile_simple.Verification_key.hash
+          in
+          let%map (_stmt, parent_with_calls), proof =
+            time ?fake_proving_time ~logger
+              "Bridge_ethereum.System_L2.inner_receive"
+              ( prove (Bridge.Inner_receive.of_serializable ~vk_hash input)
+              |> Promise.to_deferred )
+          in
+          Output.Call_forest
+            ( Tuple3.map_trd parent_with_calls
+                ~f:
+                  (Zkapp_command.Call_forest.map
+                     ~f:Account_update.read_all_proofs_from_disk )
+            , proof ) )
   | Bridge (Finalize_withdrawal input) ->
       let Compile_simple.[ _; prove; _; _ ] =
         Lazy.force Bridge_inst_mina.System_L1_enabled.provers
@@ -549,8 +633,13 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
         >>| Compile_simple.Verification_key.hash
       in
       let%bind l2_holder_vk_hash =
-        Compile_simple.Verification_key.of_tag
-          (Lazy.force Bridge_inst_mina.System_L2.tag)
+        ( match Zeko_circuits_config.Inputs.ethereum_holder_account_l1 with
+        | None ->
+            Compile_simple.Verification_key.of_tag
+              (Lazy.force Bridge_inst_mina.System_L2.tag)
+        | Some _ ->
+            Compile_simple.Verification_key.of_tag
+              (Lazy.force Bridge_inst_ethereum.System_L2.tag) )
         |> Promise.to_deferred
         (* To make fake tests work *)
         >>| Compile_simple.Verification_key.hash
@@ -612,6 +701,15 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
         Compile_simple.Verification_key.of_tag
           (Lazy.force Bridge_inst_mina.System_L2.tag)
         |> Promise.to_deferred >>| Compile_simple.Verification_key.hash
+      and bridge_ethereum_l2 =
+        match Zeko_circuits_config.Inputs.ethereum_holder_account_l1 with
+        | None ->
+            return None
+        | Some _ ->
+            Compile_simple.Verification_key.of_tag
+              (Lazy.force Bridge_inst_ethereum.System_L2.tag)
+            |> Promise.to_deferred
+            >>| Fn.compose Option.some Compile_simple.Verification_key.hash
       in
       return
         (Output.Verification_keys
@@ -620,6 +718,7 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
            ; bridge_mina_l1
            ; bridge_mina_token_owner
            ; bridge_mina_l2
+           ; bridge_ethereum_l2
            } )
 
 let run ?fake_proving_time ~logger ~mq_host () =

--- a/src/app/zeko/tests/compile_ethereum_immediate_deposit.ml
+++ b/src/app/zeko/tests/compile_ethereum_immediate_deposit.ml
@@ -1,0 +1,16 @@
+open Core_kernel
+open Zeko_types
+
+let () =
+  let (_ : Signature_lib.Public_key.Compressed.t) =
+    Option.value_exn Zeko_circuits_config.Inputs.ethereum_holder_account_l1
+      ~message:"ZEKO_ETHEREUM_BRIDGE_ADDRESS must be set"
+  in
+  let tag = Lazy.force Bridge_inst_ethereum.System_L2.tag in
+  let verification_key =
+    Promise.block_on_async_exn (fun () ->
+        Compile_simple.Verification_key.of_tag tag )
+  in
+  verification_key |> Compile_simple.Verification_key.hash
+  |> Snark_params.Tick.Field.to_string
+  |> printf "Ethereum immediate-deposit bridge VK: %s\n"

--- a/src/app/zeko/tests/dune
+++ b/src/app/zeko/tests/dune
@@ -92,6 +92,13 @@
  (modules ethereum_bridge_vectors))
 
 (executable
+ (name compile_ethereum_immediate_deposit)
+ (libraries zeko_types compile_simple_real zeko_circuits_config)
+ (preprocess
+  (pps ppx_jane))
+ (modules compile_ethereum_immediate_deposit))
+
+(executable
  (name test_pause_fake)
  (libraries zeko_circuits compile_simple_fake)
  (instrumentation

--- a/src/app/zeko/zeko_types/zeko_types.ml
+++ b/src/app/zeko/zeko_types/zeko_types.ml
@@ -56,6 +56,36 @@ module Outer_rules_inst = Outer_rules.Make (Zeko_circuits_config.Inputs) ()
 module Bridge_inst_mina =
   Bridge_rules.Make_mina (Zeko_circuits_config.Inputs) ()
 
+module Bridge_inst_ethereum = struct
+  module Inputs = struct
+    include Zeko_circuits_config.Inputs
+
+    let token_owner_l1 = None
+
+    let token_owner_l2 = None
+
+    module Deposit_params = Bridge_state.Deposit_params_base
+  end
+
+  module Rule_bridge_finalize_deposit =
+    Bridge_inst_mina.Rule_bridge_finalize_deposit
+  module Rule_bridge_finalize_deposit_ethereum =
+    Rule_bridge_finalize_deposit_ethereum.Make (Inputs)
+  module Rule_bridge_inner_receive = Bridge_inst_mina.Rule_bridge_inner_receive
+  module Rule_multisig_update_l2 = Bridge_inst_mina.Rule_multisig_update_l2
+
+  module System_L2 =
+  ( val Compile_simple.compile ~name:"bridge rules for ethereum l2"
+          ~out_typ:Snark_params.Tick.Typ.(Mina_base.Zkapp_statement.typ * V.typ)
+          ~branches:
+            [ Rule_bridge_finalize_deposit.rule
+            ; Rule_bridge_finalize_deposit_ethereum.rule
+            ; Rule_bridge_inner_receive.rule
+            ; Rule_multisig_update_l2.rule
+            ]
+          () )
+end
+
 module F = struct
   include F
 
@@ -1028,6 +1058,63 @@ module Bridge = struct
       ; inner_authorization_kind
       ; ase = Ase_inst.of_serializable ase
       ; check_accepted = Check_accepted_mina.of_serializable check_accepted
+      ; prev_next_deposit
+      ; prev_nonce =
+          Mina_numbers.Account_nonce.of_string (Checked32.to_string prev_nonce)
+      ; helper_account_new
+      }
+  end
+
+  module Finalize_deposit_ethereum = struct
+    module Ase_inst = Ase.Make_serializable_ase (struct
+      module Ase_system = Ase.With_length
+      module Action_state = Outer_action_state.With_length
+
+      module Ase_inst =
+        Bridge_inst_ethereum.Rule_bridge_finalize_deposit_ethereum.Ase_inst
+    end)
+
+    type t =
+      Bridge_inst_ethereum.Rule_bridge_finalize_deposit_ethereum.Witness.t
+
+    type serializable =
+      { public_key : Public_key.Compressed.t
+      ; may_use_token :
+          Bridge_inst_ethereum.Rule_bridge_finalize_deposit_ethereum
+          .May_use_token
+          .t
+      ; inner_authorization_kind : Rule_bridge_finalize_deposit_ethereum.A.t
+      ; ase : Ase_inst.serializable
+      ; params : Deposit_params_base.t
+      ; original_action_state : Outer_action_state.t
+      ; deposit_index : Checked32.t
+      ; prev_next_deposit : Checked32.t
+      ; prev_nonce : Checked32.t
+      ; helper_account_new : bool
+      }
+    [@@deriving yojson]
+
+    let of_serializable
+        ({ public_key
+         ; may_use_token
+         ; inner_authorization_kind
+         ; ase
+         ; params
+         ; original_action_state
+         ; deposit_index
+         ; prev_next_deposit
+         ; prev_nonce
+         ; helper_account_new
+         } :
+          serializable ) ~vk_hash : t =
+      { public_key
+      ; vk_hash
+      ; may_use_token
+      ; inner_authorization_kind
+      ; ase = Ase_inst.of_serializable ase
+      ; params
+      ; original_action_state
+      ; deposit_index
       ; prev_next_deposit
       ; prev_nonce =
           Mina_numbers.Account_nonce.of_string (Checked32.to_string prev_nonce)


### PR DESCRIPTION
## What changed

- add a separate Ethereum L2 bridge circuit branch that proves the exact canonical deposit action is inside the outer-action prefix synchronized into the inner account
- omit the later commit and timeout checks only for that Ethereum-specific branch
- add prover, GraphQL, deployment, and verification-key plumbing for the four-branch Ethereum bridge system
- retain the legacy commit-gated finalizer branch for migration compatibility

## Why

Canonical Ethereum deposits use the synthetic Ethereum holder and have no cancellation path. Requiring a later bridge commit therefore adds the settlement proof/window delay without adding a safety property. The synchronized inner outer-action state already commits to the exact deposit action.

## Impact

Ethereum deposits can be finalized immediately after inner synchronization instead of waiting for the next commit and its settlement proof. The Mina Zeko circuit and its three-branch bridge system are unchanged.

## Validation

- built the sequencer, DA layer, and signer
- compiled the real four-branch Ethereum bridge circuit; VK hash: `26411979738792341148947923691210257386959361217839606756119894603343339264783`
- passed the three-prover fake sequencer end-to-end regression
- `git diff --check`
- confirmed no diff in `check_accepted_make.ml`, `rule_bridge_finalize_deposit.ml`, or `bridge_rules.ml`