### PR TITLE
fix(sequencer): Remove duplicate transaction hash computation in executor

### DIFF
--- a/src/app/zeko/sequencer/lib/executor.ml
+++ b/src/app/zeko/sequencer/lib/executor.ml
@@ -113,13 +113,12 @@ let process_command ~logger ?settlement_export t (command : Zkapp_command.t) =
       command
     with
     | Ok command ->
-        [%log info] "Sent zkapp command: %s"
-          Transaction_hash.(
-            to_base58_check @@ hash_command (Zkapp_command command)) ;
-        increment_nonce t ;
-        let hash : Mina_transaction.Transaction_hash.t =
+        let hash =
           Mina_transaction.Transaction_hash.hash_command (Zkapp_command command)
         in
+        [%log info] "Sent zkapp command: %s"
+          (Mina_transaction.Transaction_hash.to_base58_check hash) ;
+        increment_nonce t ;
         return (Ok hash)
     | Error err when attempt >= t.max_attempts ->
         return


### PR DESCRIPTION
Transaction hash was computed twice: once for logging and once for return value.

Changed to compute hash once and reuse it for both purposes.