### PR TITLE
feat(zeko): add universal ERC20 asset registry

### DIFF
--- a/src/app/zeko/circuits/asset_registry.ml
+++ b/src/app/zeko/circuits/asset_registry.ml
@@ -3,6 +3,7 @@ open Mina_base
 open Snark_params.Tick
 open Zeko_util
 module PC = Signature_lib.Public_key.Compressed
+
 module Token_id = struct
   include Token_id
 
@@ -66,6 +67,13 @@ module Registry_state = struct
     ; Whole (Checked32.typ, leaf_count)
     ; Whole (Checked32.typ, schema_version)
     ]
+
+  let value_of_app_state
+      (root :: leaf_count :: schema_version :: _ : F.t Zkapp_state.V.t) : t =
+    { root
+    ; leaf_count = Field.to_string leaf_count |> Checked32.of_string
+    ; schema_version = Field.to_string schema_version |> Checked32.of_string
+    }
 end
 
 module Path = struct
@@ -101,9 +109,7 @@ module Output = struct
     Zkapp_command.Call_forest.t
 
   type auxiliary =
-    Account_update.Body.t
-    * Zkapp_command.Digest.Account_update.t
-    * calls
+    Account_update.Body.t * Zkapp_command.Digest.Account_update.t * calls
 
   type t = Zkapp_statement.t * auxiliary
 end
@@ -111,13 +117,13 @@ end
 let merge left right =
   Random_oracle.hash
     ~init:
-      (Hash_prefix_create.salt
-         Zeko_constants.ethereum_asset_registry_node_salt )
+      (Hash_prefix_create.salt Zeko_constants.ethereum_asset_registry_node_salt)
     [| left; right |]
 
 let merge_var left right =
   var_to_hash ~init:Zeko_constants.ethereum_asset_registry_node_salt
-    Typ.(F.typ * F.typ) (left, right)
+    Typ.(F.typ * F.typ)
+    (left, right)
 
 let path_bits_var index =
   Field.Checked.choose_preimage_var
@@ -126,14 +132,9 @@ let path_bits_var index =
 
 let implied_root_var ~leaf ~index (path : Path.var) =
   let* bits = path_bits_var index in
-  foldl (List.zip_exn path bits) ~init:leaf
-    ~f:(fun acc (sibling, is_right) ->
-      let* left =
-        if_ is_right ~typ:F.typ ~then_:sibling ~else_:acc
-      in
-      let* right =
-        if_ is_right ~typ:F.typ ~then_:acc ~else_:sibling
-      in
+  foldl (List.zip_exn path bits) ~init:leaf ~f:(fun acc (sibling, is_right) ->
+      let* left = if_ is_right ~typ:F.typ ~then_:sibling ~else_:acc in
+      let* right = if_ is_right ~typ:F.typ ~then_:acc ~else_:sibling in
       merge_var left right )
 
 let implied_root ~leaf ~index (path : Path.t) =
@@ -157,8 +158,9 @@ module Merkle_list = struct
   let count t = t.count
 
   let next_level level =
-    Array.init (Array.length level / 2) ~f:(fun i ->
-        merge level.(2 * i) level.((2 * i) + 1) )
+    Array.init
+      (Array.length level / 2)
+      ~f:(fun i -> merge level.(2 * i) level.((2 * i) + 1))
 
   let levels t =
     let rec go acc level =
@@ -208,6 +210,8 @@ end
 module type CONFIG = sig
   val registry_public_key : PC.t
 
+  val registration_authority : PC.t
+
   val schema_version : Checked32.t
 
   val approved_mft_standard_vk_id : F.t
@@ -238,10 +242,10 @@ module Make (Config : CONFIG) () = struct
 
   let assert_fits_bits ~label ~length value =
     with_label label (fun () ->
-      let* (_ : Boolean.var list) =
-        Field.Checked.choose_preimage_var value ~length
-      in
-      Checked.return () )
+        let* (_ : Boolean.var list) =
+          Field.Checked.choose_preimage_var value ~length
+        in
+        Checked.return () )
 
   let validate_record ?(check = Boolean.true_) (record : Asset_record.var) =
     let* () =
@@ -253,8 +257,7 @@ module Make (Config : CONFIG) () = struct
       Checked32.Checked.(
         record.registry_index
         < constant
-            (Checked32.of_int
-               Zeko_constants.Ethereum_asset_registry.max_assets ) )
+            (Checked32.of_int Zeko_constants.Ethereum_asset_registry.max_assets))
     in
     let* () = assert_implies check index_in_range in
     let* () =
@@ -264,7 +267,8 @@ module Make (Config : CONFIG) () = struct
     in
     let* () =
       assert_equal_if ~label:"asset registry shared vault" check PC.typ
-        record.vault_public_key (constant PC.typ Config.vault_public_key)
+        record.vault_public_key
+        (constant PC.typ Config.vault_public_key)
     in
     let* () =
       assert_not_equal_if ~label:"asset registry owner/vault separation" check
@@ -278,8 +282,8 @@ module Make (Config : CONFIG) () = struct
       make_checked (fun () -> Account_id.Checked.derive_token_id ~owner)
     in
     let* () =
-      assert_equal_if ~label:"asset registry derived token ID" check Token_id.typ
-        record.token_id_l2 derived_token_id
+      assert_equal_if ~label:"asset registry derived token ID" check
+        Token_id.typ record.token_id_l2 derived_token_id
     in
     let* decimals_supported =
       Checked32.Checked.(record.decimals < constant (Checked32.of_int 10))
@@ -301,8 +305,8 @@ module Make (Config : CONFIG) () = struct
         record.asset_id_low
     in
     let* () =
-      assert_fits_bits ~label:"asset registry Ethereum token address" ~length:160
-        record.ethereum_token_address
+      assert_fits_bits ~label:"asset registry Ethereum token address"
+        ~length:160 record.ethereum_token_address
     in
     let* () =
       let* address_is_zero =
@@ -371,7 +375,8 @@ module Make (Config : CONFIG) () = struct
   let verify ({ state; record; path } : Membership_witness.var) =
     let* () =
       assert_equal ~label:"asset registry state schema" Checked32.typ
-        state.schema_version (Checked32.Checked.constant Config.schema_version)
+        state.schema_version
+        (Checked32.Checked.constant Config.schema_version)
     in
     let* token_id = validate_record record in
     let* record_before_count =
@@ -405,14 +410,12 @@ module Make (Config : CONFIG) () = struct
     end
 
     module Elem = struct
-      type t =
-        { active : Boolean.t; record : Asset_record.t; path : Path.t }
+      type t = { active : Boolean.t; record : Asset_record.t; path : Path.t }
       [@@deriving snarky]
     end
 
     module Init = struct
-      type t =
-        { old_state : Registry_state.t; candidate : Asset_record.t }
+      type t = { old_state : Registry_state.t; candidate : Asset_record.t }
       [@@deriving snarky]
     end
 
@@ -445,13 +448,12 @@ module Make (Config : CONFIG) () = struct
         implied_root_var ~leaf ~index:state.next_expected_index path
       in
       let* () =
-        assert_equal_if ~label:"asset registry scan membership" active F.typ root
-          state.old_root
+        assert_equal_if ~label:"asset registry scan membership" active F.typ
+          root state.old_root
       in
       let* () =
         assert_not_equal_if ~label:"unique Ethereum token address" active F.typ
-          record.ethereum_token_address
-          state.candidate.ethereum_token_address
+          record.ethereum_token_address state.candidate.ethereum_token_address
       in
       let* asset_high_equal =
         Field.Checked.equal record.asset_id_high state.candidate.asset_id_high
@@ -477,8 +479,7 @@ module Make (Config : CONFIG) () = struct
       let* traversed_count =
         Checked32.Checked.succ_if state.traversed_count active
       in
-      Checked.return
-        { state with next_expected_index; traversed_count }
+      Checked.return { state with next_expected_index; traversed_count }
 
     let dummy_elem : Elem.t =
       { active = false
@@ -497,8 +498,8 @@ module Make (Config : CONFIG) () = struct
           ; universal_bridge_vk_id = Field.zero
           }
       ; path =
-          List.init Zeko_constants.Ethereum_asset_registry.depth
-            ~f:(fun _ -> Field.zero)
+          List.init Zeko_constants.Ethereum_asset_registry.depth ~f:(fun _ ->
+              Field.zero )
       }
 
     let leaf_iterations =
@@ -524,6 +525,7 @@ module Make (Config : CONFIG) () = struct
 
   module Scan = struct
     module Definition = Scan_definition
+
     include Folder.Make (Definition) ()
   end
 
@@ -534,10 +536,7 @@ module Make (Config : CONFIG) () = struct
   module Register = struct
     module Witness = struct
       type t =
-        { scan : Scan_inst.t
-        ; append_path : Path.t
-        ; registry_vk_hash : F.t
-        }
+        { scan : Scan_inst.t; append_path : Path.t; registry_vk_hash : F.t }
       [@@deriving snarky]
     end
 
@@ -582,20 +581,19 @@ module Make (Config : CONFIG) () = struct
           target.leaf_count
           < constant
               (Checked32.of_int
-                 Zeko_constants.Ethereum_asset_registry.max_assets ) )
+                 Zeko_constants.Ethereum_asset_registry.max_assets ))
       in
       let* () = Boolean.Assert.is_true has_capacity in
       let* old_root_from_empty =
-        implied_root_var ~leaf:(constant F.typ Field.zero)
+        implied_root_var
+          ~leaf:(constant F.typ Field.zero)
           ~index:target.leaf_count append_path
       in
       let* () =
         assert_equal ~label:"asset registry empty append slot" F.typ
           target.old_root old_root_from_empty
       in
-      let* candidate_leaf =
-        Asset_record.commitment_var target.candidate
-      in
+      let* candidate_leaf = Asset_record.commitment_var target.candidate in
       let* new_root =
         implied_root_var ~leaf:candidate_leaf ~index:target.leaf_count
           append_path
@@ -614,6 +612,12 @@ module Make (Config : CONFIG) () = struct
         }
       in
       let* events = var_to_events Asset_record.typ target.candidate in
+      let* registration_call_data =
+        var_to_hash
+          ~init:Zeko_constants.ethereum_asset_registry_registration_salt
+          Typ.(Registry_state.typ * Registry_state.typ * Asset_record.typ)
+          ((old_state, new_state), target.candidate)
+      in
       let account_update =
         { default_account_update with
           public_key = constant PC.typ Config.registry_public_key
@@ -644,7 +648,24 @@ module Make (Config : CONFIG) () = struct
         ; events
         }
       in
-      let*| out = make_outputs ~chain:Config.chain_l2 account_update [] in
+      (* The PoC mirrors Ethereum bridge governance with a fixed Mina
+         registration authority. Full-commitment signing binds the
+         administrator to the candidate event, exact root/count transition,
+         and every onboarding-account probe in this transaction. Ethereum
+         remains the proposal and activation source of truth. *)
+      let registration_authority =
+        { default_account_update with
+          public_key = constant PC.typ Config.registration_authority
+        ; call_data = registration_call_data
+        ; authorization_kind = authorization_signed ()
+        ; use_full_commitment = Boolean.true_
+        ; implicit_account_creation_fee = Boolean.false_
+        }
+      in
+      let*| out =
+        make_outputs ~chain:Config.chain_l2 account_update
+          [ (registration_authority, []) ]
+      in
       Compile_simple.{ prevs = One_prev verify_scan; out }
 
     let rule : _ Compile_simple.branch lazy_t =

--- a/src/app/zeko/circuits/asset_registry.ml
+++ b/src/app/zeko/circuits/asset_registry.ml
@@ -76,6 +76,38 @@ module Registry_state = struct
     }
 end
 
+module Checkpoint = struct
+  let version = 2
+
+  let fields ~(registry_public_key : PC.t) (state : Registry_state.t) =
+    [| registry_public_key.x
+     ; (if registry_public_key.is_odd then Field.one else Field.zero)
+     ; state.root
+     ; Checked32.to_field state.leaf_count
+     ; Checked32.to_field state.schema_version
+    |]
+
+  let commitment ~registry_public_key state =
+    Random_oracle.hash
+      ~init:
+        (Hash_prefix_create.salt
+           Zeko_constants.ethereum_asset_registry_checkpoint_v2_salt )
+      (fields ~registry_public_key state)
+
+  let commitment_var ~(registry_public_key : PC.t)
+      (state : Registry_state.var) =
+    var_to_hash
+      ~init:Zeko_constants.ethereum_asset_registry_checkpoint_v2_salt
+      Typ.(array ~length:5 F.typ)
+      [| constant F.typ registry_public_key.x
+       ; constant F.typ
+           (if registry_public_key.is_odd then Field.one else Field.zero)
+       ; state.root
+       ; Checked32.Checked.to_field state.leaf_count
+       ; Checked32.Checked.to_field state.schema_version
+      |]
+end
+
 module Path = struct
   include
     SnarkList

--- a/src/app/zeko/circuits/asset_registry.ml
+++ b/src/app/zeko/circuits/asset_registry.ml
@@ -285,10 +285,10 @@ module Make (Config : CONFIG) () = struct
       assert_equal_if ~label:"asset registry derived token ID" check
         Token_id.typ record.token_id_l2 derived_token_id
     in
-    let* decimals_supported =
-      Checked32.Checked.(record.decimals < constant (Checked32.of_int 10))
+    let* () =
+      assert_fits_bits ~label:"asset registry decimals" ~length:8
+        (Checked32.Checked.to_field record.decimals)
     in
-    let* () = assert_implies check decimals_supported in
     let* () =
       let* cap_is_zero =
         Currency.Amount.Checked.equal record.inventory_cap

--- a/src/app/zeko/circuits/asset_registry.ml
+++ b/src/app/zeko/circuits/asset_registry.ml
@@ -519,7 +519,7 @@ module Make (Config : CONFIG) () = struct
 
     let name = "Ethereum asset registry exhaustive scan"
 
-    let wrap_domain = Some `N15
+    let wrap_domain = Some `N14
   end
 
   module Scan = struct

--- a/src/app/zeko/circuits/asset_registry.ml
+++ b/src/app/zeko/circuits/asset_registry.ml
@@ -94,10 +94,9 @@ module Checkpoint = struct
            Zeko_constants.ethereum_asset_registry_checkpoint_v2_salt )
       (fields ~registry_public_key state)
 
-  let commitment_var ~(registry_public_key : PC.t)
-      (state : Registry_state.var) =
-    var_to_hash
-      ~init:Zeko_constants.ethereum_asset_registry_checkpoint_v2_salt
+  let commitment_var ~(registry_public_key : PC.t) (state : Registry_state.var)
+      =
+    var_to_hash ~init:Zeko_constants.ethereum_asset_registry_checkpoint_v2_salt
       Typ.(array ~length:5 F.typ)
       [| constant F.typ registry_public_key.x
        ; constant F.typ

--- a/src/app/zeko/circuits/asset_registry.ml
+++ b/src/app/zeko/circuits/asset_registry.ml
@@ -1,0 +1,669 @@
+open Core_kernel
+open Mina_base
+open Snark_params.Tick
+open Zeko_util
+module PC = Signature_lib.Public_key.Compressed
+module Token_id = struct
+  include Token_id
+
+  type var = Checked.t
+end
+
+module Asset_record = struct
+  type t =
+    { schema_version : Checked32.t
+    ; registry_index : Checked32.t
+    ; asset_id_high : F.t
+    ; asset_id_low : F.t
+    ; ethereum_token_address : F.t
+    ; token_owner_l2 : PC.t
+    ; token_id_l2 : Token_id.t
+    ; decimals : Checked32.t
+    ; inventory_cap : Currency.Amount.t
+    ; mft_standard_vk_id : F.t
+    ; vault_public_key : PC.t
+    ; universal_bridge_vk_id : F.t
+    }
+  [@@deriving snarky, yojson, equal]
+
+  let fields (record : t) =
+    let (Typ typ) = typ in
+    typ.value_to_fields record |> fst
+
+  let commitment record =
+    Random_oracle.hash
+      ~init:
+        (Hash_prefix_create.salt
+           Zeko_constants.ethereum_asset_registry_leaf_salt )
+      (fields record)
+
+  let commitment_var record =
+    var_to_hash ~init:Zeko_constants.ethereum_asset_registry_leaf_salt typ
+      record
+
+  let derived_token_id ({ token_owner_l2; _ } : t) =
+    let owner = Account_id.create token_owner_l2 Token_id.default in
+    Account_id.derive_token_id ~owner
+end
+
+module Registry_state = struct
+  type t =
+    { root : F.t; leaf_count : Checked32.t; schema_version : Checked32.t }
+  [@@deriving snarky, yojson, equal]
+
+  type fine =
+    { root : F.var option
+    ; leaf_count : Checked32.var option
+    ; schema_version : Checked32.var option
+    }
+
+  let _ = function
+    | ({ root = _; leaf_count = _; schema_version = _ } : t) ->
+        ()
+
+  let fine ({ root; leaf_count; schema_version } : fine) : Fine.t =
+    [ Whole (F.typ, root)
+    ; Whole (Checked32.typ, leaf_count)
+    ; Whole (Checked32.typ, schema_version)
+    ]
+end
+
+module Path = struct
+  include
+    SnarkList
+      (F)
+      (struct
+        let length = Zeko_constants.Ethereum_asset_registry.depth
+      end)
+
+  let to_yojson path = `List (List.map path ~f:Field.to_yojson)
+
+  let of_yojson = function
+    | `List values
+      when List.length values = Zeko_constants.Ethereum_asset_registry.depth ->
+        List.fold_right values ~init:(Ok []) ~f:(fun json acc ->
+            match (Field.of_yojson json, acc) with
+            | Ok value, Ok rest ->
+                Ok (value :: rest)
+            | Error error, _ | _, Error error ->
+                Error error )
+    | `List _ ->
+        Error "asset registry path has the wrong depth"
+    | _ ->
+        Error "asset registry path must be a JSON list"
+end
+
+module Output = struct
+  type calls =
+    ( Account_update.t
+    , Zkapp_command.Digest.Account_update.t
+    , Zkapp_command.Digest.Forest.t )
+    Zkapp_command.Call_forest.t
+
+  type auxiliary =
+    Account_update.Body.t
+    * Zkapp_command.Digest.Account_update.t
+    * calls
+
+  type t = Zkapp_statement.t * auxiliary
+end
+
+let merge left right =
+  Random_oracle.hash
+    ~init:
+      (Hash_prefix_create.salt
+         Zeko_constants.ethereum_asset_registry_node_salt )
+    [| left; right |]
+
+let merge_var left right =
+  var_to_hash ~init:Zeko_constants.ethereum_asset_registry_node_salt
+    Typ.(F.typ * F.typ) (left, right)
+
+let path_bits_var index =
+  Field.Checked.choose_preimage_var
+    (Checked32.Checked.to_field index)
+    ~length:Zeko_constants.Ethereum_asset_registry.depth
+
+let implied_root_var ~leaf ~index (path : Path.var) =
+  let* bits = path_bits_var index in
+  foldl (List.zip_exn path bits) ~init:leaf
+    ~f:(fun acc (sibling, is_right) ->
+      let* left =
+        if_ is_right ~typ:F.typ ~then_:sibling ~else_:acc
+      in
+      let* right =
+        if_ is_right ~typ:F.typ ~then_:acc ~else_:sibling
+      in
+      merge_var left right )
+
+let implied_root ~leaf ~index (path : Path.t) =
+  let rec go acc level = function
+    | [] ->
+        acc
+    | sibling :: rest ->
+        let is_right = Int.(index land (1 lsl level) <> 0) in
+        let acc = if is_right then merge sibling acc else merge acc sibling in
+        go acc (level + 1) rest
+  in
+  go leaf 0 path
+
+module Merkle_list = struct
+  type t = { leaves : F.t array; count : int }
+
+  let capacity = Zeko_constants.Ethereum_asset_registry.max_assets
+
+  let empty () = { leaves = Array.create ~len:capacity Field.zero; count = 0 }
+
+  let count t = t.count
+
+  let next_level level =
+    Array.init (Array.length level / 2) ~f:(fun i ->
+        merge level.(2 * i) level.((2 * i) + 1) )
+
+  let levels t =
+    let rec go acc level =
+      if Array.length level = 1 then List.rev (level :: acc)
+      else go (level :: acc) (next_level level)
+    in
+    go [] t.leaves
+
+  let root t =
+    match List.last (levels t) with
+    | Some root ->
+        root.(0)
+    | None ->
+        assert false
+
+  let empty_root = root (empty ())
+
+  let path t ~index =
+    if index < 0 || index >= capacity then
+      invalid_arg "asset registry path index is outside the tree" ;
+    List.drop_last_exn (levels t)
+    |> List.mapi ~f:(fun level nodes ->
+           let node_index = index lsr level in
+           nodes.(node_index lxor 1) )
+
+  let append_exn t (record : Asset_record.t) =
+    let index = Checked32.to_int record.registry_index in
+    if index <> t.count then
+      failwithf "asset registry append index %d does not match leaf count %d"
+        index t.count () ;
+    if t.count >= capacity then failwith "asset registry is full" ;
+    if not (Field.equal t.leaves.(index) Field.zero) then
+      failwith "asset registry append slot is not empty" ;
+    let leaves = Array.copy t.leaves in
+    leaves.(index) <- Asset_record.commitment record ;
+    { leaves; count = t.count + 1 }
+
+  let verify ~root (record : Asset_record.t) (path : Path.t) =
+    let index = Checked32.to_int record.registry_index in
+    List.length path = Zeko_constants.Ethereum_asset_registry.depth
+    && index < capacity
+    && Field.equal
+         (implied_root ~leaf:(Asset_record.commitment record) ~index path)
+         root
+end
+
+module type CONFIG = sig
+  val registry_public_key : PC.t
+
+  val schema_version : Checked32.t
+
+  val approved_mft_standard_vk_id : F.t
+
+  val universal_bridge_vk_id : F.t
+
+  val vault_public_key : PC.t
+
+  val chain_l2 : Mina_signature_kind.t
+end
+
+module Make (Config : CONFIG) () = struct
+  let assert_implies condition value =
+    let open Boolean.Expr in
+    ((not !condition) || !value) |> assert_
+
+  let assert_equal_if ~label condition typ left right =
+    let* equal = var_equal typ left right in
+    with_label label (fun () ->
+        let open Boolean.Expr in
+        ((not !condition) || equal) |> assert_ )
+
+  let assert_not_equal_if ~label condition typ left right =
+    let* equal = var_equal typ left right in
+    with_label label (fun () ->
+        let open Boolean.Expr in
+        ((not !condition) || not equal) |> assert_ )
+
+  let assert_fits_bits ~label ~length value =
+    with_label label (fun () ->
+      let* (_ : Boolean.var list) =
+        Field.Checked.choose_preimage_var value ~length
+      in
+      Checked.return () )
+
+  let validate_record ?(check = Boolean.true_) (record : Asset_record.var) =
+    let* () =
+      assert_equal_if ~label:"asset registry schema version" check Checked32.typ
+        record.schema_version
+        (Checked32.Checked.constant Config.schema_version)
+    in
+    let* index_in_range =
+      Checked32.Checked.(
+        record.registry_index
+        < constant
+            (Checked32.of_int
+               Zeko_constants.Ethereum_asset_registry.max_assets ) )
+    in
+    let* () = assert_implies check index_in_range in
+    let* () =
+      assert_equal_if ~label:"asset registry MFT standard version" check F.typ
+        record.mft_standard_vk_id
+        (constant F.typ Config.approved_mft_standard_vk_id)
+    in
+    let* () =
+      assert_equal_if ~label:"asset registry shared vault" check PC.typ
+        record.vault_public_key (constant PC.typ Config.vault_public_key)
+    in
+    let* () =
+      assert_not_equal_if ~label:"asset registry owner/vault separation" check
+        PC.typ record.token_owner_l2 record.vault_public_key
+    in
+    let owner =
+      Account_id.Checked.create record.token_owner_l2
+        (constant Token_id.typ Token_id.default)
+    in
+    let* derived_token_id =
+      make_checked (fun () -> Account_id.Checked.derive_token_id ~owner)
+    in
+    let* () =
+      assert_equal_if ~label:"asset registry derived token ID" check Token_id.typ
+        record.token_id_l2 derived_token_id
+    in
+    let* decimals_supported =
+      Checked32.Checked.(record.decimals < constant (Checked32.of_int 10))
+    in
+    let* () = assert_implies check decimals_supported in
+    let* () =
+      let* cap_is_zero =
+        Currency.Amount.Checked.equal record.inventory_cap
+          (constant Currency.Amount.typ Currency.Amount.zero)
+      in
+      assert_implies check Boolean.(not cap_is_zero)
+    in
+    let* () =
+      assert_fits_bits ~label:"asset registry asset ID high limb" ~length:128
+        record.asset_id_high
+    in
+    let* () =
+      assert_fits_bits ~label:"asset registry asset ID low limb" ~length:128
+        record.asset_id_low
+    in
+    let* () =
+      assert_fits_bits ~label:"asset registry Ethereum token address" ~length:160
+        record.ethereum_token_address
+    in
+    let* () =
+      let* address_is_zero =
+        Field.Checked.equal record.ethereum_token_address
+          (constant F.typ Field.zero)
+      in
+      assert_implies check Boolean.(not address_is_zero)
+    in
+    let* () =
+      let* high_zero =
+        Field.Checked.equal record.asset_id_high (constant F.typ Field.zero)
+      in
+      let* low_zero =
+        Field.Checked.equal record.asset_id_low (constant F.typ Field.zero)
+      in
+      let* both_zero = Boolean.(high_zero && low_zero) in
+      assert_implies check (Boolean.not both_zero)
+    in
+    let* () =
+      assert_equal_if ~label:"asset registry universal bridge version" check
+        F.typ record.universal_bridge_vk_id
+        (constant F.typ Config.universal_bridge_vk_id)
+    in
+    Checked.return derived_token_id
+
+  module Membership_witness = struct
+    type t =
+      { state : Registry_state.t; record : Asset_record.t; path : Path.t }
+    [@@deriving snarky, yojson]
+  end
+
+  let registry_precondition (state : Registry_state.var) =
+    { default_account_update with
+      public_key = constant PC.typ Config.registry_public_key
+    ; authorization_kind =
+        constant Account_update.Authorization_kind.typ None_given
+    ; preconditions =
+        { default_account_update.preconditions with
+          account =
+            { default_account_update.preconditions.account with
+              state =
+                Registry_state.fine
+                  { root = Some state.root
+                  ; leaf_count = Some state.leaf_count
+                  ; schema_version = Some state.schema_version
+                  }
+                |> var_to_precondition_fine
+            }
+        }
+    }
+
+  module Verified_asset = struct
+    type t =
+      { record : Asset_record.var
+      ; token_id : Token_id.Checked.t
+      ; authenticated_registry_call : Account_update.Checked.t
+      }
+
+    let record t = t.record
+
+    let token_id t = t.token_id
+
+    let authenticated_registry_call t = t.authenticated_registry_call
+  end
+
+  let verify ({ state; record; path } : Membership_witness.var) =
+    let* () =
+      assert_equal ~label:"asset registry state schema" Checked32.typ
+        state.schema_version (Checked32.Checked.constant Config.schema_version)
+    in
+    let* token_id = validate_record record in
+    let* record_before_count =
+      Checked32.Checked.(record.registry_index < state.leaf_count)
+    in
+    let* () = Boolean.Assert.is_true record_before_count in
+    let* leaf = Asset_record.commitment_var record in
+    let* implied_root =
+      implied_root_var ~leaf ~index:record.registry_index path
+    in
+    let* () =
+      assert_equal ~label:"asset registry membership root" F.typ state.root
+        implied_root
+    in
+    Checked.return
+      { Verified_asset.record
+      ; token_id
+      ; authenticated_registry_call = registry_precondition state
+      }
+
+  module Scan_definition = struct
+    module Stmt = struct
+      type t =
+        { old_root : F.t
+        ; leaf_count : Checked32.t
+        ; candidate : Asset_record.t
+        ; next_expected_index : Checked32.t
+        ; traversed_count : Checked32.t
+        }
+      [@@deriving snarky]
+    end
+
+    module Elem = struct
+      type t =
+        { active : Boolean.t; record : Asset_record.t; path : Path.t }
+      [@@deriving snarky]
+    end
+
+    module Init = struct
+      type t =
+        { old_state : Registry_state.t; candidate : Asset_record.t }
+      [@@deriving snarky]
+    end
+
+    let init ~check ({ old_state; candidate } : Init.var) =
+      let check = Option.value check ~default:Boolean.true_ in
+      let* () =
+        assert_equal_if ~label:"asset registry scan schema" check Checked32.typ
+          old_state.schema_version
+          (Checked32.Checked.constant Config.schema_version)
+      in
+      Checked.return
+        { Stmt.old_root = old_state.root
+        ; leaf_count = old_state.leaf_count
+        ; candidate
+        ; next_expected_index = Checked32.Checked.zero
+        ; traversed_count = Checked32.Checked.zero
+        }
+
+    let step ({ active; record; path } : Elem.var) (state : Stmt.var) =
+      let* () =
+        assert_equal_if ~label:"asset registry scan index" active Checked32.typ
+          record.registry_index state.next_expected_index
+      in
+      let* within_committed_list =
+        Checked32.Checked.(state.next_expected_index < state.leaf_count)
+      in
+      let* () = assert_implies active within_committed_list in
+      let* leaf = Asset_record.commitment_var record in
+      let* root =
+        implied_root_var ~leaf ~index:state.next_expected_index path
+      in
+      let* () =
+        assert_equal_if ~label:"asset registry scan membership" active F.typ root
+          state.old_root
+      in
+      let* () =
+        assert_not_equal_if ~label:"unique Ethereum token address" active F.typ
+          record.ethereum_token_address
+          state.candidate.ethereum_token_address
+      in
+      let* asset_high_equal =
+        Field.Checked.equal record.asset_id_high state.candidate.asset_id_high
+      in
+      let* asset_low_equal =
+        Field.Checked.equal record.asset_id_low state.candidate.asset_id_low
+      in
+      let* () =
+        let* both_equal = Boolean.(asset_high_equal && asset_low_equal) in
+        assert_implies active (Boolean.not both_equal)
+      in
+      let* () =
+        assert_not_equal_if ~label:"unique L2 token owner" active PC.typ
+          record.token_owner_l2 state.candidate.token_owner_l2
+      in
+      let* () =
+        assert_not_equal_if ~label:"unique derived L2 token ID" active
+          Token_id.typ record.token_id_l2 state.candidate.token_id_l2
+      in
+      let* next_expected_index =
+        Checked32.Checked.succ_if state.next_expected_index active
+      in
+      let* traversed_count =
+        Checked32.Checked.succ_if state.traversed_count active
+      in
+      Checked.return
+        { state with next_expected_index; traversed_count }
+
+    let dummy_elem : Elem.t =
+      { active = false
+      ; record =
+          { schema_version = Config.schema_version
+          ; registry_index = Checked32.zero
+          ; asset_id_high = Field.zero
+          ; asset_id_low = Field.zero
+          ; ethereum_token_address = Field.zero
+          ; token_owner_l2 = PC.empty
+          ; token_id_l2 = Token_id.default
+          ; decimals = Checked32.zero
+          ; inventory_cap = Currency.Amount.zero
+          ; mft_standard_vk_id = Config.approved_mft_standard_vk_id
+          ; vault_public_key = Config.vault_public_key
+          ; universal_bridge_vk_id = Field.zero
+          }
+      ; path =
+          List.init Zeko_constants.Ethereum_asset_registry.depth
+            ~f:(fun _ -> Field.zero)
+      }
+
+    let leaf_iterations =
+      Zeko_constants.Folder_iterations.Ethereum_asset_registry_scan
+      .leaf_iterations
+
+    let leaf_option_iterations =
+      Zeko_constants.Folder_iterations.Ethereum_asset_registry_scan
+      .leaf_option_iterations
+
+    let extend_iterations =
+      Zeko_constants.Folder_iterations.Ethereum_asset_registry_scan
+      .extend_iterations
+
+    let extend_option_iterations =
+      Zeko_constants.Folder_iterations.Ethereum_asset_registry_scan
+      .extend_option_iterations
+
+    let name = "Ethereum asset registry exhaustive scan"
+
+    let wrap_domain = Some `N15
+  end
+
+  module Scan = struct
+    module Definition = Scan_definition
+    include Folder.Make (Definition) ()
+  end
+
+  module Scan_inst = Scan.Make (struct
+    let get_iterations = 0
+  end)
+
+  module Register = struct
+    module Witness = struct
+      type t =
+        { scan : Scan_inst.t
+        ; append_path : Path.t
+        ; registry_vk_hash : F.t
+        }
+      [@@deriving snarky]
+    end
+
+    let main (w : Witness.t V.t) =
+      let* { scan; append_path; registry_vk_hash } =
+        exists Witness.typ ~compute:(V.get w)
+      in
+      let* `Source source, `Target target, verify_scan =
+        Scan_inst.get_full scan
+      in
+      let* () =
+        assert_equal ~label:"asset registry scan candidate" Asset_record.typ
+          source.candidate target.candidate
+      in
+      let* () =
+        assert_equal ~label:"asset registry scan old root" F.typ source.old_root
+          target.old_root
+      in
+      let* () =
+        assert_equal ~label:"asset registry scan leaf count" Checked32.typ
+          source.leaf_count target.leaf_count
+      in
+      let* () =
+        assert_equal ~label:"asset registry exhaustive index" Checked32.typ
+          target.next_expected_index target.leaf_count
+      in
+      let* () =
+        assert_equal ~label:"asset registry exhaustive count" Checked32.typ
+          target.traversed_count target.leaf_count
+      in
+      let* derived_token_id = validate_record target.candidate in
+      let* () =
+        assert_equal ~label:"asset registry registered token ID" Token_id.typ
+          target.candidate.token_id_l2 derived_token_id
+      in
+      let* () =
+        assert_equal ~label:"asset registry append index" Checked32.typ
+          target.candidate.registry_index target.leaf_count
+      in
+      let* has_capacity =
+        Checked32.Checked.(
+          target.leaf_count
+          < constant
+              (Checked32.of_int
+                 Zeko_constants.Ethereum_asset_registry.max_assets ) )
+      in
+      let* () = Boolean.Assert.is_true has_capacity in
+      let* old_root_from_empty =
+        implied_root_var ~leaf:(constant F.typ Field.zero)
+          ~index:target.leaf_count append_path
+      in
+      let* () =
+        assert_equal ~label:"asset registry empty append slot" F.typ
+          target.old_root old_root_from_empty
+      in
+      let* candidate_leaf =
+        Asset_record.commitment_var target.candidate
+      in
+      let* new_root =
+        implied_root_var ~leaf:candidate_leaf ~index:target.leaf_count
+          append_path
+      in
+      let* new_count = Checked32.Checked.succ target.leaf_count in
+      let new_state : Registry_state.var =
+        { root = new_root
+        ; leaf_count = new_count
+        ; schema_version = Checked32.Checked.constant Config.schema_version
+        }
+      in
+      let old_state : Registry_state.var =
+        { root = target.old_root
+        ; leaf_count = target.leaf_count
+        ; schema_version = Checked32.Checked.constant Config.schema_version
+        }
+      in
+      let* events = var_to_events Asset_record.typ target.candidate in
+      let account_update =
+        { default_account_update with
+          public_key = constant PC.typ Config.registry_public_key
+        ; authorization_kind = authorization_vk_hash registry_vk_hash
+        ; update =
+            { default_account_update.update with
+              app_state =
+                Registry_state.fine
+                  { root = Some new_state.root
+                  ; leaf_count = Some new_state.leaf_count
+                  ; schema_version = Some new_state.schema_version
+                  }
+                |> var_to_app_state_fine
+            }
+        ; preconditions =
+            { default_account_update.preconditions with
+              account =
+                { default_account_update.preconditions.account with
+                  state =
+                    Registry_state.fine
+                      { root = Some old_state.root
+                      ; leaf_count = Some old_state.leaf_count
+                      ; schema_version = Some old_state.schema_version
+                      }
+                    |> var_to_precondition_fine
+                }
+            }
+        ; events
+        }
+      in
+      let*| out = make_outputs ~chain:Config.chain_l2 account_update [] in
+      Compile_simple.{ prevs = One_prev verify_scan; out }
+
+    let rule : _ Compile_simple.branch lazy_t =
+      lazy
+        { branch_name = "register Ethereum asset"
+        ; tags = One_tag (Lazy.force Scan.tag)
+        ; main
+        }
+  end
+
+  module System =
+  ( val Compile_simple.compile ~name:"Ethereum asset registry"
+          ~out_typ:Typ.(Mina_base.Zkapp_statement.typ * V.typ)
+          ~branches:[ Register.rule ] () )
+
+  type registry_tag_var = System.tag_var
+
+  let registry_tag = System.tag
+
+  let register =
+    Lazy.map System.provers ~f:(fun Compile_simple.[ register ] -> register)
+end

--- a/src/app/zeko/circuits/asset_registry.mli
+++ b/src/app/zeko/circuits/asset_registry.mli
@@ -54,6 +54,16 @@ module Registry_state : sig
   val value_of_app_state : F.t Zkapp_state.V.t -> t
 end
 
+module Checkpoint : sig
+  val version : int
+
+  val commitment :
+    registry_public_key:PC.t -> Registry_state.t -> F.t
+
+  val commitment_var :
+    registry_public_key:PC.t -> Registry_state.var -> F.var Checked.t
+end
+
 module Path : sig
   type t = F.t list
 

--- a/src/app/zeko/circuits/asset_registry.mli
+++ b/src/app/zeko/circuits/asset_registry.mli
@@ -176,6 +176,8 @@ module Make (Config : CONFIG) () : sig
       val extend_iterations : int
 
       val extend_option_iterations : int
+
+      val wrap_domain : [ `N13 | `N14 | `N15 ] option
     end
 
     type trans =

--- a/src/app/zeko/circuits/asset_registry.mli
+++ b/src/app/zeko/circuits/asset_registry.mli
@@ -1,0 +1,262 @@
+[@@@warning "-67"]
+
+open Mina_base
+open Snark_params.Tick
+open Zeko_util
+
+module PC = Signature_lib.Public_key.Compressed
+module Token_id : sig
+  include module type of Mina_base.Token_id
+
+  type var = Checked.t
+end
+
+(** The immutable, versioned identity shared by the OCaml circuit, settlement
+    adapter, Solidity registry, indexer, and SDK. Field order is part of the V1
+    wire and leaf commitment. *)
+module Asset_record : sig
+  type t =
+    { schema_version : Checked32.t
+    ; registry_index : Checked32.t
+    ; asset_id_high : F.t
+    ; asset_id_low : F.t
+    ; ethereum_token_address : F.t
+    ; token_owner_l2 : PC.t
+    ; token_id_l2 : Token_id.t
+    ; decimals : Checked32.t
+    ; inventory_cap : Currency.Amount.t
+    ; mft_standard_vk_id : F.t
+    ; vault_public_key : PC.t
+    ; universal_bridge_vk_id : F.t
+    }
+  [@@deriving snarky, yojson, equal]
+
+  val commitment : t -> F.t
+
+  val commitment_var : var -> F.var Checked.t
+
+  val derived_token_id : t -> Token_id.t
+end
+
+module Registry_state : sig
+  type t =
+    { root : F.t; leaf_count : Checked32.t; schema_version : Checked32.t }
+  [@@deriving snarky, yojson, equal]
+
+  type fine =
+    { root : F.var option
+    ; leaf_count : Checked32.var option
+    ; schema_version : Checked32.var option
+    }
+
+  val fine : fine -> Fine.t
+end
+
+module Path : sig
+  type t = F.t list
+
+  type var = F.var list
+
+  val typ : (var, t) Typ.t
+
+  val to_yojson : t -> Yojson.Safe.t
+
+  val of_yojson : Yojson.Safe.t -> (t, string) Result.t
+end
+
+module Output : sig
+  type calls =
+    ( Account_update.t
+    , Zkapp_command.Digest.Account_update.t
+    , Zkapp_command.Digest.Forest.t )
+    Zkapp_command.Call_forest.t
+
+  type auxiliary =
+    Account_update.Body.t
+    * Zkapp_command.Digest.Account_update.t
+    * calls
+
+  type t = Zkapp_statement.t * auxiliary
+end
+
+(** Pure append-only tree implementation used by witness preparation and tests.
+    Paths are always relative to the current root and must be refreshed after an
+    append. *)
+module Merkle_list : sig
+  type t
+
+  val empty : unit -> t
+
+  val count : t -> int
+
+  val root : t -> F.t
+
+  val path : t -> index:int -> Path.t
+
+  val append_exn : t -> Asset_record.t -> t
+
+  val verify : root:F.t -> Asset_record.t -> Path.t -> bool
+
+  val empty_root : F.t
+end
+
+module type CONFIG = sig
+  val registry_public_key : PC.t
+
+  val schema_version : Checked32.t
+
+  val approved_mft_standard_vk_id : F.t
+
+  val universal_bridge_vk_id : F.t
+
+  val vault_public_key : PC.t
+
+  val chain_l2 : Mina_signature_kind.t
+end
+
+(** Verified-registry seam. A caller receives an abstract [Verified_asset.t]
+    only after record invariants and Merkle membership have been constrained.
+    [authenticated_registry_call] is the account-state precondition that binds
+    the witnessed root/count/version to the dedicated registry zkApp. *)
+module Make (Config : CONFIG) () : sig
+  module Membership_witness : sig
+    type t =
+      { state : Registry_state.t; record : Asset_record.t; path : Path.t }
+    [@@deriving snarky, yojson]
+  end
+
+  module Verified_asset : sig
+    type t
+
+    val record : t -> Asset_record.var
+
+    val token_id : t -> Token_id.Checked.t
+
+    val authenticated_registry_call : t -> Account_update.Checked.t
+  end
+
+  val verify : Membership_witness.var -> Verified_asset.t Checked.t
+
+  module Scan : sig
+    module Definition : sig
+      module Stmt : sig
+        type t =
+          { old_root : F.t
+          ; leaf_count : Checked32.t
+          ; candidate : Asset_record.t
+          ; next_expected_index : Checked32.t
+          ; traversed_count : Checked32.t
+          }
+        [@@deriving snarky]
+      end
+
+      module Elem : sig
+        type t =
+          { active : Boolean.t; record : Asset_record.t; path : Path.t }
+        [@@deriving snarky]
+      end
+
+      module Init : sig
+        type t =
+          { old_state : Registry_state.t; candidate : Asset_record.t }
+        [@@deriving snarky]
+      end
+
+      val init :
+        check:Boolean.var option -> Init.var -> Stmt.var Checked.t
+
+      val step : Elem.var -> Stmt.var -> Stmt.var Checked.t
+
+      val dummy_elem : Elem.t
+
+      val leaf_iterations : int
+
+      val leaf_option_iterations : int
+
+      val extend_iterations : int
+
+      val extend_option_iterations : int
+    end
+
+    type trans =
+      { source : Definition.Stmt.t; target : Definition.Stmt.t }
+
+    type t := trans * Proof.t
+
+    val leaf :
+      (Definition.Elem.t list * Definition.Stmt.t -> t Promise.t) lazy_t
+
+    val leaf_option :
+      (Definition.Elem.t list * Definition.Stmt.t -> t Promise.t) lazy_t
+
+    val extend : (Definition.Elem.t list * t -> t Promise.t) lazy_t
+
+    val extend_option : (Definition.Elem.t list * t -> t Promise.t) lazy_t
+
+    type merge_input =
+      { left : trans
+      ; left_proof : Proof.t
+      ; right : trans
+      ; right_proof : Proof.t
+      }
+
+    val merge : (merge_input -> t Promise.t) lazy_t
+
+    type tag_var
+
+    val tag : tag_var Compile_simple.tag lazy_t
+
+    module Make (Inputs : sig
+      val get_iterations : int
+    end) : sig
+      include SnarkType
+
+      val get_full :
+           ?check:Boolean.var
+        -> var
+        -> ( [ `Source of Definition.Stmt.var ]
+           * [ `Target of Definition.Stmt.var ]
+           * tag_var Compile_simple.prev )
+           Checked.t
+
+      val make :
+           proof_source:Definition.Stmt.t
+        -> proof_target:Definition.Stmt.t
+        -> ?proof:Proof.t
+        -> Definition.Init.t
+        -> Definition.Elem.t list
+        -> t
+    end
+  end
+
+  module Scan_inst : sig
+    include SnarkType
+
+    val make :
+         proof_source:Scan.Definition.Stmt.t
+      -> proof_target:Scan.Definition.Stmt.t
+      -> ?proof:Proof.t
+      -> Scan.Definition.Init.t
+      -> Scan.Definition.Elem.t list
+      -> t
+  end
+
+  module Register : sig
+    module Witness : sig
+      type t =
+        { scan : Scan_inst.t
+        ; append_path : Path.t
+        ; registry_vk_hash : F.t
+        }
+      [@@deriving snarky]
+    end
+
+  end
+
+  type registry_tag_var
+
+  val registry_tag : registry_tag_var Compile_simple.tag lazy_t
+
+  val register :
+    (Register.Witness.t -> (Output.t * Proof.t) Promise.t) lazy_t
+end

--- a/src/app/zeko/circuits/asset_registry.mli
+++ b/src/app/zeko/circuits/asset_registry.mli
@@ -3,8 +3,8 @@
 open Mina_base
 open Snark_params.Tick
 open Zeko_util
-
 module PC = Signature_lib.Public_key.Compressed
+
 module Token_id : sig
   include module type of Mina_base.Token_id
 
@@ -50,6 +50,8 @@ module Registry_state : sig
     }
 
   val fine : fine -> Fine.t
+
+  val value_of_app_state : F.t Zkapp_state.V.t -> t
 end
 
 module Path : sig
@@ -64,6 +66,9 @@ module Path : sig
   val of_yojson : Yojson.Safe.t -> (t, string) Result.t
 end
 
+val implied_root_var :
+  leaf:F.var -> index:Checked32.var -> Path.var -> F.var Checked.t
+
 module Output : sig
   type calls =
     ( Account_update.t
@@ -72,9 +77,7 @@ module Output : sig
     Zkapp_command.Call_forest.t
 
   type auxiliary =
-    Account_update.Body.t
-    * Zkapp_command.Digest.Account_update.t
-    * calls
+    Account_update.Body.t * Zkapp_command.Digest.Account_update.t * calls
 
   type t = Zkapp_statement.t * auxiliary
 end
@@ -102,6 +105,8 @@ end
 
 module type CONFIG = sig
   val registry_public_key : PC.t
+
+  val registration_authority : PC.t
 
   val schema_version : Checked32.t
 
@@ -151,19 +156,16 @@ module Make (Config : CONFIG) () : sig
       end
 
       module Elem : sig
-        type t =
-          { active : Boolean.t; record : Asset_record.t; path : Path.t }
+        type t = { active : Boolean.t; record : Asset_record.t; path : Path.t }
         [@@deriving snarky]
       end
 
       module Init : sig
-        type t =
-          { old_state : Registry_state.t; candidate : Asset_record.t }
+        type t = { old_state : Registry_state.t; candidate : Asset_record.t }
         [@@deriving snarky]
       end
 
-      val init :
-        check:Boolean.var option -> Init.var -> Stmt.var Checked.t
+      val init : check:Boolean.var option -> Init.var -> Stmt.var Checked.t
 
       val step : Elem.var -> Stmt.var -> Stmt.var Checked.t
 
@@ -180,8 +182,7 @@ module Make (Config : CONFIG) () : sig
       val wrap_domain : [ `N13 | `N14 | `N15 ] option
     end
 
-    type trans =
-      { source : Definition.Stmt.t; target : Definition.Stmt.t }
+    type trans = { source : Definition.Stmt.t; target : Definition.Stmt.t }
 
     type t := trans * Proof.t
 
@@ -246,19 +247,14 @@ module Make (Config : CONFIG) () : sig
   module Register : sig
     module Witness : sig
       type t =
-        { scan : Scan_inst.t
-        ; append_path : Path.t
-        ; registry_vk_hash : F.t
-        }
+        { scan : Scan_inst.t; append_path : Path.t; registry_vk_hash : F.t }
       [@@deriving snarky]
     end
-
   end
 
   type registry_tag_var
 
   val registry_tag : registry_tag_var Compile_simple.tag lazy_t
 
-  val register :
-    (Register.Witness.t -> (Output.t * Proof.t) Promise.t) lazy_t
+  val register : (Register.Witness.t -> (Output.t * Proof.t) Promise.t) lazy_t
 end

--- a/src/app/zeko/circuits/asset_registry.mli
+++ b/src/app/zeko/circuits/asset_registry.mli
@@ -57,8 +57,7 @@ end
 module Checkpoint : sig
   val version : int
 
-  val commitment :
-    registry_public_key:PC.t -> Registry_state.t -> F.t
+  val commitment : registry_public_key:PC.t -> Registry_state.t -> F.t
 
   val commitment_var :
     registry_public_key:PC.t -> Registry_state.var -> F.var Checked.t

--- a/src/app/zeko/circuits/bridge_rules.ml
+++ b/src/app/zeko/circuits/bridge_rules.ml
@@ -44,6 +44,8 @@ struct
 
         let ethereum_holder_account_l1 = Inputs.ethereum_holder_account_l1
 
+        let ethereum_asset_id = None
+
         let token_owner_l1 = None
 
         let chain_l1 = Inputs.chain_l1
@@ -62,6 +64,8 @@ struct
     let token_owner_l1 = None
 
     let token_owner_l2 = None
+
+    let ethereum_asset_id = None
 
     module Deposit_params = Deposit_params_base
     module Withdrawal_params = Withdrawal_params_base
@@ -129,6 +133,97 @@ struct
           () )
 end
 
+module Make_ethereum_token (Inputs : sig
+  val token_owner_l2 : Account_id.t
+
+  val ethereum_holder_account_l1 : PC.t
+
+  val ethereum_asset_id_high : Snark_params.Tick.Field.t
+
+  val ethereum_asset_id_low : Snark_params.Tick.Field.t
+
+  val zeko_l2 : PC.t
+
+  val holder_account_l2 : PC.t
+
+  val bridge_fee_recipient_l1 : PC.t
+
+  val bridge_fee_recipient_l2 : PC.t
+
+  val chain_l1 : Mina_signature_kind.t
+
+  val chain_l2 : Mina_signature_kind.t
+
+  val multisig_key : Multisig.t
+end)
+() =
+struct
+  let ethereum_asset_id =
+    Some (Inputs.ethereum_asset_id_high, Inputs.ethereum_asset_id_low)
+
+  module Check_accepted =
+    Check_accepted_make.Make
+      (struct
+        let holder_accounts_l1 = []
+
+        let ethereum_holder_account_l1 = Some Inputs.ethereum_holder_account_l1
+
+        let ethereum_asset_id = ethereum_asset_id
+
+        let token_owner_l1 = None
+
+        let chain_l1 = Inputs.chain_l1
+
+        module Deposit_params = Deposit_params_ethereum_token
+
+        let bridge_fee_recipient_l1 = Inputs.bridge_fee_recipient_l1
+
+        let bridge_proof_fee = Currency.Amount.zero
+      end)
+      ()
+
+  module Circuit_inputs = struct
+    include Inputs
+
+    let holder_accounts_l1 = []
+
+    let ethereum_holder_account_l1 = Some Inputs.ethereum_holder_account_l1
+
+    let ethereum_asset_id = ethereum_asset_id
+
+    let token_owner_l1 = None
+
+    let token_owner_l2 = Some Inputs.token_owner_l2
+
+    let bridge_proof_fee = Currency.Amount.zero
+
+    module Deposit_params = Deposit_params_ethereum_token
+    module Withdrawal_params = Withdrawal_params_ethereum_token
+    module Check_accepted = Check_accepted
+  end
+
+  module Rule_bridge_finalize_deposit =
+    Rule_bridge_finalize_deposit.Make (Circuit_inputs)
+  module Rule_bridge_inner_receive =
+    Rule_bridge_inner_receive.Make (Circuit_inputs)
+
+  module Rule_multisig_update_l2 = Rule_multisig_update.Make (struct
+    let chain = Inputs.chain_l2
+
+    let multisig_key = Inputs.multisig_key
+  end)
+
+  module System_L2 =
+  ( val Compile_simple.compile ~name:"bridge rules for Ethereum ERC20 on l2"
+          ~out_typ:Snark_params.Tick.Typ.(Mina_base.Zkapp_statement.typ * V.typ)
+          ~branches:
+            [ Rule_bridge_finalize_deposit.rule
+            ; Rule_bridge_inner_receive.rule
+            ; Rule_multisig_update_l2.rule
+            ]
+          () )
+end
+
 module Make_custom (Inputs : sig
   val token_owner_l1 : Account_id.t
 
@@ -175,6 +270,8 @@ struct
 
         let ethereum_holder_account_l1 = Inputs.ethereum_holder_account_l1
 
+        let ethereum_asset_id = None
+
         let token_owner_l1 = Some Inputs.token_owner_l1
 
         let chain_l1 = Inputs.chain_l1
@@ -193,6 +290,8 @@ struct
     let token_owner_l1 = Some Inputs.token_owner_l1
 
     let token_owner_l2 = Some Inputs.token_owner_l2
+
+    let ethereum_asset_id = None
 
     module Deposit_params = Deposit_params_custom
     module Withdrawal_params = Withdrawal_params_custom

--- a/src/app/zeko/circuits/bridge_rules.ml
+++ b/src/app/zeko/circuits/bridge_rules.ml
@@ -36,6 +36,8 @@ struct
     | None ->
         None
 
+  let registry_binding () = Checked.return None
+
   let authenticated_registry_call () = None
 
   let call_data () _ = Checked.return (constant F.typ Field.zero)
@@ -110,14 +112,13 @@ struct
 
     let ethereum_asset_id = None
 
-    module Asset =
-      Static_asset (struct
-        let holder_account_l2 = Inputs.holder_account_l2
+    module Asset = Static_asset (struct
+      let holder_account_l2 = Inputs.holder_account_l2
 
-        let token_owner_l2 = None
+      let token_owner_l2 = None
 
-        let ethereum_asset_id = None
-      end)
+      let ethereum_asset_id = None
+    end)
 
     module Deposit_params = Deposit_params_base
     module Withdrawal_params = Withdrawal_params_base
@@ -226,7 +227,7 @@ struct
 
         let chain_l1 = Inputs.chain_l1
 
-        module Deposit_params = Deposit_params_ethereum_token
+        module Deposit_params = Deposit_params_ethereum_token_v1
 
         let bridge_fee_recipient_l1 = Inputs.bridge_fee_recipient_l1
 
@@ -249,17 +250,16 @@ struct
 
     let bridge_proof_fee = Currency.Amount.zero
 
-    module Asset =
-      Static_asset (struct
-        let holder_account_l2 = Inputs.holder_account_l2
+    module Asset = Static_asset (struct
+      let holder_account_l2 = Inputs.holder_account_l2
 
-        let token_owner_l2 = Some Inputs.token_owner_l2
+      let token_owner_l2 = Some Inputs.token_owner_l2
 
-        let ethereum_asset_id = ethereum_asset_id
-      end)
+      let ethereum_asset_id = ethereum_asset_id
+    end)
 
-    module Deposit_params = Deposit_params_ethereum_token
-    module Withdrawal_params = Withdrawal_params_ethereum_token
+    module Deposit_params = Deposit_params_ethereum_token_v1
+    module Withdrawal_params = Withdrawal_params_ethereum_token_v1
     module Check_accepted = Check_accepted
   end
 
@@ -287,6 +287,8 @@ end
 
 module Make_ethereum_assets (Inputs : sig
   val registry_public_key : PC.t
+
+  val registration_authority : PC.t
 
   val registry_schema_version : Checked32.t
 
@@ -317,10 +319,11 @@ struct
       (struct
         let registry_public_key = Inputs.registry_public_key
 
+        let registration_authority = Inputs.registration_authority
+
         let schema_version = Inputs.registry_schema_version
 
-        let approved_mft_standard_vk_id =
-          Inputs.approved_mft_standard_vk_id
+        let approved_mft_standard_vk_id = Inputs.approved_mft_standard_vk_id
 
         let universal_bridge_vk_id = Inputs.universal_bridge_vk_id
 
@@ -339,14 +342,18 @@ struct
 
     let record = Registry.Verified_asset.record
 
-    let vault_public_key verified =
-      (record verified).vault_public_key
+    let vault_public_key verified = (record verified).vault_public_key
 
     let token_id_l2 = Registry.Verified_asset.token_id
 
     let ethereum_asset_id verified =
       let record = record verified in
       Some (record.asset_id_high, record.asset_id_low)
+
+    let registry_binding verified =
+      let record = record verified in
+      let* commitment = Asset_registry.Asset_record.commitment_var record in
+      Checked.return (Some (record.registry_index, commitment))
 
     let authenticated_registry_call verified =
       Some (Registry.Verified_asset.authenticated_registry_call verified)
@@ -366,8 +373,7 @@ struct
       (struct
         let holder_accounts_l1 = []
 
-        let ethereum_holder_account_l1 =
-          Some Inputs.ethereum_holder_account_l1
+        let ethereum_holder_account_l1 = Some Inputs.ethereum_holder_account_l1
 
         (* Asset identity is dynamic here and is constrained against the
            verified registry record in finalization. *)
@@ -390,8 +396,7 @@ struct
 
     let holder_accounts_l1 = []
 
-    let ethereum_holder_account_l1 =
-      Some Inputs.ethereum_holder_account_l1
+    let ethereum_holder_account_l1 = Some Inputs.ethereum_holder_account_l1
 
     let ethereum_asset_id = None
 
@@ -496,14 +501,13 @@ struct
 
     let ethereum_asset_id = None
 
-    module Asset =
-      Static_asset (struct
-        let holder_account_l2 = Inputs.holder_account_l2
+    module Asset = Static_asset (struct
+      let holder_account_l2 = Inputs.holder_account_l2
 
-        let token_owner_l2 = Some Inputs.token_owner_l2
+      let token_owner_l2 = Some Inputs.token_owner_l2
 
-        let ethereum_asset_id = None
-      end)
+      let ethereum_asset_id = None
+    end)
 
     module Deposit_params = Deposit_params_custom
     module Withdrawal_params = Withdrawal_params_custom

--- a/src/app/zeko/circuits/bridge_rules.ml
+++ b/src/app/zeko/circuits/bridge_rules.ml
@@ -121,7 +121,15 @@ struct
     end)
 
     module Deposit_params = Deposit_params_base
-    module Withdrawal_params = Withdrawal_params_base
+
+    module Withdrawal_params = struct
+      include Withdrawal_params_base
+
+      let recipient_domain =
+        Withdrawal_recipient_domain.of_ethereum_holder_account
+          Inputs.ethereum_holder_account_l1
+    end
+
     module Check_accepted = Check_accepted
   end
 
@@ -510,7 +518,15 @@ struct
     end)
 
     module Deposit_params = Deposit_params_custom
-    module Withdrawal_params = Withdrawal_params_custom
+
+    module Withdrawal_params = struct
+      include Withdrawal_params_custom
+
+      let recipient_domain =
+        Withdrawal_recipient_domain.of_ethereum_holder_account
+          Inputs.ethereum_holder_account_l1
+    end
+
     module Check_accepted = Check_accepted
   end
 

--- a/src/app/zeko/circuits/bridge_rules.ml
+++ b/src/app/zeko/circuits/bridge_rules.ml
@@ -1,6 +1,49 @@
 open Mina_base
 module PC = Signature_lib.Public_key.Compressed
 open Bridge_state
+open Snark_params.Tick
+open Zeko_util
+
+module Static_asset (Inputs : sig
+  val holder_account_l2 : PC.t
+
+  val token_owner_l2 : Account_id.t option
+
+  val ethereum_asset_id : (F.t * F.t) option
+end) =
+struct
+  module Witness = struct
+    type t = unit
+
+    type var = unit
+
+    let typ = Typ.unit
+  end
+
+  type verified = unit
+
+  let verify () = Checked.return ()
+
+  let vault_public_key () = constant PC.typ Inputs.holder_account_l2
+
+  let token_id_l2 () =
+    constant Token_id.typ (token_owner_id Inputs.token_owner_l2)
+
+  let ethereum_asset_id () =
+    match Inputs.ethereum_asset_id with
+    | Some (high, low) ->
+        Some (constant F.typ high, constant F.typ low)
+    | None ->
+        None
+
+  let authenticated_registry_call () = None
+
+  let call_data () _ = Checked.return (constant F.typ Field.zero)
+
+  let is_custom_token = Option.is_some Inputs.token_owner_l2
+
+  let is_ethereum_asset = Option.is_some Inputs.ethereum_asset_id
+end
 
 module Make_mina (Inputs : sig
   val holder_accounts_l1 : PC.t list
@@ -66,6 +109,15 @@ struct
     let token_owner_l2 = None
 
     let ethereum_asset_id = None
+
+    module Asset =
+      Static_asset (struct
+        let holder_account_l2 = Inputs.holder_account_l2
+
+        let token_owner_l2 = None
+
+        let ethereum_asset_id = None
+      end)
 
     module Deposit_params = Deposit_params_base
     module Withdrawal_params = Withdrawal_params_base
@@ -197,6 +249,15 @@ struct
 
     let bridge_proof_fee = Currency.Amount.zero
 
+    module Asset =
+      Static_asset (struct
+        let holder_account_l2 = Inputs.holder_account_l2
+
+        let token_owner_l2 = Some Inputs.token_owner_l2
+
+        let ethereum_asset_id = ethereum_asset_id
+      end)
+
     module Deposit_params = Deposit_params_ethereum_token
     module Withdrawal_params = Withdrawal_params_ethereum_token
     module Check_accepted = Check_accepted
@@ -216,6 +277,148 @@ struct
   module System_L2 =
   ( val Compile_simple.compile ~name:"bridge rules for Ethereum ERC20 on l2"
           ~out_typ:Snark_params.Tick.Typ.(Mina_base.Zkapp_statement.typ * V.typ)
+          ~branches:
+            [ Rule_bridge_finalize_deposit.rule
+            ; Rule_bridge_inner_receive.rule
+            ; Rule_multisig_update_l2.rule
+            ]
+          () )
+end
+
+module Make_ethereum_assets (Inputs : sig
+  val registry_public_key : PC.t
+
+  val registry_schema_version : Checked32.t
+
+  val approved_mft_standard_vk_id : F.t
+
+  val universal_bridge_vk_id : F.t
+
+  val vault_public_key : PC.t
+
+  val ethereum_holder_account_l1 : PC.t
+
+  val zeko_l2 : PC.t
+
+  val bridge_fee_recipient_l1 : PC.t
+
+  val bridge_fee_recipient_l2 : PC.t
+
+  val chain_l1 : Mina_signature_kind.t
+
+  val chain_l2 : Mina_signature_kind.t
+
+  val multisig_key : Multisig.t
+end)
+() =
+struct
+  module Registry =
+    Asset_registry.Make
+      (struct
+        let registry_public_key = Inputs.registry_public_key
+
+        let schema_version = Inputs.registry_schema_version
+
+        let approved_mft_standard_vk_id =
+          Inputs.approved_mft_standard_vk_id
+
+        let universal_bridge_vk_id = Inputs.universal_bridge_vk_id
+
+        let vault_public_key = Inputs.vault_public_key
+
+        let chain_l2 = Inputs.chain_l2
+      end)
+      ()
+
+  module Asset = struct
+    module Witness = Registry.Membership_witness
+
+    type verified = Registry.Verified_asset.t
+
+    let verify = Registry.verify
+
+    let record = Registry.Verified_asset.record
+
+    let vault_public_key verified =
+      (record verified).vault_public_key
+
+    let token_id_l2 = Registry.Verified_asset.token_id
+
+    let ethereum_asset_id verified =
+      let record = record verified in
+      Some (record.asset_id_high, record.asset_id_low)
+
+    let authenticated_registry_call verified =
+      Some (Registry.Verified_asset.authenticated_registry_call verified)
+
+    let call_data verified amount =
+      var_to_hash ~init:Zeko_constants.ethereum_asset_bridge_call_salt
+        Typ.(Asset_registry.Asset_record.typ * Currency.Amount.typ)
+        (record verified, amount)
+
+    let is_custom_token = true
+
+    let is_ethereum_asset = true
+  end
+
+  module Check_accepted =
+    Check_accepted_make.Make
+      (struct
+        let holder_accounts_l1 = []
+
+        let ethereum_holder_account_l1 =
+          Some Inputs.ethereum_holder_account_l1
+
+        (* Asset identity is dynamic here and is constrained against the
+           verified registry record in finalization. *)
+        let ethereum_asset_id = None
+
+        let token_owner_l1 = None
+
+        let chain_l1 = Inputs.chain_l1
+
+        module Deposit_params = Deposit_params_ethereum_token
+
+        let bridge_fee_recipient_l1 = Inputs.bridge_fee_recipient_l1
+
+        let bridge_proof_fee = Currency.Amount.zero
+      end)
+      ()
+
+  module Circuit_inputs = struct
+    include Inputs
+
+    let holder_accounts_l1 = []
+
+    let ethereum_holder_account_l1 =
+      Some Inputs.ethereum_holder_account_l1
+
+    let ethereum_asset_id = None
+
+    let token_owner_l1 = None
+
+    let bridge_proof_fee = Currency.Amount.zero
+
+    module Asset = Asset
+    module Deposit_params = Deposit_params_ethereum_token
+    module Check_accepted = Check_accepted
+  end
+
+  module Rule_bridge_finalize_deposit =
+    Rule_bridge_finalize_deposit.Make (Circuit_inputs)
+  module Rule_bridge_inner_receive =
+    Rule_bridge_inner_receive.Make (Circuit_inputs)
+
+  module Rule_multisig_update_l2 = Rule_multisig_update.Make (struct
+    let chain = Inputs.chain_l2
+
+    let multisig_key = Inputs.multisig_key
+  end)
+
+  module System_L2 =
+  ( val Compile_simple.compile
+          ~name:"universal registry-backed Ethereum asset bridge on l2"
+          ~out_typ:Typ.(Mina_base.Zkapp_statement.typ * V.typ)
           ~branches:
             [ Rule_bridge_finalize_deposit.rule
             ; Rule_bridge_inner_receive.rule
@@ -292,6 +495,15 @@ struct
     let token_owner_l2 = Some Inputs.token_owner_l2
 
     let ethereum_asset_id = None
+
+    module Asset =
+      Static_asset (struct
+        let holder_account_l2 = Inputs.holder_account_l2
+
+        let token_owner_l2 = Some Inputs.token_owner_l2
+
+        let ethereum_asset_id = None
+      end)
 
     module Deposit_params = Deposit_params_custom
     module Withdrawal_params = Withdrawal_params_custom

--- a/src/app/zeko/circuits/bridge_state.ml
+++ b/src/app/zeko/circuits/bridge_state.ml
@@ -7,11 +7,7 @@ module PC = Signature_lib.Public_key.Compressed
 module Withdrawal_recipient_domain = struct
   type t = Mina | Ethereum
 
-  let of_ethereum_holder_account = function
-    | None ->
-        Mina
-    | Some _ ->
-        Ethereum
+  let of_ethereum_holder_account = function None -> Mina | Some _ -> Ethereum
 end
 
 module Ethereum_address = struct

--- a/src/app/zeko/circuits/bridge_state.ml
+++ b/src/app/zeko/circuits/bridge_state.ml
@@ -20,13 +20,13 @@ module Ethereum_address = struct
   let validate ({ PC.Poly.x; is_odd } : PC.t) =
     if is_odd then
       Or_error.error_string "Ethereum withdrawal recipient must be even"
-    else if List.drop (Field.to_bits x) bit_length |> List.exists ~f:Fn.id then
+    else if List.drop (Field.unpack x) bit_length |> List.exists ~f:Fn.id then
       Or_error.error_string
         "Ethereum withdrawal recipient x-coordinate must fit 160 bits"
     else Ok ()
 
   let assert_valid ({ PC.Poly.x; is_odd } : PC.var) =
-    let* () = Boolean.Assert.is_false is_odd in
+    let* () = Boolean.Assert.is_true (Boolean.not is_odd) in
     let* (_ : Boolean.var list) =
       Field.Checked.choose_preimage_var x ~length:bit_length
     in

--- a/src/app/zeko/circuits/bridge_state.ml
+++ b/src/app/zeko/circuits/bridge_state.ml
@@ -459,6 +459,10 @@ let withdrawal_action (type withdrawal_params_var) ~chain_l2
     { default_account_update with
       public_key = constant PC.typ holder_account_l2
     ; token_id = constant Token_id.typ (token_owner_id token_owner_l2)
+    ; use_full_commitment =
+        constant Boolean.typ (Option.is_none token_owner_l2)
+    ; implicit_account_creation_fee =
+        constant Boolean.typ (Option.is_none token_owner_l2)
     ; balance_change =
         Currency.Amount.Signed.Checked.of_unsigned base_params.amount
     ; may_use_token =

--- a/src/app/zeko/circuits/bridge_state.ml
+++ b/src/app/zeko/circuits/bridge_state.ml
@@ -169,6 +169,25 @@ module Deposit_params_base = struct
   let base (x : var) = x
 
   let custom _ = None
+
+  let ethereum_salt = Zeko_constants.ethereum_deposit_salt
+
+  let asset_id _ = None
+end
+
+module Deposit_params_ethereum_token = struct
+  type t =
+    { asset_id_high : F.t; asset_id_low : F.t; base : Deposit_params_base.t }
+  [@@deriving snarky]
+
+  let base { base; _ } : Deposit_params_base.var = base
+
+  let custom _ = None
+
+  let ethereum_salt = Zeko_constants.ethereum_erc20_deposit_salt
+
+  let asset_id { asset_id_high; asset_id_low; _ } =
+    Some (asset_id_high, asset_id_low)
 end
 
 (* When the token is custom, and we need token owner authorization. *)
@@ -184,6 +203,10 @@ module Deposit_params_custom = struct
   let base { base; _ } : Deposit_params_base.var = base
 
   let custom x = Some x
+
+  let ethereum_salt = Zeko_constants.ethereum_deposit_salt
+
+  let asset_id _ = None
 end
 
 (* When the token is the Mina token. *)
@@ -194,6 +217,12 @@ module Withdrawal_params_base = struct
   let base (x : var) = x
 
   let custom _ = None
+
+  let debit_first = false
+
+  let hash_salt = Zeko_constants.withdrawal_salt
+
+  let asset_id _ = None
 end
 
 (* When the token is custom, and we need token owner authorization. *)
@@ -209,6 +238,35 @@ module Withdrawal_params_custom = struct
   let base { base; _ } : Withdrawal_params_base.var = base
 
   let custom x = Some x
+
+  let debit_first = false
+
+  let hash_salt = Zeko_constants.withdrawal_salt
+
+  let asset_id _ = None
+end
+
+module Withdrawal_params_ethereum_token = struct
+  type t =
+    { asset_id_high : F.t
+    ; asset_id_low : F.t
+    ; custom : Withdrawal_params_custom.t
+    }
+  [@@deriving snarky]
+
+  let base { custom; _ } : Withdrawal_params_base.var = custom.base
+
+  let custom { custom; _ } = Some custom
+
+  (* Mina's FungibleToken.approveBase rejects a positive running balance as
+     flash minting.  The user debit supplied in [nested_children] therefore
+     has to precede the bridge-vault receive synthesized below. *)
+  let debit_first = true
+
+  let hash_salt = Zeko_constants.ethereum_erc20_withdrawal_salt
+
+  let asset_id { asset_id_high; asset_id_low; _ } =
+    Some (asset_id_high, asset_id_low)
 end
 
 module type DEPOSIT_PARAMS = sig
@@ -217,6 +275,10 @@ module type DEPOSIT_PARAMS = sig
   val base : var -> Deposit_params_base.var
 
   val custom : var -> Deposit_params_custom.var option
+
+  val ethereum_salt : string
+
+  val asset_id : var -> (F.var * F.var) option
 end
 
 module type WITHDRAWAL_PARAMS = sig
@@ -225,11 +287,18 @@ module type WITHDRAWAL_PARAMS = sig
   val base : var -> Withdrawal_params_base.var
 
   val custom : var -> Withdrawal_params_custom.var option
+
+  val debit_first : bool
+
+  val hash_salt : string
+
+  val asset_id : var -> (F.var * F.var) option
 end
 
 let deposit_action (type deposit_params_var) ~chain_l1
     ~(holder_accounts_l1 : PC.t list) ~(token_owner_l1 : Account_id.t option)
     ~(ethereum_holder_account_l1 : PC.t option)
+    ~(ethereum_asset_id : (F.t * F.t) option)
     (module Deposit_params : DEPOSIT_PARAMS with type var = deposit_params_var)
     (params : deposit_params_var) ~(bridge_fee_recipient_l1 : PC.var)
     ~(bridge_proof_fee : Currency.Amount.var) :
@@ -241,6 +310,26 @@ let deposit_action (type deposit_params_var) ~chain_l1
      Adding an account is however not a problem.
   *)
   let base_params = Deposit_params.base params in
+  let* () =
+    match
+      ( ethereum_holder_account_l1
+      , ethereum_asset_id
+      , Deposit_params.asset_id params )
+    with
+    | Some _, Some (expected_high, expected_low), Some (actual_high, actual_low)
+      ->
+        let* () =
+          assert_equal ~label:__LOC__ F.typ actual_high
+            (constant F.typ expected_high)
+        in
+        assert_equal ~label:__LOC__ F.typ actual_low
+          (constant F.typ expected_low)
+    | Some _, None, None | None, None, None ->
+        Checked.return ()
+    | _ ->
+        failwith
+          "Ethereum deposit asset schema does not match circuit configuration"
+  in
   let@ () = with_label __LOC__ in
   let permitted_holder_accounts =
     match ethereum_holder_account_l1 with
@@ -308,8 +397,8 @@ let deposit_action (type deposit_params_var) ~chain_l1
     match ethereum_holder_account_l1 with
     | Some _ ->
         let* aux =
-          var_to_hash ~init:Zeko_constants.ethereum_deposit_salt
-            Deposit_params.typ params
+          var_to_hash ~init:Deposit_params.ethereum_salt Deposit_params.typ
+            params
         in
         Checked.return (constant C.typ [], aux)
     | None ->
@@ -334,7 +423,8 @@ let deposit_action (type deposit_params_var) ~chain_l1
 
 let withdrawal_action (type withdrawal_params_var) ~chain_l2
     ~(holder_account_l2 : PC.t) ~(token_owner_l2 : Account_id.t option)
-    ~l2_holder_vk_hash ~bridge_fee_recipient_l2 ~bridge_proof_fee
+    ~(ethereum_asset_id : (F.t * F.t) option) ~l2_holder_vk_hash
+    ~bridge_fee_recipient_l2 ~bridge_proof_fee
     (module Withdrawal_params : WITHDRAWAL_PARAMS
       with type var = withdrawal_params_var ) (params : Withdrawal_params.var) :
     Rollup_state.Inner_action.var Checked.t =
@@ -344,6 +434,20 @@ let withdrawal_action (type withdrawal_params_var) ~chain_l2
      Adding an account is however not a problem.
   *)
   let base_params = Withdrawal_params.base params in
+  let* () =
+    match (ethereum_asset_id, Withdrawal_params.asset_id params) with
+    | Some (expected_high, expected_low), Some (actual_high, actual_low) ->
+        let* () =
+          assert_equal ~label:__LOC__ F.typ actual_high
+            (constant F.typ expected_high)
+        in
+        assert_equal ~label:__LOC__ F.typ actual_low
+          (constant F.typ expected_low)
+    | None, None ->
+        Checked.return ()
+    | _ ->
+        failwith "Withdrawal asset schema does not match circuit configuration"
+  in
   let a =
     { default_account_update with
       public_key = constant PC.typ holder_account_l2
@@ -376,10 +480,10 @@ let withdrawal_action (type withdrawal_params_var) ~chain_l2
         constant Account_update.Authorization_kind.typ None_given
     }
   in
-  let a', (children : Calls.t) =
+  let* (a', children) : Account_update.Checked.t * Calls.t =
     match token_owner_l2 with
     | None ->
-        (a, [])
+        Checked.return (a, ([] : Calls.t))
     | Some token_owner_l2 ->
         let custom_params =
           Withdrawal_params.custom params
@@ -388,19 +492,41 @@ let withdrawal_action (type withdrawal_params_var) ~chain_l2
                  "If token_id isn't default, then Withdrawal_params_custom \
                   must be used."
         in
-        ( { default_account_update with
+        let token_owner =
+          { default_account_update with
             public_key = Account_id.public_key token_owner_l2 |> constant PC.typ
           ; token_id =
               Account_id.token_id token_owner_l2 |> constant Token_id.typ
           ; authorization_kind = custom_params.authorization_kind
           ; call_data = custom_params.call_data
           }
-        , (a, []) :: Raw custom_params.nested_children )
+        in
+        if Withdrawal_params.debit_first then
+          let (debit, debit_children), tail =
+            Zkapp_call_forest.Checked.pop_exn ~signature_kind:chain_l2
+              custom_params.nested_children
+          in
+          let* () =
+            Boolean.Assert.is_true
+              (Zkapp_call_forest.Checked.is_empty debit_children)
+          in
+          let* () =
+            Boolean.Assert.is_true (Zkapp_call_forest.Checked.is_empty tail)
+          in
+          let children : Calls.t =
+            [ (debit.account_update.data, []); (a, []) ]
+          in
+          Checked.return (token_owner, children)
+        else
+          let children : Calls.t =
+            (a, []) :: Raw custom_params.nested_children
+          in
+          Checked.return (token_owner, children)
   in
   let* children' =
     Calls.hash ~chain:chain_l2
       ((a', children) :: (fee_payout, []) :: Raw base_params.children)
   in
-  let hash_prefix = Zeko_constants.withdrawal_salt in
+  let hash_prefix = Withdrawal_params.hash_salt in
   let* aux = var_to_hash ~init:hash_prefix Withdrawal_params.typ params in
   Checked.return ({ aux; children = children' } : Rollup_state.Inner_action.var)

--- a/src/app/zeko/circuits/bridge_state.ml
+++ b/src/app/zeko/circuits/bridge_state.ml
@@ -4,6 +4,16 @@ open Zeko_util
 open Snark_params.Tick
 module PC = Signature_lib.Public_key.Compressed
 
+module Withdrawal_recipient_domain = struct
+  type t = Mina | Ethereum
+
+  let of_ethereum_holder_account = function
+    | None ->
+        Mina
+    | Some _ ->
+        Ethereum
+end
+
 module Ethereum_address = struct
   let bit_length = 160
 
@@ -21,6 +31,20 @@ module Ethereum_address = struct
       Field.Checked.choose_preimage_var x ~length:bit_length
     in
     Checked.return ()
+
+  let validate_for domain recipient =
+    match domain with
+    | Withdrawal_recipient_domain.Mina ->
+        Ok ()
+    | Withdrawal_recipient_domain.Ethereum ->
+        validate recipient
+
+  let assert_valid_for domain recipient =
+    match domain with
+    | Withdrawal_recipient_domain.Mina ->
+        Checked.return ()
+    | Withdrawal_recipient_domain.Ethereum ->
+        assert_valid recipient
 end
 
 module Outer_bridge_state = struct
@@ -278,6 +302,8 @@ module Withdrawal_params_base = struct
 
   let debit_first = false
 
+  let recipient_domain = Withdrawal_recipient_domain.Mina
+
   let hash_salt = Zeko_constants.withdrawal_salt
 
   let asset_id _ = None
@@ -299,6 +325,8 @@ module Withdrawal_params_custom = struct
   let custom x = Some x
 
   let debit_first = false
+
+  let recipient_domain = Withdrawal_recipient_domain.Mina
 
   let hash_salt = Zeko_constants.withdrawal_salt
 
@@ -324,6 +352,8 @@ module Withdrawal_params_ethereum_token_v1 = struct
      has to precede the bridge-vault receive synthesized below. *)
   let debit_first = true
 
+  let recipient_domain = Withdrawal_recipient_domain.Ethereum
+
   let hash_salt = Zeko_constants.ethereum_erc20_withdrawal_salt
 
   let asset_id { asset_id_high; asset_id_low; _ } =
@@ -348,6 +378,8 @@ module Withdrawal_params_ethereum_token = struct
   let custom { custom; _ } = Some custom
 
   let debit_first = true
+
+  let recipient_domain = Withdrawal_recipient_domain.Ethereum
 
   let hash_salt = Zeko_constants.ethereum_erc20_withdrawal_v2_salt
 
@@ -381,6 +413,8 @@ module type WITHDRAWAL_PARAMS = sig
   val custom : var -> Withdrawal_params_custom.var option
 
   val debit_first : bool
+
+  val recipient_domain : Withdrawal_recipient_domain.t
 
   val hash_salt : string
 
@@ -539,6 +573,10 @@ let withdrawal_action (type withdrawal_params_var) ~chain_l2
   *)
   let base_params = Withdrawal_params.base params in
   let* () =
+    Ethereum_address.assert_valid_for Withdrawal_params.recipient_domain
+      base_params.recipient
+  in
+  let* () =
     match
       (ethereum_registry_binding, Withdrawal_params.registry_binding params)
     with
@@ -551,7 +589,6 @@ let withdrawal_action (type withdrawal_params_var) ~chain_l2
             Checked32.typ encoding_version
             (Checked32.Checked.constant (Checked32.of_int 2))
         in
-        let* () = Ethereum_address.assert_valid base_params.recipient in
         let* () =
           assert_equal ~label:"Ethereum ERC20 withdrawal registry index"
             Checked32.typ actual_index

--- a/src/app/zeko/circuits/bridge_state.ml
+++ b/src/app/zeko/circuits/bridge_state.ml
@@ -153,6 +153,14 @@ open struct
 
     type var = Checked.t
   end
+
+  module B = struct
+    type t = Account_update.Body.t
+
+    type var = Account_update.Body.Checked.t
+
+    let typ = Account_update.Body.typ ()
+  end
 end
 
 (* When the token is the Mina token. *)
@@ -228,9 +236,8 @@ end
 (* When the token is custom, and we need token owner authorization. *)
 module Withdrawal_params_custom = struct
   type t =
-    { authorization_kind : A.t
+    { token_owner_body : B.t
     ; nested_children : C.t
-    ; call_data : F.t
     ; base : Withdrawal_params_base.t
     }
   [@@deriving snarky]
@@ -492,14 +499,14 @@ let withdrawal_action (type withdrawal_params_var) ~chain_l2
                  "If token_id isn't default, then Withdrawal_params_custom \
                   must be used."
         in
-        let token_owner =
-          { default_account_update with
-            public_key = Account_id.public_key token_owner_l2 |> constant PC.typ
-          ; token_id =
-              Account_id.token_id token_owner_l2 |> constant Token_id.typ
-          ; authorization_kind = custom_params.authorization_kind
-          ; call_data = custom_params.call_data
-          }
+        let token_owner = custom_params.token_owner_body in
+        let* () =
+          assert_equal ~label:__LOC__ PC.typ token_owner.public_key
+            (Account_id.public_key token_owner_l2 |> constant PC.typ)
+        in
+        let* () =
+          assert_equal ~label:__LOC__ Token_id.typ token_owner.token_id
+            (Account_id.token_id token_owner_l2 |> constant Token_id.typ)
         in
         if Withdrawal_params.debit_first then
           let (debit, debit_children), tail =

--- a/src/app/zeko/circuits/bridge_state.ml
+++ b/src/app/zeko/circuits/bridge_state.ml
@@ -4,6 +4,25 @@ open Zeko_util
 open Snark_params.Tick
 module PC = Signature_lib.Public_key.Compressed
 
+module Ethereum_address = struct
+  let bit_length = 160
+
+  let validate ({ PC.Poly.x; is_odd } : PC.t) =
+    if is_odd then
+      Or_error.error_string "Ethereum withdrawal recipient must be even"
+    else if List.drop (Field.to_bits x) bit_length |> List.exists ~f:Fn.id then
+      Or_error.error_string
+        "Ethereum withdrawal recipient x-coordinate must fit 160 bits"
+    else Ok ()
+
+  let assert_valid ({ PC.Poly.x; is_odd } : PC.var) =
+    let* () = Boolean.Assert.is_false is_odd in
+    let* (_ : Boolean.var list) =
+      Field.Checked.choose_preimage_var x ~length:bit_length
+    in
+    Checked.return ()
+end
+
 module Outer_bridge_state = struct
   type t =
     { disable_offset_lower : Slot.t
@@ -532,6 +551,7 @@ let withdrawal_action (type withdrawal_params_var) ~chain_l2
             Checked32.typ encoding_version
             (Checked32.Checked.constant (Checked32.of_int 2))
         in
+        let* () = Ethereum_address.assert_valid base_params.recipient in
         let* () =
           assert_equal ~label:"Ethereum ERC20 withdrawal registry index"
             Checked32.typ actual_index

--- a/src/app/zeko/circuits/bridge_state.ml
+++ b/src/app/zeko/circuits/bridge_state.ml
@@ -331,7 +331,9 @@ let deposit_action (type deposit_params_var) ~chain_l1
         in
         assert_equal ~label:__LOC__ F.typ actual_low
           (constant F.typ expected_low)
-    | Some _, None, None | None, None, None ->
+    | Some _, None, Some _
+    | Some _, None, None
+    | None, None, None ->
         Checked.return ()
     | _ ->
         failwith

--- a/src/app/zeko/circuits/bridge_state.ml
+++ b/src/app/zeko/circuits/bridge_state.ml
@@ -509,17 +509,20 @@ let withdrawal_action (type withdrawal_params_var) ~chain_l2
             (Account_id.token_id token_owner_l2 |> constant Token_id.typ)
         in
         if Withdrawal_params.debit_first then
-          let (debit, debit_children), tail =
-            Zkapp_call_forest.Checked.pop_exn ~signature_kind:chain_l2
-              custom_params.nested_children
+          let* (debit, debit_children), tail =
+            make_checked (fun () ->
+                Zkapp_call_forest.Checked.pop_exn ~signature_kind:chain_l2
+                  custom_params.nested_children )
           in
-          let* () =
-            Boolean.Assert.is_true
-              (Zkapp_call_forest.Checked.is_empty debit_children)
+          let* debit_children_empty =
+            make_checked (fun () ->
+                Zkapp_call_forest.Checked.is_empty debit_children )
           in
-          let* () =
-            Boolean.Assert.is_true (Zkapp_call_forest.Checked.is_empty tail)
+          let* () = Boolean.Assert.is_true debit_children_empty in
+          let* tail_empty =
+            make_checked (fun () -> Zkapp_call_forest.Checked.is_empty tail)
           in
+          let* () = Boolean.Assert.is_true tail_empty in
           let children : Calls.t =
             [ (debit.account_update.data, []); (a, []) ]
           in

--- a/src/app/zeko/circuits/bridge_state.ml
+++ b/src/app/zeko/circuits/bridge_state.ml
@@ -181,9 +181,11 @@ module Deposit_params_base = struct
   let ethereum_salt = Zeko_constants.ethereum_deposit_salt
 
   let asset_id _ = None
+
+  let registry_binding _ = None
 end
 
-module Deposit_params_ethereum_token = struct
+module Deposit_params_ethereum_token_v1 = struct
   type t =
     { asset_id_high : F.t; asset_id_low : F.t; base : Deposit_params_base.t }
   [@@deriving snarky]
@@ -196,6 +198,33 @@ module Deposit_params_ethereum_token = struct
 
   let asset_id { asset_id_high; asset_id_low; _ } =
     Some (asset_id_high, asset_id_low)
+
+  let registry_binding _ = None
+end
+
+module Deposit_params_ethereum_token = struct
+  type t =
+    { encoding_version : Checked32.t
+    ; registry_index : Checked32.t
+    ; record_commitment : F.t
+    ; asset_id_high : F.t
+    ; asset_id_low : F.t
+    ; base : Deposit_params_base.t
+    }
+  [@@deriving snarky]
+
+  let base { base; _ } : Deposit_params_base.var = base
+
+  let custom _ = None
+
+  let ethereum_salt = Zeko_constants.ethereum_erc20_deposit_v2_salt
+
+  let asset_id { asset_id_high; asset_id_low; _ } =
+    Some (asset_id_high, asset_id_low)
+
+  let registry_binding
+      { encoding_version; registry_index; record_commitment; _ } =
+    Some (encoding_version, registry_index, record_commitment)
 end
 
 (* When the token is custom, and we need token owner authorization. *)
@@ -215,6 +244,8 @@ module Deposit_params_custom = struct
   let ethereum_salt = Zeko_constants.ethereum_deposit_salt
 
   let asset_id _ = None
+
+  let registry_binding _ = None
 end
 
 (* When the token is the Mina token. *)
@@ -231,6 +262,8 @@ module Withdrawal_params_base = struct
   let hash_salt = Zeko_constants.withdrawal_salt
 
   let asset_id _ = None
+
+  let registry_binding _ = None
 end
 
 (* When the token is custom, and we need token owner authorization. *)
@@ -251,9 +284,11 @@ module Withdrawal_params_custom = struct
   let hash_salt = Zeko_constants.withdrawal_salt
 
   let asset_id _ = None
+
+  let registry_binding _ = None
 end
 
-module Withdrawal_params_ethereum_token = struct
+module Withdrawal_params_ethereum_token_v1 = struct
   type t =
     { asset_id_high : F.t
     ; asset_id_low : F.t
@@ -274,6 +309,35 @@ module Withdrawal_params_ethereum_token = struct
 
   let asset_id { asset_id_high; asset_id_low; _ } =
     Some (asset_id_high, asset_id_low)
+
+  let registry_binding _ = None
+end
+
+module Withdrawal_params_ethereum_token = struct
+  type t =
+    { encoding_version : Checked32.t
+    ; registry_index : Checked32.t
+    ; record_commitment : F.t
+    ; asset_id_high : F.t
+    ; asset_id_low : F.t
+    ; custom : Withdrawal_params_custom.t
+    }
+  [@@deriving snarky]
+
+  let base { custom; _ } : Withdrawal_params_base.var = custom.base
+
+  let custom { custom; _ } = Some custom
+
+  let debit_first = true
+
+  let hash_salt = Zeko_constants.ethereum_erc20_withdrawal_v2_salt
+
+  let asset_id { asset_id_high; asset_id_low; _ } =
+    Some (asset_id_high, asset_id_low)
+
+  let registry_binding
+      { encoding_version; registry_index; record_commitment; _ } =
+    Some (encoding_version, registry_index, record_commitment)
 end
 
 module type DEPOSIT_PARAMS = sig
@@ -286,6 +350,8 @@ module type DEPOSIT_PARAMS = sig
   val ethereum_salt : string
 
   val asset_id : var -> (F.var * F.var) option
+
+  val registry_binding : var -> (Checked32.var * Checked32.var * F.var) option
 end
 
 module type WITHDRAWAL_PARAMS = sig
@@ -300,6 +366,8 @@ module type WITHDRAWAL_PARAMS = sig
   val hash_salt : string
 
   val asset_id : var -> (F.var * F.var) option
+
+  val registry_binding : var -> (Checked32.var * Checked32.var * F.var) option
 end
 
 let deposit_action (type deposit_params_var) ~chain_l1
@@ -318,6 +386,15 @@ let deposit_action (type deposit_params_var) ~chain_l1
   *)
   let base_params = Deposit_params.base params in
   let* () =
+    match Deposit_params.registry_binding params with
+    | None ->
+        Checked.return ()
+    | Some (encoding_version, _, _) ->
+        assert_equal ~label:"Ethereum ERC20 deposit encoding version"
+          Checked32.typ encoding_version
+          (Checked32.Checked.constant (Checked32.of_int 2))
+  in
+  let* () =
     match
       ( ethereum_holder_account_l1
       , ethereum_asset_id
@@ -331,9 +408,7 @@ let deposit_action (type deposit_params_var) ~chain_l1
         in
         assert_equal ~label:__LOC__ F.typ actual_low
           (constant F.typ expected_low)
-    | Some _, None, Some _
-    | Some _, None, None
-    | None, None, None ->
+    | Some _, None, Some _ | Some _, None, None | None, None, None ->
         Checked.return ()
     | _ ->
         failwith
@@ -432,7 +507,8 @@ let deposit_action (type deposit_params_var) ~chain_l1
 
 let withdrawal_action (type withdrawal_params_var) ~chain_l2
     ~(holder_account_l2 : PC.t) ~(token_owner_l2 : Account_id.t option)
-    ~(ethereum_asset_id : (F.t * F.t) option) ~l2_holder_vk_hash
+    ~(ethereum_asset_id : (F.t * F.t) option)
+    ~(ethereum_registry_binding : (Checked32.t * F.t) option) ~l2_holder_vk_hash
     ~bridge_fee_recipient_l2 ~bridge_proof_fee
     (module Withdrawal_params : WITHDRAWAL_PARAMS
       with type var = withdrawal_params_var ) (params : Withdrawal_params.var) :
@@ -443,6 +519,31 @@ let withdrawal_action (type withdrawal_params_var) ~chain_l2
      Adding an account is however not a problem.
   *)
   let base_params = Withdrawal_params.base params in
+  let* () =
+    match
+      (ethereum_registry_binding, Withdrawal_params.registry_binding params)
+    with
+    | None, None ->
+        Checked.return ()
+    | ( Some (expected_index, expected_commitment)
+      , Some (encoding_version, actual_index, actual_commitment) ) ->
+        let* () =
+          assert_equal ~label:"Ethereum ERC20 withdrawal encoding version"
+            Checked32.typ encoding_version
+            (Checked32.Checked.constant (Checked32.of_int 2))
+        in
+        let* () =
+          assert_equal ~label:"Ethereum ERC20 withdrawal registry index"
+            Checked32.typ actual_index
+            (Checked32.Checked.constant expected_index)
+        in
+        assert_equal ~label:"Ethereum ERC20 withdrawal record commitment" F.typ
+          actual_commitment
+          (constant F.typ expected_commitment)
+    | _ ->
+        failwith
+          "Withdrawal registry binding does not match circuit configuration"
+  in
   let* () =
     match (ethereum_asset_id, Withdrawal_params.asset_id params) with
     | Some (expected_high, expected_low), Some (actual_high, actual_low) ->
@@ -461,8 +562,7 @@ let withdrawal_action (type withdrawal_params_var) ~chain_l2
     { default_account_update with
       public_key = constant PC.typ holder_account_l2
     ; token_id = constant Token_id.typ (token_owner_id token_owner_l2)
-    ; use_full_commitment =
-        constant Boolean.typ (Option.is_none token_owner_l2)
+    ; use_full_commitment = constant Boolean.typ (Option.is_none token_owner_l2)
     ; implicit_account_creation_fee =
         constant Boolean.typ (Option.is_none token_owner_l2)
     ; balance_change =

--- a/src/app/zeko/circuits/check_accepted_make.ml
+++ b/src/app/zeko/circuits/check_accepted_make.ml
@@ -9,8 +9,10 @@ module Make (Inputs : sig
 
   val holder_accounts_l1 : Signature_lib.Public_key.Compressed.t list
 
-  val ethereum_holder_account_l1 :
-    Signature_lib.Public_key.Compressed.t option
+  val ethereum_holder_account_l1 : Signature_lib.Public_key.Compressed.t option
+
+  val ethereum_asset_id :
+    (Snark_params.Tick.Field.t * Snark_params.Tick.Field.t) option
 
   val token_owner_l1 : Account_id.t option
 
@@ -63,6 +65,7 @@ struct
           ~bridge_fee_recipient_l1:(constant PC.typ bridge_fee_recipient_l1)
           ~bridge_proof_fee:(constant Currency.Amount.typ bridge_proof_fee)
           ~holder_accounts_l1 ~token_owner_l1 ~ethereum_holder_account_l1
+          ~ethereum_asset_id
           (module Deposit_params)
           params
       in

--- a/src/app/zeko/circuits/design/README.md
+++ b/src/app/zeko/circuits/design/README.md
@@ -6,6 +6,7 @@
 - [prover.md](./prover.md)
 - [parallel-merger.md](./parallel-merger.md)
 - [sequencer.md](./sequencer.md)
+- [ethereum-erc20-bridge.md](./ethereum-erc20-bridge.md)
 
 Files in `old/` are historical and not up-to-date.
 

--- a/src/app/zeko/circuits/design/ethereum-erc20-bridge.md
+++ b/src/app/zeko/circuits/design/ethereum-erc20-bridge.md
@@ -62,9 +62,11 @@ The maintained reference implementation has the properties this bridge needs:
   accounts in the same transaction
   ([deployment guide](https://minafoundation.github.io/mina-fungible-token/deploy.html)).
 
-Do not fork `FungibleToken` to add bridge behavior. The standard's interoperability
-benefit comes from using the same owner implementation; bridge-specific policy
-belongs in the admin contract and bridge-vault verification key.
+Do not fork `FungibleToken` to add bridge behavior. The standard's
+interoperability benefit comes from using the same owner implementation. For
+the bounded-inventory model, the admin is used only during deployment;
+bridge-specific runtime policy belongs in the bridge and bridge-vault
+verification key.
 
 ## L2 account topology
 
@@ -73,7 +75,7 @@ For every registered ERC-20 asset:
 | Role | Mina account ID | Authorization and purpose |
 | --- | --- | --- |
 | Token owner | `(ft_owner_pk, TokenId.default)` | Unmodified `FungibleToken`; owns `ft_token_id = derive_token_id(owner_account_id)` and runs `approveBase`. |
-| Token admin | `(ft_admin_pk, TokenId.default)` | Separate admin contract. For the vault model it authorizes only the bounded deployment mint, pause/resume, and governed upgrades. |
+| Token admin | `(ft_admin_pk, TokenId.default)` | Unmodified separate admin contract. It authorizes the bounded deployment mint, then its controller is permanently set to `Public_key.Compressed.empty`; it provides no post-registration administration. |
 | Circulation account | `(ft_owner_pk, ft_token_id)` | Reserved by the standard for supply accounting. Never use it as the bridge vault. |
 | Bridge vault | `(shared_vault_l2, ft_token_id)` | Holds that asset's pre-minted inventory and uses the universal bridge verification key. Every asset shares the public key and VK but has a distinct derived token ID/account/balance. |
 | User balance | `(user_pk, ft_token_id)` | Ordinary standard fungible-token account. |
@@ -231,8 +233,8 @@ Required invariants:
 - the bounded mint is auditable and the final standard admin controller is the
   fixed non-signing `Public_key.Compressed.empty`;
 - no path can transfer from the reserved circulation account; and
-- emergency pause covers Solidity deposits/releases and L2 standard-token
-  transfers coherently.
+- rollup commit freezing and the Ethereum bridge pause stop cross-chain
+  progress; ordinary L2 standard-token transfers remain enabled.
 
 The tradeoff is supply reporting: the standard circulation account counts the
 pre-minted vault inventory even while it is idle, so `getCirculating()` is not
@@ -356,7 +358,7 @@ settlement guest binds the OCaml Poseidon transition to the same ordered
 canonical records activated by Solidity.
 
 
-## Deployment and upgrade policy
+## Deployment and post-registration policy
 
 Onboard one asset atomically where possible:
 
@@ -373,16 +375,14 @@ Onboard one asset atomically where possible:
    pending Solidity proposal; and
 7. enable deposits only after a cross-chain deposit/withdrawal rehearsal.
 
-For the strongest first deployment, set the standard token owner's
-`allowUpdates` to false. If upgrades are required, use the standard's supported
-admin/verification-key path behind a timelocked multisig and treat a token-owner,
-admin, vault, circuit VK, settlement VK, or Solidity registry change as one
-cross-chain migration. Pause both directions before changing any member of that
-set. Existing holder enable/disable circuits can still rotate the vault's send
-permission/VK on their scheduled windows; the custom version differs by using
-the derived token ID
-([`rule_bridge_disable.ml`, lines 25-111](../rule_bridge_disable.ml#L25-L111),
-[`rule_bridge_enable.ml`, lines 25-111](../rule_bridge_enable.ml#L25-L111)).
+Set the standard token owner's `allowUpdates` to false. Registration permanently
+revokes the standard admin controller, so token-level `pause`, `resume`,
+`setAdmin`, and authorized verification-key upgrades are unavailable afterward.
+The supported emergency controls are rollup commit freezing and the Ethereum
+bridge pause; neither disables ordinary L2 standard-token transfers. A future
+token-owner, admin, vault, circuit, settlement, or Solidity registry change
+requires a separately reviewed cross-chain migration rather than the revoked
+standard-admin path.
 
 ## Verification coverage
 

--- a/src/app/zeko/circuits/design/ethereum-erc20-bridge.md
+++ b/src/app/zeko/circuits/design/ethereum-erc20-bridge.md
@@ -223,6 +223,9 @@ changes generated today by `finalize_deposit`, `withdrawal_action`, and
 Required invariants:
 
 - `user_wrapped_supply <= ethereum_locked_for_asset` at every accepted state;
+- Solidity rejects deposits whose outstanding per-token liability would exceed
+  an immutable `depositCapByToken`, configured to equal the initial pre-minted
+  L2 vault inventory;
 - a deposit cannot finalize if the vault lacks the net amount;
 - the bounded mint is auditable and routine mint authority is revoked or capped
   after deployment;

--- a/src/app/zeko/circuits/design/ethereum-erc20-bridge.md
+++ b/src/app/zeko/circuits/design/ethereum-erc20-bridge.md
@@ -1,6 +1,6 @@
 # Ethereum ERC-20 to Zeko fungible-token bridge
 
-Status: implementation design and gap analysis, 2026-07-21.
+Status: PoC implementation contract and remaining release gaps, 2026-07-28.
 
 This note defines the L2 Mina fungible-token topology for an ERC-20 bridge and
 connects it to the existing OCaml bridge circuits. It is intentionally narrower
@@ -18,21 +18,21 @@ admin whose controller was deployed as `Public_key.Compressed.empty`. The first
 implementation uses the pre-minted inventory for balanced
 vault-to-user/user-to-vault transfers.
 
-This is the supply model that the current OCaml custom-token rules can be
-adapted to. Exact mint-on-deposit and burn-on-withdrawal are supported by the
-Mina fungible-token standard in principle, but are **not** what
-`Bridge_rules.Make_custom` currently proves. They require a different bridge
-circuit and an admin policy that authorizes each mint from the accepted Ethereum
-deposit proof.
+This is the supply model used by the registry-backed OCaml bridge rules. Exact
+mint-on-deposit and burn-on-withdrawal are supported by the Mina fungible-token
+standard in principle, but are **not** what the current bridge circuits prove.
+They require a different bridge circuit and an admin policy that authorizes each
+mint from the accepted Ethereum deposit proof.
 
-The Ethereum side of a deposit remains the existing witness-action path:
+The Ethereum side of a deposit uses the existing witness-action path:
 `submitDeposit` transfers ERC-20 into Solidity custody and emits the canonical
 deposit fields; those fields become the proof witness action consumed by
 `Check_accepted`, just as a native Mina deposit's account-update forest becomes
-the witness action. The current Ethereum branch already replaces Mina children
-with a salted hash of the deposit parameters
-([`bridge_state.ml`, lines 307-325](../bridge_state.ml#L307-L325)). The ERC-20
-version must extend that preimage with an asset identity.
+the witness action. The registry-backed V2 branch replaces Mina children with a
+salted hash that binds the encoding version, registry index, record commitment,
+asset ID, and deposit parameters
+([`Bridge_state.deposit_action`](../bridge_state.ml)). The explicit legacy V1
+branch keeps its original salt and asset-ID-only preimage.
 
 ## Why the standard token contract fits
 
@@ -94,7 +94,7 @@ For every registered ERC-20 asset:
 `token_owner_l2` in the circuit must be the token owner's **account ID**, not
 the derived token ID. The existing helper `token_owner_id` performs that
 derivation for custom assets
-([`zeko_util.ml`, lines 433-437](../zeko_util.ml#L433-L437)).
+([`Zeko_util.token_owner_id`](../zeko_util.ml)).
 
 Each supported ERC-20 gets its own token owner, derived token ID, inventory,
 fee policy, and immutable registry entry. The owner and token ID are dynamic
@@ -127,6 +127,14 @@ limbs, ERC-20 address, L2 owner/token ID, and decimals. Solidity, the OCaml
 action constructor, settlement guest, SDK, and indexer must implement one
 canonical encoding and reject unknown versions.
 
+Registry-backed deposit and withdrawal actions use encoding version 2. Both
+preimages contain `registry_index` and the V1 asset-record commitment. Deposit
+finalization checks those fields and the asset ID against authenticated registry
+membership; withdrawal construction performs the same checks before hashing the
+V2 action. The retained `Make_ethereum_token` V1 circuit family omits registry
+fields and continues to use the original V1 salts. Public GraphQL proof requests
+expose registry V2 only.
+
 Use identical base units on both chains:
 
 - require the registered ERC-20 decimals to equal the L2 token's `UInt8`
@@ -156,13 +164,13 @@ creation fee from a custom-token `UInt64` amount.
 3. `Check_accepted` follows the existing rule: the deposit is accepted only
    after a synchronized commit includes it before its timeout, or rejected after
    the timeout path
-   ([`check_accepted_make.ml`, lines 58-125](../check_accepted_make.ml#L58-L125)).
+   ([`Check_accepted_make.Make`](../check_accepted_make.ml)).
 4. Finalization on L2 proves the accepted deposit, advances the recipient's
    replay helper, debits the custom-token bridge vault, and credits the
    recipient. The current rule already binds the accepted proof, derives the
    helper token, requires a strictly increasing deposit index, and emits the
    deposit event
-   ([`rule_bridge_finalize_deposit.ml`, lines 118-255](../rule_bridge_finalize_deposit.ml#L118-L255)).
+   ([`Rule_bridge_finalize_deposit.Make`](../rule_bridge_finalize_deposit.ml)).
 5. The entire custom-token subtree is passed to the standard owner's
    `approveBase`; its token changes must be conserved and ordered debit-first.
 
@@ -184,7 +192,7 @@ subtree is a one-for-one vault transfer.
 New custom-token accounts must set `implicit_account_creation_fee = false` and
 be funded from MINA fee excess. Mina transaction logic explicitly forbids an
 implicit creation fee on a non-default token
-([`zkapp_command_logic.ml`, lines 1426-1465](../../../../lib/transaction_logic/zkapp_command_logic.ml#L1426-L1465)).
+([`zkapp_command_logic.ml`](../../../../lib/transaction_logic/zkapp_command_logic.ml)).
 
 ## Withdrawal flow: Zeko to Ethereum
 
@@ -194,7 +202,7 @@ implicit creation fee on a non-default token
 2. The bridge-vault receive update uses the existing `inner_receive` proof. Its
    purpose is to satisfy the vault's proof access permission while binding the
    amount and token ID
-   ([`rule_bridge_inner_receive.ml`, lines 18-40](../rule_bridge_inner_receive.ml#L18-L40)).
+   ([`Rule_bridge_inner_receive.Make`](../rule_bridge_inner_receive.ml)).
 3. The rollup inner witness action binds asset ID, amount, Ethereum recipient,
    and the exact approved child forest. A separate default-MINA debit/payout may
    fund proving; it must sit outside the custom-token conservation subtree.
@@ -202,7 +210,7 @@ implicit creation fee on a non-default token
    the exact action and Solidity releases the registered ERC-20 from custody to
    the bound recipient. The OCaml withdrawal proof already binds the withdrawal
    action to the inner action-state extension and a committed outer action
-   ([`rule_bridge_finalize_withdrawal.ml`, lines 128-168](../rule_bridge_finalize_withdrawal.ml#L128-L168));
+   ([`Rule_bridge_finalize_withdrawal.Make`](../rule_bridge_finalize_withdrawal.ml));
    Ethereum replaces the Mina L1 payout portion with Solidity settlement.
 
 The required submission subtree is:
@@ -275,8 +283,10 @@ and no vault-capacity ceiling.
 `Make_mina` fixes both sides to the default token and base parameters, while
 `Make_custom` fixes **both** L1 and L2 to custom-token owners and custom
 parameters
-([`bridge_rules.ml`, lines 5-69 and 132-200](../bridge_rules.ml#L5-L200)). An
-Ethereum ERC-20 bridge is a hybrid:
+([`bridge_rules.ml`](../bridge_rules.ml)). The explicit legacy
+`Make_ethereum_token` family fixes one static ERC-20 identity, while
+`Make_ethereum_assets` verifies a dynamic V2 registry record. An Ethereum ERC-20
+bridge is a hybrid:
 
 ```text
 L1 custody/action source: Ethereum ERC-20, no Mina token owner
@@ -285,49 +295,37 @@ L2 asset:                  custom Mina FungibleToken
 L2 withdrawal forest:      custom parameters and token-owner approval
 ```
 
-Introduce a side-specific asset functor (or `Make_ethereum_custom`) instead of
-reusing `Make_custom` unchanged. In particular, the current Ethereum action
-hashes whichever `Deposit_params` module the enclosing functor selected. Using
-`Make_custom` would make Solidity bind irrelevant Mina authorization/call-forest
-fields and still would not provide a canonical ERC-20 identity
-([`bridge_state.ml`, lines 230-325](../bridge_state.ml#L230-L325)).
+The implemented side-specific families avoid reusing `Make_custom` unchanged.
+Their V1 and V2 parameter modules select distinct Ethereum salts and exclude
+irrelevant Mina L1 authorization and call-forest fields
+([`bridge_state.ml`](../bridge_state.ml)).
 
-### Required circuit corrections
+### ERC-20-specific circuit corrections
 
-The existing custom path compiles, but its generated forests are not yet valid
-standard-token transactions:
+The ERC-20 circuit families apply the standard-token forest constraints:
 
-1. `withdrawal_action` prepends the positive vault receive before caller-supplied
-   nested children
-   ([`bridge_state.ml`, lines 379-402](../bridge_state.ml#L379-L402)). A standard
-   sender debit in `nested_children` therefore comes too late and triggers the
-   reference implementation's flash-mint check. Permit a constrained debit-first
-   ordering.
-2. Deposit-finalization custom-token payouts are children of the vault update
-   but use `Parents_own_token`
-   ([`rule_bridge_finalize_deposit.ml`, lines 245-306](../rule_bridge_finalize_deposit.ml#L245-L306)).
-   A direct child's `Parents_own_token` selects the token derived from the vault
-   account; it does not retain `ft_token_id`. Those payouts must use
-   `Inherit_from_parent`, while the replay helper intentionally keeps
-   `Parents_own_token`. The caller derivation and non-default-token check are in
-   [`zkapp_command_logic.ml`, lines 1043-1108 and 1224-1236](../../../../lib/transaction_logic/zkapp_command_logic.ml#L1043-L1108).
-3. The custom payouts set `implicit_account_creation_fee = true` and subtract a
-   MINA creation fee from the custom-token amount
-   ([`rule_bridge_finalize_deposit.ml`, lines 257-297](../rule_bridge_finalize_deposit.ml#L257-L297)).
-   Non-default tokens cannot pay this implicit fee, and the subtraction also
-   makes the custom-token forest unbalanced. Use a separate MINA funding update
-   and denomination-specific fees.
+1. V1 and V2 withdrawals require exactly one leaf sender debit before the
+   positive vault receive, satisfying `approveBase`'s no-positive-prefix rule
+   ([`Bridge_state.withdrawal_action`](../bridge_state.ml)).
+2. Deposit-finalization custom-token payouts use `Inherit_from_parent`, retaining
+   the owner's derived token ID; the replay helper intentionally uses
+   `Parents_own_token`
+   ([`Rule_bridge_finalize_deposit.Make`](../rule_bridge_finalize_deposit.ml)).
+3. ERC-20 vault and recipient updates disable implicit account-creation fees and
+   move the full custom-token amount one-for-one. Default-token fee payers or
+   sponsors fund MINA account creation separately.
 
 Equivalent corrections are needed in any retained custom-Mina L1
 finalize/cancel rules. For the Ethereum bridge, Solidity handles those L1 paths.
 
 ## Implemented runtime seam
 
-This branch implements the security-critical cross-chain seam:
+The cross-repository PoC implements the security-critical cross-chain seam:
 
-- `Make_ethereum_token` combines an Ethereum deposit source with a custom-token
-  L2 vault and fixes custom-token payout denomination, token inheritance, and
-  debit-first withdrawal ordering;
+- legacy `Make_ethereum_token` and registry-backed `Make_ethereum_assets`
+  combine an Ethereum deposit source with a custom-token L2 vault and enforce
+  custom-token payout denomination, token inheritance, and debit-first
+  withdrawal ordering;
 - the settlement bridge guest converts a canonical Solidity `submitDeposit`
   log into the exact asset-bound outer Witness action consumed by
   `Check_accepted`;
@@ -339,28 +337,45 @@ This branch implements the security-critical cross-chain seam:
 
 The executable Mina Fungible Token orchestration follows the same boundary:
 
-- the sequencer config accepts the registry account, schema, approved MFT
-  standard VK ID, shared vault public key, and universal bridge VK ID;
+- the sequencer config accepts the registry and registration-authority accounts,
+  shared vault, approved MFT standard ID, approved token/admin VK hashes, and
+  universal bridge ID/hash. The registry schema version is the compiled Zeko
+  constant, and the Ethereum bridge address is required when the registry is
+  enabled;
 - public bridge types, prover jobs, VK responses, and proof dispatch carry a
   verified asset record plus membership path through one
   `Make_ethereum_assets` circuit family;
 - registration uses the existing recursive folder pattern to scan every dense
   old leaf at the next exact index, reject duplicate Ethereum token, asset ID,
   owner, or derived token ID, verify an empty append slot, and commit the
-  incremented root/count;
+  incremented root/count. A fixed registration authority signs the full
+  commitment, and both the sequencer admission path and commit circuit limit the
+  pending transition to one append per commit;
 - GraphQL exposes proof-only token deposit-finalization and withdrawal-request
-  mutations plus the immutable public token configuration;
+  mutations. `circuitsConfig.ethereumAssets` publishes the live registry
+  root/count together with the registry, authority, vault, schema, approved
+  standard/VK values, and compiled bridge/registry VK hashes;
 - withdrawal input carries the complete standard token-owner account-update
   body. The circuit pins its public key and default token ID while the standard
   owner's proof enforces all remaining `approveBase` semantics;
 - the bridge SDK checks the returned vault forest and owner public input, grafts
   the genuine standard-token proof/signature authorizations, and only then
   submits the complete L2 transaction; and
-- the operator deployment helper validates each pending Solidity record and
-  Zeko membership, deploys the unmodified `FungibleToken`, live provisioning
-  admin, and empty-controller final admin, locks each token-specific shared
-  vault account to the universal VK with proof-authorized sends, mints exactly
-  the registered cap, and installs the final admin before registration.
+- the companion operator deployment helper validates each pending Solidity
+  record and Zeko membership, deploys the unmodified `FungibleToken`, live
+  provisioning admin, and empty-controller final admin, locks each token-specific
+  shared vault account to the universal VK with proof-authorized sends, mints
+  exactly the registered cap, and installs the final admin before registration.
+
+The Pickles commit circuit opens the old and new registry accounts against the
+transaction SNARK's source and target ledger roots. It permits no registry
+change or one append at the old count, and binds the candidate record, empty
+slot, and resulting root/count. For an append it also opens the real token owner,
+final admin, shared-vault token account, and circulation account in the target
+ledger. Those openings pin the derived token ID, decimals, approved owner/admin
+VKs, revoked admin controller, unpaused owner, vault/circulation balances equal
+to the inventory cap, universal vault VK, and the required immutable
+permissions.
 
 The archive and Actions indexer reconstruct immutable records and refreshed
 membership paths after later appends. They are availability aids, not security
@@ -403,8 +418,8 @@ Onboard one asset atomically where possible:
    the already-deployed empty-controller final admin;
 7. fund all default-token account-creation costs and helper sponsorship policy;
 8. append the canonical record through the exhaustive Zeko registry transition,
-   settle the new root/count and ordered record batch, and activate exactly that
-   pending Solidity proposal; and
+   settle that single new root/count and ordered record batch, and activate
+   exactly that pending Solidity proposal; and
 9. enable deposits only after a cross-chain deposit/withdrawal rehearsal.
 
 The registry commit verifies that the token owner already points to the final
@@ -429,8 +444,9 @@ The active PoC gate is limited to focused builds and fake/vector proofs:
    live provisioning signer, reject invalid registry membership, and cover
    accepted deposit finalization, helper progression, denomination, token
    inheritance, checkpoint key parity, 160-bit even withdrawal recipients,
-   native/V1/V2 withdrawal action and export fields, two registrations in one
-   command, and separate pending registrations before and after a commit.
+   native/V1/V2 withdrawal action and export fields, rejection of two
+   registrations in one command, and separate pending registrations before and
+   after a commit.
 
 ```bash
 dune build ./src/app/zeko/tests/asset_registry_vectors.exe ./src/app/zeko/tests/ethereum_bridge_vectors.exe

--- a/src/app/zeko/circuits/design/ethereum-erc20-bridge.md
+++ b/src/app/zeko/circuits/design/ethereum-erc20-bridge.md
@@ -368,6 +368,13 @@ boundaries: the circuit authenticates the registry account root/count, and the
 settlement guest binds the OCaml Poseidon transition to the same ordered
 canonical records activated by Solidity.
 
+Registry settlement uses checkpoint wire version 2. Its Poseidon input order is
+`registry_public_key.x`, `registry_public_key.is_odd`, `root`, `count`,
+`schema_version` under the `Zeko registry checkpoint V2` domain. Settlement
+JSON reports `checkpointVersion: 2` and encodes `registryPublicKey` as the
+64-digit Mina compressed x-coordinate with parity in the high bit, matching
+`tokenOwnerL2` and `vaultPublicKey`. Version 1 omitted parity and must not be
+accepted as a version-2 checkpoint.
 
 ## Deployment and post-registration policy
 
@@ -413,7 +420,9 @@ The active PoC gate is limited to focused builds and fake/vector proofs:
    tag/VK, authenticate the final empty-controller admin, reject retaining the
    live provisioning signer, reject invalid registry membership, and cover
    accepted deposit finalization, helper progression, denomination, token
-   inheritance, and withdrawal action/export fields.
+   inheritance, checkpoint key parity, 160-bit even withdrawal recipients,
+   withdrawal action/export fields, and the one-pending-registration admission
+   limit before and after a commit.
 
 ```bash
 dune build ./src/app/zeko/tests/asset_registry_vectors.exe ./src/app/zeko/tests/ethereum_bridge_vectors.exe

--- a/src/app/zeko/circuits/design/ethereum-erc20-bridge.md
+++ b/src/app/zeko/circuits/design/ethereum-erc20-bridge.md
@@ -1,0 +1,418 @@
+# Ethereum ERC-20 to Zeko fungible-token bridge
+
+Status: implementation design and gap analysis, 2026-07-21.
+
+This note defines the L2 Mina fungible-token topology for an ERC-20 bridge and
+connects it to the existing OCaml bridge circuits. It is intentionally narrower
+than the general bridge specification: Ethereum owns ERC-20 custody and timeout
+refunds, while Zeko proves the accepted rollup transition and the L2 custom-token
+movement.
+
+## Decision
+
+Use the unmodified Mina Foundation `FungibleToken` contract as the L2 token
+owner, a separate admin contract, and a proof-controlled bridge-vault account
+under that token. For the first implementation, pre-mint a bounded inventory to
+the bridge vault and use balanced vault-to-user/user-to-vault transfers.
+
+This is the supply model that the current OCaml custom-token rules can be
+adapted to. Exact mint-on-deposit and burn-on-withdrawal are supported by the
+Mina fungible-token standard in principle, but are **not** what
+`Bridge_rules.Make_custom` currently proves. They require a different bridge
+circuit and an admin policy that authorizes each mint from the accepted Ethereum
+deposit proof.
+
+The Ethereum side of a deposit remains the existing witness-action path:
+`submitDeposit` transfers ERC-20 into Solidity custody and emits the canonical
+deposit fields; those fields become the proof witness action consumed by
+`Check_accepted`, just as a native Mina deposit's account-update forest becomes
+the witness action. The current Ethereum branch already replaces Mina children
+with a salted hash of the deposit parameters
+([`bridge_state.ml`, lines 307-325](../bridge_state.ml#L307-L325)). The ERC-20
+version must extend that preimage with an asset identity.
+
+## Why the standard token contract fits
+
+Mina's standard deliberately keeps custom logic out of the token owner. Token
+balances are ledger accounts under a token ID derived from the owner, complex
+transactions are approved as account-update forests, and privileged minting is
+delegated to a separate admin contract. This separation is part of
+[RFC 14](https://github.com/o1-labs/rfcs/blob/main/0014-fungible-token-standard.md),
+not an application convention.
+
+The maintained reference implementation has the properties this bridge needs:
+
+- `TokenContract.deriveTokenId()` derives the managed token from the owner's
+  account, and a token contract can approve a forest containing at most nine
+  token-using account updates
+  ([o1js `TokenContract`](https://github.com/o1-labs/o1js/blob/main/src/lib/mina/v1/token/token-contract.ts#L48-L159)).
+- `FungibleToken.approveBase` requires the token balance changes to sum to zero,
+  rejects a positive running balance (tokens cannot be received before they are
+  sent), and prevents changes to token-account `access` and `receive`
+  permissions
+  ([reference implementation](https://github.com/MinaFoundation/mina-fungible-token/blob/main/FungibleToken.ts)).
+- `mint` asks the configured admin contract for authorization; `burn` reduces a
+  holder balance; both update the reserved circulation account
+  ([reference implementation, mint and burn](https://github.com/MinaFoundation/mina-fungible-token/blob/main/FungibleToken.ts#L143-L170)).
+- The owner stores `decimals` as `UInt8`, while token movements use `UInt64`
+  ([standard API](https://minafoundation.github.io/mina-fungible-token/api.html)).
+- Deployment creates a reserved circulation account at the token owner's public
+  key under the derived token ID. The official deployment guide recommends
+  deploying the admin, token, and initialization atomically and funding all new
+  accounts in the same transaction
+  ([deployment guide](https://minafoundation.github.io/mina-fungible-token/deploy.html)).
+
+Do not fork `FungibleToken` to add bridge behavior. The standard's interoperability
+benefit comes from using the same owner implementation; bridge-specific policy
+belongs in the admin contract and bridge-vault verification key.
+
+## L2 account topology
+
+For one registered ERC-20 asset:
+
+| Role | Mina account ID | Authorization and purpose |
+| --- | --- | --- |
+| Token owner | `(ft_owner_pk, TokenId.default)` | Unmodified `FungibleToken`; owns `ft_token_id = derive_token_id(owner_account_id)` and runs `approveBase`. |
+| Token admin | `(ft_admin_pk, TokenId.default)` | Separate admin contract. For the vault model it authorizes only the bounded deployment mint, pause/resume, and governed upgrades. |
+| Circulation account | `(ft_owner_pk, ft_token_id)` | Reserved by the standard for supply accounting. Never use it as the bridge vault. |
+| Bridge vault | `(holder_account_l2, ft_token_id)` | Holds the pre-minted bridge inventory and uses the custom bridge L2 verification key. This is `Inputs.holder_account_l2` under `Inputs.token_owner_l2`. |
+| User balance | `(user_pk, ft_token_id)` | Ordinary standard fungible-token account. |
+| Deposit replay helper | `(user_pk, derive_token_id(bridge_vault_account_id))` | Stores `next_deposit`; it is a subtoken of the bridge vault, not an FT balance. |
+| Rollup inner account | `(zeko_l2, TokenId.default)` | Existing rollup state and synchronized Ethereum action checkpoint. |
+
+`token_owner_l2` in the circuit must be the token owner's **account ID**, not
+the derived token ID. The existing helper `token_owner_id` performs that
+derivation for custom assets
+([`zeko_util.ml`, lines 433-437](../zeko_util.ml#L433-L437)).
+
+Each supported ERC-20 gets its own token owner, token ID, vault, circuit
+instance/verification key, fee policy, and asset registry entry. A single
+generic proof can be considered later, but the current circuits take these
+values as compile-time inputs.
+
+## Asset and amount binding
+
+A multi-asset bridge cannot identify an asset only through an off-chain archive
+record. Define a versioned registry record and bind it into both directions:
+
+```text
+asset_domain_v1 = keccak256(bytes("ZEKO_ERC20_ASSET_V1"))
+asset_id_v1 = keccak256(abi.encode(
+  asset_domain_v1,
+  ethereum_chain_id,
+  solidity_bridge_address,
+  erc20_address,
+  canonical_mina_token_owner_account_id,
+  ft_token_id,
+  decimals
+))
+```
+
+Represent the 256-bit ID in proof fields as two unsigned 128-bit limbs. Do not
+reduce a `bytes32` modulo the Mina field, which would introduce aliases. The
+registry and every deposit/withdrawal preimage must bind the version, both ID
+limbs, ERC-20 address, L2 owner/token ID, and decimals. Solidity, the OCaml
+action constructor, settlement guest, SDK, and indexer must implement one
+canonical encoding and reject unknown versions.
+
+Use identical base units on both chains:
+
+- require the registered ERC-20 decimals to equal the L2 token's `UInt8`
+  decimals;
+- require every bridged amount to fit `UInt64` before Solidity emits an action;
+- perform no decimal scaling or rounding; and
+- initially reject fee-on-transfer, rebasing, callback-bearing, or otherwise
+  non-exact ERC-20s. Solidity must verify that custody increased by exactly the
+  submitted gross amount.
+
+Split fees by denomination. An ERC-20 fee is an asset amount enforced by
+Solidity. Mina transaction/proving and account-creation fees are MINA amounts
+funded by a default-token fee payer or sponsor. Never subtract a Mina account
+creation fee from a custom-token `UInt64` amount.
+
+## Deposit flow: Ethereum to Zeko
+
+1. `submitDeposit(token, amount, recipient)` resolves the token's immutable
+   registry entry, transfers exactly `amount` base units into Solidity custody,
+   fixes the no-cancellation timeout to `UInt32.max`, and emits the canonical
+   `BridgeDeposit` witness fields plus `ERC20DepositSubmitted` with the asset ID.
+2. The Ethereum action importer converts the canonical deposit log and immutable
+   registry identity into the same versioned
+   `Outer_action.Witness` preimage on every node. The witness contains no Mina L1
+   account-update children; ERC-20 custody is proven by the settlement/Ethereum
+   domain binding.
+3. `Check_accepted` follows the existing rule: the deposit is accepted only
+   after a synchronized commit includes it before its timeout, or rejected after
+   the timeout path
+   ([`check_accepted_make.ml`, lines 58-125](../check_accepted_make.ml#L58-L125)).
+4. Finalization on L2 proves the accepted deposit, advances the recipient's
+   replay helper, debits the custom-token bridge vault, and credits the
+   recipient. The current rule already binds the accepted proof, derives the
+   helper token, requires a strictly increasing deposit index, and emits the
+   deposit event
+   ([`rule_bridge_finalize_deposit.ml`, lines 118-255](../rule_bridge_finalize_deposit.ml#L118-L255)).
+5. The entire custom-token subtree is passed to the standard owner's
+   `approveBase`; its token changes must be conserved and ordered debit-first.
+
+The valid L2 forest is conceptually:
+
+```text
+FungibleToken.approveBase                         (owner, default token)
+└── bridge vault: -net_amount, Proof             (ft_token_id, Parents_own_token)
+    ├── replay helper update, user signature     (vault subtoken, Parents_own_token)
+    ├── rollup inner-state witness               (default token, No)
+    └── recipient: +net_amount, no auth          (ft_token_id, Inherit_from_parent)
+```
+
+If an L2 asset fee is desired, add a custom-token fee recipient after the vault
+debit and keep the subtree sum zero. The simpler first release charges the
+ERC-20 fee in Solidity and makes the OCaml `amount` the net amount, so the L2
+subtree is a one-for-one vault transfer.
+
+New custom-token accounts must set `implicit_account_creation_fee = false` and
+be funded from MINA fee excess. Mina transaction logic explicitly forbids an
+implicit creation fee on a non-default token
+([`zkapp_command_logic.ml`, lines 1426-1465](../../../../lib/transaction_logic/zkapp_command_logic.ml#L1426-L1465)).
+
+## Withdrawal flow: Zeko to Ethereum
+
+1. The user constructs a custom-token forest approved by the standard owner.
+   The sender debit must occur before the bridge-vault credit; the reference
+   `approveBase` rejects a positive prefix as flash minting.
+2. The bridge-vault receive update uses the existing `inner_receive` proof. Its
+   purpose is to satisfy the vault's proof access permission while binding the
+   amount and token ID
+   ([`rule_bridge_inner_receive.ml`, lines 18-40](../rule_bridge_inner_receive.ml#L18-L40)).
+3. The rollup inner witness action binds asset ID, amount, Ethereum recipient,
+   and the exact approved child forest. A separate default-MINA debit/payout may
+   fund proving; it must sit outside the custom-token conservation subtree.
+4. After the existing commit and withdrawal-delay checks, settlement exports
+   the exact action and Solidity releases the registered ERC-20 from custody to
+   the bound recipient. The OCaml withdrawal proof already binds the withdrawal
+   action to the inner action-state extension and a committed outer action
+   ([`rule_bridge_finalize_withdrawal.ml`, lines 128-168](../rule_bridge_finalize_withdrawal.ml#L128-L168));
+   Ethereum replaces the Mina L1 payout portion with Solidity settlement.
+
+The required submission subtree is:
+
+```text
+FungibleToken.approveBase                         (owner, default token)
+├── user: -amount, Signature                     (ft_token_id, Parents_own_token)
+└── bridge vault: +amount, bridge Proof          (ft_token_id, Parents_own_token)
+
+rollup witness / MINA fee updates                 (default-token siblings)
+```
+
+On timeout cancellation, Solidity refunds the original ERC-20 custody entry.
+The Mina L1 custom-token cancellation circuit is not part of the Ethereum
+path.
+
+## Vault inventory versus mint/burn
+
+Both models are compatible with the **standard**, but only one is compatible
+with the current bridge circuits.
+
+### Bounded vault inventory (selected first release)
+
+During deployment the admin mints a fixed bridge capacity to the bridge vault.
+Deposits move inventory vault-to-user; withdrawals return it user-to-vault. The
+standard owner's `approveBase` sees a balanced forest, matching the balance
+changes generated today by `finalize_deposit`, `withdrawal_action`, and
+`inner_receive`.
+
+Required invariants:
+
+- `user_wrapped_supply <= ethereum_locked_for_asset` at every accepted state;
+- a deposit cannot finalize if the vault lacks the net amount;
+- the bounded mint is auditable and routine mint authority is revoked or capped
+  after deployment;
+- no path can transfer from the reserved circulation account; and
+- emergency pause covers Solidity deposits/releases and L2 standard-token
+  transfers coherently.
+
+The tradeoff is supply reporting: the standard circulation account counts the
+pre-minted vault inventory even while it is idle, so `getCirculating()` is not
+the economic amount backed by Ethereum custody. Indexers must expose both
+standard minted supply and `minted_supply - vault_balance`. The capacity also
+places an explicit upper bound on outstanding wrapped ERC-20.
+
+### Exact mint on deposit and burn on withdrawal (future design)
+
+The standard exposes `mint` and `burn`, so this model does not require a fork of
+`FungibleToken`. It does require new OCaml/account-update semantics:
+
+- accepted-deposit finalization must call standard `mint`, and a bridge-aware
+  admin must authorize exactly `(asset_id, deposit_index, recipient, amount)`;
+- withdrawal submission must call standard `burn` and bind that burn to the
+  emitted rollup witness action; and
+- replay state, pause state, admin authorization, and action ordering must be
+  proven in those new methods.
+
+An unbalanced child forest sent to `approveBase` is not minting and will be
+rejected. Therefore exact mint/burn cannot be enabled by changing a balance,
+`authorization_kind`, or deployment flag in `Make_custom`; it is a separate
+circuit/admin design. Its advantage is exact standard circulation accounting
+and no vault-capacity ceiling.
+
+## Connection to the existing OCaml functors
+
+`Make_mina` fixes both sides to the default token and base parameters, while
+`Make_custom` fixes **both** L1 and L2 to custom-token owners and custom
+parameters
+([`bridge_rules.ml`, lines 5-69 and 132-200](../bridge_rules.ml#L5-L200)). An
+Ethereum ERC-20 bridge is a hybrid:
+
+```text
+L1 custody/action source: Ethereum ERC-20, no Mina token owner
+L1 deposit preimage:       versioned Ethereum/ERC-20 parameters
+L2 asset:                  custom Mina FungibleToken
+L2 withdrawal forest:      custom parameters and token-owner approval
+```
+
+Introduce a side-specific asset functor (or `Make_ethereum_custom`) instead of
+reusing `Make_custom` unchanged. In particular, the current Ethereum action
+hashes whichever `Deposit_params` module the enclosing functor selected. Using
+`Make_custom` would make Solidity bind irrelevant Mina authorization/call-forest
+fields and still would not provide a canonical ERC-20 identity
+([`bridge_state.ml`, lines 230-325](../bridge_state.ml#L230-L325)).
+
+### Required circuit corrections
+
+The existing custom path compiles, but its generated forests are not yet valid
+standard-token transactions:
+
+1. `withdrawal_action` prepends the positive vault receive before caller-supplied
+   nested children
+   ([`bridge_state.ml`, lines 379-402](../bridge_state.ml#L379-L402)). A standard
+   sender debit in `nested_children` therefore comes too late and triggers the
+   reference implementation's flash-mint check. Permit a constrained debit-first
+   ordering.
+2. Deposit-finalization custom-token payouts are children of the vault update
+   but use `Parents_own_token`
+   ([`rule_bridge_finalize_deposit.ml`, lines 245-306](../rule_bridge_finalize_deposit.ml#L245-L306)).
+   A direct child's `Parents_own_token` selects the token derived from the vault
+   account; it does not retain `ft_token_id`. Those payouts must use
+   `Inherit_from_parent`, while the replay helper intentionally keeps
+   `Parents_own_token`. The caller derivation and non-default-token check are in
+   [`zkapp_command_logic.ml`, lines 1043-1108 and 1224-1236](../../../../lib/transaction_logic/zkapp_command_logic.ml#L1043-L1108).
+3. The custom payouts set `implicit_account_creation_fee = true` and subtract a
+   MINA creation fee from the custom-token amount
+   ([`rule_bridge_finalize_deposit.ml`, lines 257-297](../rule_bridge_finalize_deposit.ml#L257-L297)).
+   Non-default tokens cannot pay this implicit fee, and the subtraction also
+   makes the custom-token forest unbalanced. Use a separate MINA funding update
+   and denomination-specific fees.
+
+Equivalent corrections are needed in any retained custom-Mina L1
+finalize/cancel rules. For the Ethereum bridge, Solidity handles those L1 paths.
+
+## Implemented seam and remaining runtime work
+
+This branch implements the security-critical cross-chain seam:
+
+- `Make_ethereum_token` combines an Ethereum deposit source with a custom-token
+  L2 vault and fixes custom-token payout denomination, token inheritance, and
+  debit-first withdrawal ordering;
+- the settlement bridge guest converts a canonical Solidity `submitDeposit`
+  log into the exact asset-bound outer Witness action consumed by
+  `Check_accepted`;
+- the sequencer archive/export and settlement guest support an asset-bound
+  token-withdrawal preimage and V3 claim leaf; and
+- Solidity, the gateway, and the browser SDK implement canonical ERC-20
+  custody, indexing, delayed claim, per-asset replay protection, and liability
+  accounting.
+
+The remaining gap is executable Mina Fungible Token orchestration. The current
+sequencer still instantiates and submits only the native bridge:
+
+- The public bridge types serialize base deposit/withdrawal parameters and
+  expose only `Bridge_inst_mina`
+  ([`zeko_types.ml`, lines 52-58 and 811-1260](../../zeko_types/zeko_types.ml#L52-L58)).
+- Circuit compilation, prover jobs, VK responses, and proof dispatch are all
+  wired to the Mina instance
+  ([`compile_circuits.ml`, lines 13-43](../../sequencer/prover/lib/compile_circuits.ml#L13-L43),
+  [`prover.ml`, lines 139-215 and 457-623](../../sequencer/prover/lib/prover.ml#L139-L215)).
+- The bridge prover validates one signed default-token transferrer and constructs
+  base parameters; it cannot build or validate a standard FT approval forest
+  ([`bridge_prover.ml`, lines 158-192 and 264-625](../../sequencer/lib/bridge_prover.ml#L158-L192)).
+- GraphQL accepts only base deposit/withdrawal parameters and exposes no asset
+  registry/token-owner identity
+  ([`gql.ml`, lines 1424-1500 and 1800-2033](../../sequencer/lib/gql.ml#L1424-L1500)).
+- Deployment creates default-token rollup/holder accounts and Mina bridge VKs;
+  it does not deploy a standard FT owner/admin/circulation account, custom vault,
+  inventory, or asset registry
+  ([`deploy.ml`, lines 46-216](../../sequencer/lib/deploy.ml#L46-L216)).
+- The proof-result flow immediately executes the generated forest. A standard
+  token transaction instead needs a prove-only phase: obtain the deterministic
+  bridge vault proof/forest, wrap it with the unmodified `FungibleToken`
+  owner's `approveBase` update and proof, then submit the composed transaction.
+- Deployment still needs the standard owner/admin/circulation accounts, custom
+  vault VK, bounded inventory, and coordinated Solidity/circuit asset entry.
+
+The archive is an availability aid, not a security boundary. The settlement
+guest must recompute the versioned leaf from proof-bound action fields and reject
+archive metadata that does not match.
+
+## Deployment and upgrade policy
+
+Deploy one asset atomically where possible:
+
+1. publish the immutable asset registry entry and canonical action schema;
+2. deploy the admin and unmodified `FungibleToken`, initialize decimals and
+   circulation, and verify the expected standard verification keys;
+3. create the custom-token bridge vault with the enabled bridge VK and proof
+   permissions;
+4. mint the bounded inventory to the vault, then revoke or enforce the configured
+   mint cap;
+5. fund all default-token account-creation costs and helper sponsorship policy;
+6. register the exact asset ID, L2 token owner/token ID, circuit VK ID, decimals,
+   and limits in Solidity and settlement configuration; and
+7. unpause only after a cross-chain deposit/withdrawal/cancellation rehearsal.
+
+For the strongest first deployment, set the standard token owner's
+`allowUpdates` to false. If upgrades are required, use the standard's supported
+admin/verification-key path behind a timelocked multisig and treat a token-owner,
+admin, vault, circuit VK, settlement VK, or Solidity registry change as one
+cross-chain migration. Pause both directions before changing any member of that
+set. Existing holder enable/disable circuits can still rotate the vault's send
+permission/VK on their scheduled windows; the custom version differs by using
+the derived token ID
+([`rule_bridge_disable.ml`, lines 25-111](../rule_bridge_disable.ml#L25-L111),
+[`rule_bridge_enable.ml`, lines 25-111](../rule_bridge_enable.ml#L25-L111)).
+
+## Verification plan
+
+Existing coverage is insufficient: the custom test only compiles its systems,
+while the real bridge behavior test instantiates `Make_mina`
+([`compile_circuits.ml`, lines 109-159](../../tests/compile_circuits.ml#L109-L159),
+[`test_all_real.ml`, lines 1540-1628](../../tests/test_all_real.ml#L1540-L1628)).
+Add these gates:
+
+1. Cross-language ERC-20 deposit vectors for the versioned asset preimage,
+   including negative tests for wrong chain, bridge, ERC-20 address, token owner,
+   token ID, decimals, and asset-ID limb order. The existing vector hashes only
+   `Deposit_params_base`
+   ([`ethereum_bridge_vectors.ml`, lines 16-53](../../tests/ethereum_bridge_vectors.ml#L16-L53)).
+2. A real transaction-logic test for accepted custom deposit finalization under
+   the standard owner. Assert debit-first conservation, `Inherit_from_parent`
+   payouts, replay-helper advancement, and separate MINA funding for every new
+   account.
+3. A real withdrawal-submission test with sender debit before vault credit,
+   standard `approveBase`, vault receive proof, exact inner action, and failures
+   for reordered/unbalanced/wrong-asset forests.
+4. Settlement export/guest tests proving that archive metadata cannot change the
+   asset, recipient, amount, or action order and that cross-asset replay fails.
+5. A full Anvil-to-Zeko roundtrip: ERC-20 `submitDeposit` log to witness action,
+   accepted L2 vault transfer, user withdrawal to vault, delayed Solidity claim,
+   and timeout refund. Include vault exhaustion, duplicate index, pause, and
+   unsupported-token cases.
+
+After implementation, run the repository gates from a persistent `tmux` session
+for the heavy commands:
+
+```bash
+dune build ./src/app/zeko/sequencer ./src/app/zeko/da_layer ./src/app/zeko/signer
+dune exec ./src/app/zeko/tests/ethereum_bridge_vectors.exe
+dune exec ./src/app/zeko/tests/compile_circuits.exe
+dune exec ./src/app/zeko/tests/test_all_real.exe
+src/app/zeko/sequencer/tests/run-sequencer-test.sh real 1 false true
+```

--- a/src/app/zeko/circuits/design/ethereum-erc20-bridge.md
+++ b/src/app/zeko/circuits/design/ethereum-erc20-bridge.md
@@ -376,6 +376,14 @@ JSON reports `checkpointVersion: 2` and encodes `registryPublicKey` as the
 `tokenOwnerL2` and `vaultPublicKey`. Version 1 omitted parity and must not be
 accepted as a version-2 checkpoint.
 
+Every Ethereum-settlement withdrawal recipient is encoded as an even compressed
+Mina key whose x-coordinate fits 160 bits. The circuit applies that domain to
+native withdrawals when an Ethereum holder is configured and to both legacy V1
+and registry V2 ERC-20 withdrawals unconditionally. GraphQL applies the same
+rule to its native and registry V2 inputs; it exposes no legacy V1 request
+input. Mina-only native and custom-token bridge instances retain ordinary
+compressed Mina recipient semantics.
+
 ## Deployment and post-registration policy
 
 Onboard one asset atomically where possible:
@@ -421,8 +429,8 @@ The active PoC gate is limited to focused builds and fake/vector proofs:
    live provisioning signer, reject invalid registry membership, and cover
    accepted deposit finalization, helper progression, denomination, token
    inheritance, checkpoint key parity, 160-bit even withdrawal recipients,
-   withdrawal action/export fields, and the one-pending-registration admission
-   limit before and after a commit.
+   native/V1/V2 withdrawal action and export fields, two registrations in one
+   command, and separate pending registrations before and after a commit.
 
 ```bash
 dune build ./src/app/zeko/tests/asset_registry_vectors.exe ./src/app/zeko/tests/ethereum_bridge_vectors.exe

--- a/src/app/zeko/circuits/design/ethereum-erc20-bridge.md
+++ b/src/app/zeko/circuits/design/ethereum-erc20-bridge.md
@@ -228,8 +228,8 @@ Required invariants:
   an immutable `depositCapByToken`, configured to equal the initial pre-minted
   L2 vault inventory;
 - a deposit cannot finalize if the vault lacks the net amount;
-- the bounded mint is auditable and routine mint authority is revoked or capped
-  after deployment;
+- the bounded mint is auditable and the final standard admin controller is the
+  fixed non-signing `Public_key.Compressed.empty`;
 - no path can transfer from the reserved circulation account; and
 - emergency pause covers Solidity deposits/releases and L2 standard-token
   transfers coherently.
@@ -365,8 +365,8 @@ Onboard one asset atomically where possible:
    circulation, and verify the expected standard verification keys;
 3. create the token-specific account at the shared vault public key with the
    universal bridge VK and locked proof permissions;
-4. mint the bounded inventory to the vault, then revoke or enforce the configured
-   mint cap;
+4. mint the bounded inventory to the vault, then rotate the unmodified standard
+   admin controller to the fixed non-signing `Public_key.Compressed.empty`;
 5. fund all default-token account-creation costs and helper sponsorship policy;
 6. append the canonical record through the exhaustive Zeko registry transition,
    settle the new root/count and ordered record batch, and activate exactly that

--- a/src/app/zeko/circuits/design/ethereum-erc20-bridge.md
+++ b/src/app/zeko/circuits/design/ethereum-erc20-bridge.md
@@ -68,14 +68,14 @@ belongs in the admin contract and bridge-vault verification key.
 
 ## L2 account topology
 
-For one registered ERC-20 asset:
+For every registered ERC-20 asset:
 
 | Role | Mina account ID | Authorization and purpose |
 | --- | --- | --- |
 | Token owner | `(ft_owner_pk, TokenId.default)` | Unmodified `FungibleToken`; owns `ft_token_id = derive_token_id(owner_account_id)` and runs `approveBase`. |
 | Token admin | `(ft_admin_pk, TokenId.default)` | Separate admin contract. For the vault model it authorizes only the bounded deployment mint, pause/resume, and governed upgrades. |
 | Circulation account | `(ft_owner_pk, ft_token_id)` | Reserved by the standard for supply accounting. Never use it as the bridge vault. |
-| Bridge vault | `(holder_account_l2, ft_token_id)` | Holds the pre-minted bridge inventory and uses the custom bridge L2 verification key. This is `Inputs.holder_account_l2` under `Inputs.token_owner_l2`. |
+| Bridge vault | `(shared_vault_l2, ft_token_id)` | Holds that asset's pre-minted inventory and uses the universal bridge verification key. Every asset shares the public key and VK but has a distinct derived token ID/account/balance. |
 | User balance | `(user_pk, ft_token_id)` | Ordinary standard fungible-token account. |
 | Deposit replay helper | `(user_pk, derive_token_id(bridge_vault_account_id))` | Stores `next_deposit`; it is a subtoken of the bridge vault, not an FT balance. |
 | Rollup inner account | `(zeko_l2, TokenId.default)` | Existing rollup state and synchronized Ethereum action checkpoint. |
@@ -85,10 +85,11 @@ the derived token ID. The existing helper `token_owner_id` performs that
 derivation for custom assets
 ([`zeko_util.ml`, lines 433-437](../zeko_util.ml#L433-L437)).
 
-Each supported ERC-20 gets its own token owner, token ID, vault, circuit
-instance/verification key, fee policy, and asset registry entry. A single
-generic proof can be considered later, but the current circuits take these
-values as compile-time inputs.
+Each supported ERC-20 gets its own token owner, derived token ID, inventory,
+fee policy, and immutable registry entry. The owner and token ID are dynamic
+verified-record values. All assets use the same registry-configured vault public
+key and universal bridge circuit/verification key; the derived token ID keeps
+their vault balances and replay helpers independent.
 
 ## Asset and amount binding
 
@@ -326,12 +327,15 @@ This branch implements the security-critical cross-chain seam:
 
 The executable Mina Fungible Token orchestration follows the same boundary:
 
-- the sequencer config accepts one immutable asset ID, Ethereum token address,
-  L2 token owner, derived token ID, and vault, and compiles the corresponding
-  `Make_ethereum_token` check-accepted and L2 systems;
-- public bridge types, prover jobs, VK responses, and proof dispatch carry the
-  Ethereum-token instance explicitly rather than falling through the native
-  Mina instance;
+- the sequencer config accepts the registry account, schema, approved MFT
+  standard VK ID, shared vault public key, and universal bridge VK ID;
+- public bridge types, prover jobs, VK responses, and proof dispatch carry a
+  verified asset record plus membership path through one
+  `Make_ethereum_assets` circuit family;
+- registration uses the existing recursive folder pattern to scan every dense
+  old leaf at the next exact index, reject duplicate Ethereum token, asset ID,
+  owner, or derived token ID, verify an empty append slot, and commit the
+  incremented root/count;
 - GraphQL exposes proof-only token deposit-finalization and withdrawal-request
   mutations plus the immutable public token configuration;
 - withdrawal input carries the complete standard token-owner account-update
@@ -340,34 +344,34 @@ The executable Mina Fungible Token orchestration follows the same boundary:
 - the bridge SDK checks the returned vault forest and owner public input, grafts
   the genuine standard-token proof/signature authorizations, and only then
   submits the complete L2 transaction; and
-- the operator deployment helper validates the Solidity registry/cap and Zeko
-  configuration, deploys unmodified `FungibleToken`/`FungibleTokenAdmin`, locks
-  the separate bridge vault to the circuit VK with proof-authorized sends, and
-  mints exactly the registered cap.
+- the operator deployment helper validates each pending Solidity record and
+  Zeko membership, deploys unmodified `FungibleToken`/`FungibleTokenAdmin`,
+  locks each token-specific shared-vault account to the universal VK with
+  proof-authorized sends, and mints exactly the registered cap.
 
-The current runtime remains deliberately one-asset-per-circuit. Supporting
-multiple ERC-20s in one sequencer requires explicit circuit/VK routing rather
-than weakening these immutable bindings.
+The archive and Actions indexer reconstruct immutable records and refreshed
+membership paths after later appends. They are availability aids, not security
+boundaries: the circuit authenticates the registry account root/count, and the
+settlement guest binds the OCaml Poseidon transition to the same ordered
+canonical records activated by Solidity.
 
-The archive is an availability aid, not a security boundary. The settlement
-guest must recompute the versioned leaf from proof-bound action fields and reject
-archive metadata that does not match.
 
 ## Deployment and upgrade policy
 
-Deploy one asset atomically where possible:
+Onboard one asset atomically where possible:
 
-1. publish the immutable asset registry entry and canonical action schema;
+1. propose the exact immutable Solidity record in `Pending` state;
 2. deploy the admin and unmodified `FungibleToken`, initialize decimals and
    circulation, and verify the expected standard verification keys;
-3. create the custom-token bridge vault with the enabled bridge VK and proof
-   permissions;
+3. create the token-specific account at the shared vault public key with the
+   universal bridge VK and locked proof permissions;
 4. mint the bounded inventory to the vault, then revoke or enforce the configured
    mint cap;
 5. fund all default-token account-creation costs and helper sponsorship policy;
-6. register the exact asset ID, L2 token owner/token ID, circuit VK ID, decimals,
-   and limits in Solidity and settlement configuration; and
-7. unpause only after a cross-chain deposit/withdrawal/cancellation rehearsal.
+6. append the canonical record through the exhaustive Zeko registry transition,
+   settle the new root/count and ordered record batch, and activate exactly that
+   pending Solidity proposal; and
+7. enable deposits only after a cross-chain deposit/withdrawal rehearsal.
 
 For the strongest first deployment, set the standard token owner's
 `allowUpdates` to false. If upgrades are required, use the standard's supported
@@ -384,23 +388,25 @@ the derived token ID
 
 The branch now has these executable gates:
 
-1. OCaml, Rust, and TypeScript share the asset-bound ERC-20 deposit vector and
-   the OCaml withdrawal vector binds the complete owner body and debit-first
-   forest.
-2. Circuit-vector tests exercise accepted deposit finalization, helper-account
-   progression, custom-token denomination, token inheritance, and withdrawal
+1. OCaml, Rust, Solidity, and TypeScript share canonical record, asset/action,
+   registry-transition, and settlement receipt encodings.
+2. Registry vectors cover empty, populated, and maximum-size scans plus wrong
+   roots/counts, repeated/skipped/reordered leaves, non-empty append slots, and
+   every uniqueness dimension.
+3. Universal circuit vectors exercise two dynamic owners through one circuit
+   tag/VK, registry membership rejection, accepted deposit finalization,
+   helper-account progression, denomination, token inheritance, and withdrawal
    action/export fields.
-3. The bridge SDK rejects malformed/wrong-asset/wrong-owner/wrong-VK forests and
+4. The bridge SDK rejects malformed/wrong-asset/wrong-owner/wrong-VK forests and
    runs a local ledger roundtrip through the unmodified standard owner's
    `approveBase`: exact-cap vault provisioning, vault-to-user deposit, then
    user-to-vault withdrawal.
-4. Settlement guest, gateway, and Solidity tests cover the canonical V2 deposit
-   leaf, V3 withdrawal leaf, immutable registry, cap/liability accounting,
-   replay rejection, and delayed ERC-20 release.
-
-A combined live Anvil-to-real-sequencer rehearsal remains a release/deployment
-gate. It must preserve the same immutable circuit/VK manifest and should include
-vault exhaustion, duplicate index, pause, and unsupported-token cases.
+5. Settlement guest, gateway, and Solidity tests cover V4 batched registry
+   synchronization, pending/activation status, V2 deposits, V3 withdrawals,
+   per-token caps/liabilities, replay rejection, and delayed release.
+6. The full local gate uses the real sequencer/prover, three DA nodes, Actions
+   services, two unmodified token owners, one shared vault key/VK, Anvil custody,
+   and exact claims without generating an SP1 proof.
 
 After implementation, run the repository gates from a persistent `tmux` session
 for the heavy commands:

--- a/src/app/zeko/circuits/design/ethereum-erc20-bridge.md
+++ b/src/app/zeko/circuits/design/ethereum-erc20-bridge.md
@@ -308,7 +308,7 @@ standard-token transactions:
 Equivalent corrections are needed in any retained custom-Mina L1
 finalize/cancel rules. For the Ethereum bridge, Solidity handles those L1 paths.
 
-## Implemented seam and remaining runtime work
+## Implemented runtime seam
 
 This branch implements the security-critical cross-chain seam:
 
@@ -324,32 +324,30 @@ This branch implements the security-critical cross-chain seam:
   custody, indexing, delayed claim, per-asset replay protection, and liability
   accounting.
 
-The remaining gap is executable Mina Fungible Token orchestration. The current
-sequencer still instantiates and submits only the native bridge:
+The executable Mina Fungible Token orchestration follows the same boundary:
 
-- The public bridge types serialize base deposit/withdrawal parameters and
-  expose only `Bridge_inst_mina`
-  ([`zeko_types.ml`, lines 52-58 and 811-1260](../../zeko_types/zeko_types.ml#L52-L58)).
-- Circuit compilation, prover jobs, VK responses, and proof dispatch are all
-  wired to the Mina instance
-  ([`compile_circuits.ml`, lines 13-43](../../sequencer/prover/lib/compile_circuits.ml#L13-L43),
-  [`prover.ml`, lines 139-215 and 457-623](../../sequencer/prover/lib/prover.ml#L139-L215)).
-- The bridge prover validates one signed default-token transferrer and constructs
-  base parameters; it cannot build or validate a standard FT approval forest
-  ([`bridge_prover.ml`, lines 158-192 and 264-625](../../sequencer/lib/bridge_prover.ml#L158-L192)).
-- GraphQL accepts only base deposit/withdrawal parameters and exposes no asset
-  registry/token-owner identity
-  ([`gql.ml`, lines 1424-1500 and 1800-2033](../../sequencer/lib/gql.ml#L1424-L1500)).
-- Deployment creates default-token rollup/holder accounts and Mina bridge VKs;
-  it does not deploy a standard FT owner/admin/circulation account, custom vault,
-  inventory, or asset registry
-  ([`deploy.ml`, lines 46-216](../../sequencer/lib/deploy.ml#L46-L216)).
-- The proof-result flow immediately executes the generated forest. A standard
-  token transaction instead needs a prove-only phase: obtain the deterministic
-  bridge vault proof/forest, wrap it with the unmodified `FungibleToken`
-  owner's `approveBase` update and proof, then submit the composed transaction.
-- Deployment still needs the standard owner/admin/circulation accounts, custom
-  vault VK, bounded inventory, and coordinated Solidity/circuit asset entry.
+- the sequencer config accepts one immutable asset ID, Ethereum token address,
+  L2 token owner, derived token ID, and vault, and compiles the corresponding
+  `Make_ethereum_token` check-accepted and L2 systems;
+- public bridge types, prover jobs, VK responses, and proof dispatch carry the
+  Ethereum-token instance explicitly rather than falling through the native
+  Mina instance;
+- GraphQL exposes proof-only token deposit-finalization and withdrawal-request
+  mutations plus the immutable public token configuration;
+- withdrawal input carries the complete standard token-owner account-update
+  body. The circuit pins its public key and default token ID while the standard
+  owner's proof enforces all remaining `approveBase` semantics;
+- the bridge SDK checks the returned vault forest and owner public input, grafts
+  the genuine standard-token proof/signature authorizations, and only then
+  submits the complete L2 transaction; and
+- the operator deployment helper validates the Solidity registry/cap and Zeko
+  configuration, deploys unmodified `FungibleToken`/`FungibleTokenAdmin`, locks
+  the separate bridge vault to the circuit VK with proof-authorized sends, and
+  mints exactly the registered cap.
+
+The current runtime remains deliberately one-asset-per-circuit. Supporting
+multiple ERC-20s in one sequencer requires explicit circuit/VK routing rather
+than weakening these immutable bindings.
 
 The archive is an availability aid, not a security boundary. The settlement
 guest must recompute the versioned leaf from proof-bound action fields and reject
@@ -382,32 +380,27 @@ the derived token ID
 ([`rule_bridge_disable.ml`, lines 25-111](../rule_bridge_disable.ml#L25-L111),
 [`rule_bridge_enable.ml`, lines 25-111](../rule_bridge_enable.ml#L25-L111)).
 
-## Verification plan
+## Verification coverage
 
-Existing coverage is insufficient: the custom test only compiles its systems,
-while the real bridge behavior test instantiates `Make_mina`
-([`compile_circuits.ml`, lines 109-159](../../tests/compile_circuits.ml#L109-L159),
-[`test_all_real.ml`, lines 1540-1628](../../tests/test_all_real.ml#L1540-L1628)).
-Add these gates:
+The branch now has these executable gates:
 
-1. Cross-language ERC-20 deposit vectors for the versioned asset preimage,
-   including negative tests for wrong chain, bridge, ERC-20 address, token owner,
-   token ID, decimals, and asset-ID limb order. The existing vector hashes only
-   `Deposit_params_base`
-   ([`ethereum_bridge_vectors.ml`, lines 16-53](../../tests/ethereum_bridge_vectors.ml#L16-L53)).
-2. A real transaction-logic test for accepted custom deposit finalization under
-   the standard owner. Assert debit-first conservation, `Inherit_from_parent`
-   payouts, replay-helper advancement, and separate MINA funding for every new
-   account.
-3. A real withdrawal-submission test with sender debit before vault credit,
-   standard `approveBase`, vault receive proof, exact inner action, and failures
-   for reordered/unbalanced/wrong-asset forests.
-4. Settlement export/guest tests proving that archive metadata cannot change the
-   asset, recipient, amount, or action order and that cross-asset replay fails.
-5. A full Anvil-to-Zeko roundtrip: ERC-20 `submitDeposit` log to witness action,
-   accepted L2 vault transfer, user withdrawal to vault, delayed Solidity claim,
-   and timeout refund. Include vault exhaustion, duplicate index, pause, and
-   unsupported-token cases.
+1. OCaml, Rust, and TypeScript share the asset-bound ERC-20 deposit vector and
+   the OCaml withdrawal vector binds the complete owner body and debit-first
+   forest.
+2. Circuit-vector tests exercise accepted deposit finalization, helper-account
+   progression, custom-token denomination, token inheritance, and withdrawal
+   action/export fields.
+3. The bridge SDK rejects malformed/wrong-asset/wrong-owner/wrong-VK forests and
+   runs a local ledger roundtrip through the unmodified standard owner's
+   `approveBase`: exact-cap vault provisioning, vault-to-user deposit, then
+   user-to-vault withdrawal.
+4. Settlement guest, gateway, and Solidity tests cover the canonical V2 deposit
+   leaf, V3 withdrawal leaf, immutable registry, cap/liability accounting,
+   replay rejection, and delayed ERC-20 release.
+
+A combined live Anvil-to-real-sequencer rehearsal remains a release/deployment
+gate. It must preserve the same immutable circuit/VK manifest and should include
+vault exhaustion, duplicate index, pause, and unsupported-token cases.
 
 After implementation, run the repository gates from a persistent `tmux` session
 for the heavy commands:

--- a/src/app/zeko/circuits/design/ethereum-erc20-bridge.md
+++ b/src/app/zeko/circuits/design/ethereum-erc20-bridge.md
@@ -11,9 +11,12 @@ movement.
 ## Decision
 
 Use the unmodified Mina Foundation `FungibleToken` contract as the L2 token
-owner, a separate admin contract, and a proof-controlled bridge-vault account
-under that token. For the first implementation, pre-mint a bounded inventory to
-the bridge vault and use balanced vault-to-user/user-to-vault transfers.
+owner, two unmodified standard admin instances during provisioning, and a
+proof-controlled bridge-vault account under that token. A live provisioning
+admin authorizes the bounded mint; the owner then installs a separate final
+admin whose controller was deployed as `Public_key.Compressed.empty`. The first
+implementation uses the pre-minted inventory for balanced
+vault-to-user/user-to-vault transfers.
 
 This is the supply model that the current OCaml custom-token rules can be
 adapted to. Exact mint-on-deposit and burn-on-withdrawal are supported by the
@@ -54,6 +57,11 @@ The maintained reference implementation has the properties this bridge needs:
 - `mint` asks the configured admin contract for authorization; `burn` reduces a
   holder balance; both update the reserved circulation account
   ([reference implementation, mint and burn](https://github.com/MinaFoundation/mina-fungible-token/blob/main/FungibleToken.ts#L143-L170)).
+- `FungibleTokenAdmin` sets its controller during deployment, while
+  `FungibleToken.setAdmin` asks the currently installed admin to authorize a
+  replacement admin contract
+  ([standard admin deployment](https://github.com/MinaFoundation/mina-fungible-token/blob/main/FungibleTokenAdmin.ts#L33-L50),
+  [standard admin replacement](https://github.com/MinaFoundation/mina-fungible-token/blob/main/FungibleToken.ts#L122-L128)).
 - The owner stores `decimals` as `UInt8`, while token movements use `UInt64`
   ([standard API](https://minafoundation.github.io/mina-fungible-token/api.html)).
 - Deployment creates a reserved circulation account at the token owner's public
@@ -64,9 +72,9 @@ The maintained reference implementation has the properties this bridge needs:
 
 Do not fork `FungibleToken` to add bridge behavior. The standard's
 interoperability benefit comes from using the same owner implementation. For
-the bounded-inventory model, the admin is used only during deployment;
-bridge-specific runtime policy belongs in the bridge and bridge-vault
-verification key.
+the bounded-inventory model, the live provisioning admin is used only before
+the final admin handoff; bridge-specific runtime policy belongs in the bridge
+and bridge-vault verification key.
 
 ## L2 account topology
 
@@ -75,7 +83,8 @@ For every registered ERC-20 asset:
 | Role | Mina account ID | Authorization and purpose |
 | --- | --- | --- |
 | Token owner | `(ft_owner_pk, TokenId.default)` | Unmodified `FungibleToken`; owns `ft_token_id = derive_token_id(owner_account_id)` and runs `approveBase`. |
-| Token admin | `(ft_admin_pk, TokenId.default)` | Unmodified separate admin contract. It authorizes the bounded deployment mint, then its controller is permanently set to `Public_key.Compressed.empty`; it provides no post-registration administration. |
+| Provisioning admin | `(ft_provisioning_admin_pk, TokenId.default)` | Unmodified `FungibleTokenAdmin` with a live controller. It authorizes the exact bounded mint and the handoff to the final admin, then is no longer referenced by the token owner. |
+| Final token admin | `(ft_admin_pk, TokenId.default)` | Separate unmodified `FungibleTokenAdmin` deployed with controller `Public_key.Compressed.empty`. The token owner points here before registration, so it provides no post-registration administration. |
 | Circulation account | `(ft_owner_pk, ft_token_id)` | Reserved by the standard for supply accounting. Never use it as the bridge vault. |
 | Bridge vault | `(shared_vault_l2, ft_token_id)` | Holds that asset's pre-minted inventory and uses the universal bridge verification key. Every asset shares the public key and VK but has a distinct derived token ID/account/balance. |
 | User balance | `(user_pk, ft_token_id)` | Ordinary standard fungible-token account. |
@@ -217,11 +226,12 @@ with the current bridge circuits.
 
 ### Bounded vault inventory (selected first release)
 
-During deployment the admin mints a fixed bridge capacity to the bridge vault.
-Deposits move inventory vault-to-user; withdrawals return it user-to-vault. The
-standard owner's `approveBase` sees a balanced forest, matching the balance
-changes generated today by `finalize_deposit`, `withdrawal_action`, and
-`inner_receive`.
+During deployment the live provisioning admin authorizes a fixed bridge
+capacity mint to the bridge vault. The final empty-controller admin is installed
+before registration. Deposits move inventory vault-to-user; withdrawals return
+it user-to-vault. The standard owner's `approveBase` sees a balanced forest,
+matching the balance changes generated today by `finalize_deposit`,
+`withdrawal_action`, and `inner_receive`.
 
 Required invariants:
 
@@ -347,9 +357,10 @@ The executable Mina Fungible Token orchestration follows the same boundary:
   the genuine standard-token proof/signature authorizations, and only then
   submits the complete L2 transaction; and
 - the operator deployment helper validates each pending Solidity record and
-  Zeko membership, deploys unmodified `FungibleToken`/`FungibleTokenAdmin`,
-  locks each token-specific shared-vault account to the universal VK with
-  proof-authorized sends, and mints exactly the registered cap.
+  Zeko membership, deploys the unmodified `FungibleToken`, live provisioning
+  admin, and empty-controller final admin, locks each token-specific shared
+  vault account to the universal VK with proof-authorized sends, mints exactly
+  the registered cap, and installs the final admin before registration.
 
 The archive and Actions indexer reconstruct immutable records and refreshed
 membership paths after later appends. They are availability aids, not security
@@ -363,21 +374,28 @@ canonical records activated by Solidity.
 Onboard one asset atomically where possible:
 
 1. propose the exact immutable Solidity record in `Pending` state;
-2. deploy the admin and unmodified `FungibleToken`, initialize decimals and
-   circulation, and verify the expected standard verification keys;
-3. create the token-specific account at the shared vault public key with the
+2. deploy a live-controller provisioning `FungibleTokenAdmin`, a separate
+   `FungibleTokenAdmin` whose controller is `Public_key.Compressed.empty`, and
+   the unmodified `FungibleToken` with `allowUpdates = false`, configured to use
+   the provisioning admin;
+3. initialize decimals and circulation, and verify both standard admin accounts
+   and the token owner use the expected standard verification keys;
+4. create the token-specific account at the shared vault public key with the
    universal bridge VK and locked proof permissions;
-4. mint the bounded inventory to the vault, then rotate the unmodified standard
-   admin controller to the fixed non-signing `Public_key.Compressed.empty`;
-5. fund all default-token account-creation costs and helper sponsorship policy;
-6. append the canonical record through the exhaustive Zeko registry transition,
+5. use the provisioning admin to authorize exactly the registered-cap mint to
+   the vault;
+6. call `FungibleToken.setAdmin` under the provisioning controller to install
+   the already-deployed empty-controller final admin;
+7. fund all default-token account-creation costs and helper sponsorship policy;
+8. append the canonical record through the exhaustive Zeko registry transition,
    settle the new root/count and ordered record batch, and activate exactly that
    pending Solidity proposal; and
-7. enable deposits only after a cross-chain deposit/withdrawal rehearsal.
+9. enable deposits only after a cross-chain deposit/withdrawal rehearsal.
 
-Set the standard token owner's `allowUpdates` to false. Registration permanently
-revokes the standard admin controller, so token-level `pause`, `resume`,
-`setAdmin`, and authorized verification-key upgrades are unavailable afterward.
+The registry commit verifies that the token owner already points to the final
+admin and that the final admin's controller is empty. The provisioning admin
+therefore retains no token authority. Token-level `pause`, `resume`, `setAdmin`,
+and authorized verification-key upgrades are unavailable after registration.
 The supported emergency controls are rollup commit freezing and the Ethereum
 bridge pause; neither disables ordinary L2 standard-token transfers. A future
 token-owner, admin, vault, circuit, settlement, or Solidity registry change
@@ -386,34 +404,28 @@ standard-admin path.
 
 ## Verification coverage
 
-The branch now has these executable gates:
+The active PoC gate is limited to focused builds and fake/vector proofs:
 
-1. OCaml, Rust, Solidity, and TypeScript share canonical record, asset/action,
-   registry-transition, and settlement receipt encodings.
-2. Registry vectors cover empty, populated, and maximum-size scans plus wrong
+1. Registry vectors cover empty, populated, and maximum-size scans plus wrong
    roots/counts, repeated/skipped/reordered leaves, non-empty append slots, and
    every uniqueness dimension.
-3. Universal circuit vectors exercise two dynamic owners through one circuit
-   tag/VK, registry membership rejection, accepted deposit finalization,
-   helper-account progression, denomination, token inheritance, and withdrawal
-   action/export fields.
-4. The bridge SDK rejects malformed/wrong-asset/wrong-owner/wrong-VK forests and
-   runs a local ledger roundtrip through the unmodified standard owner's
-   `approveBase`: exact-cap vault provisioning, vault-to-user deposit, then
-   user-to-vault withdrawal.
-5. Settlement guest, gateway, and Solidity tests cover V4 batched registry
-   synchronization, pending/activation status, V2 deposits, V3 withdrawals,
-   per-token caps/liabilities, replay rejection, and delayed release.
-6. The full local gate uses the real sequencer/prover, three DA nodes, Actions
-   services, two unmodified token owners, one shared vault key/VK, Anvil custody,
-   and exact claims without generating an SP1 proof.
-
-After implementation, run the repository gates from a persistent `tmux` session
-for the heavy commands:
+2. Ethereum bridge vectors exercise two dynamic owners through one circuit
+   tag/VK, authenticate the final empty-controller admin, reject retaining the
+   live provisioning signer, reject invalid registry membership, and cover
+   accepted deposit finalization, helper progression, denomination, token
+   inheritance, and withdrawal action/export fields.
 
 ```bash
-dune build ./src/app/zeko/sequencer ./src/app/zeko/da_layer ./src/app/zeko/signer
+dune build ./src/app/zeko/tests/asset_registry_vectors.exe ./src/app/zeko/tests/ethereum_bridge_vectors.exe
+dune exec ./src/app/zeko/tests/asset_registry_vectors.exe -- --max
 dune exec ./src/app/zeko/tests/ethereum_bridge_vectors.exe
+```
+
+The following real Pickles and non-fake prover commands are future release
+validation only. They are outside the active PoC gate and must not be run for
+this PoC review:
+
+```bash
 dune exec ./src/app/zeko/tests/compile_circuits.exe
 dune exec ./src/app/zeko/tests/test_all_real.exe
 src/app/zeko/sequencer/tests/run-sequencer-test.sh real 1 false true

--- a/src/app/zeko/circuits/dune
+++ b/src/app/zeko/circuits/dune
@@ -27,7 +27,7 @@
    ppx_compare
    h_list.ppx))
  (modules
- bridge_rules
+  bridge_rules
   asset_registry
   emergency_da_folder
   emergency_da_rules

--- a/src/app/zeko/circuits/dune
+++ b/src/app/zeko/circuits/dune
@@ -27,7 +27,8 @@
    ppx_compare
    h_list.ppx))
  (modules
-  bridge_rules
+ bridge_rules
+  asset_registry
   emergency_da_folder
   emergency_da_rules
   rule_emergency_da

--- a/src/app/zeko/circuits/outer_rules.ml
+++ b/src/app/zeko/circuits/outer_rules.ml
@@ -12,6 +12,9 @@ module Make (Inputs : sig
   val max_sequencer_inactivity : int
 
   val emergency_da_public_key : Signature_lib.Public_key.Compressed.t
+
+  val ethereum_asset_registry_public_key :
+    Signature_lib.Public_key.Compressed.t option
 end)
 () =
 struct

--- a/src/app/zeko/circuits/outer_rules.ml
+++ b/src/app/zeko/circuits/outer_rules.ml
@@ -16,9 +16,6 @@ module Make (Inputs : sig
   val ethereum_asset_registry_public_key :
     Signature_lib.Public_key.Compressed.t option
 
-  val ethereum_asset_registration_authority :
-    Signature_lib.Public_key.Compressed.t
-
   val ethereum_asset_registry_schema_version : Zeko_util.Checked32.t
 
   val ethereum_asset_approved_mft_standard_vk_id : Snark_params.Tick.Field.t

--- a/src/app/zeko/circuits/outer_rules.ml
+++ b/src/app/zeko/circuits/outer_rules.ml
@@ -15,6 +15,23 @@ module Make (Inputs : sig
 
   val ethereum_asset_registry_public_key :
     Signature_lib.Public_key.Compressed.t option
+
+  val ethereum_asset_registration_authority :
+    Signature_lib.Public_key.Compressed.t
+
+  val ethereum_asset_registry_schema_version : Zeko_util.Checked32.t
+
+  val ethereum_asset_approved_mft_standard_vk_id : Snark_params.Tick.Field.t
+
+  val ethereum_asset_approved_mft_token_vk_hash : Snark_params.Tick.Field.t
+
+  val ethereum_asset_approved_mft_admin_vk_hash : Snark_params.Tick.Field.t
+
+  val ethereum_asset_universal_bridge_vk_id : Snark_params.Tick.Field.t
+
+  val ethereum_asset_universal_bridge_vk_hash : Snark_params.Tick.Field.t
+
+  val ethereum_asset_vault_public_key : Signature_lib.Public_key.Compressed.t
 end)
 () =
 struct

--- a/src/app/zeko/circuits/rule_bridge_finalize_cancelled_deposit.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_cancelled_deposit.ml
@@ -20,6 +20,8 @@ module Make (Inputs : sig
 
   val ethereum_holder_account_l1 : PC.t option
 
+  val ethereum_asset_id : (F.t * F.t) option
+
   val zeko_l1 : PC.t
 
   val chain_l1 : Mina_signature_kind.t
@@ -39,6 +41,8 @@ module Make (Inputs : sig
             let holder_accounts_l1 = holder_accounts_l1
 
             let ethereum_holder_account_l1 = ethereum_holder_account_l1
+
+            let ethereum_asset_id = ethereum_asset_id
 
             let token_owner_l1 = token_owner_l1
 

--- a/src/app/zeko/circuits/rule_bridge_finalize_deposit.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_deposit.ml
@@ -246,12 +246,15 @@ struct
         Typ.(Checked32.typ * Deposit_params.typ)
         (deposit_index, params)
     in
+    let is_ethereum_custom_token = Option.is_some ethereum_asset_id in
     let account_update =
       { default_account_update with
         public_key
       ; token_id = constant Token_id.typ token_id_l2
       ; may_use_token
       ; authorization_kind = authorization_vk_hash vk_hash
+      ; implicit_account_creation_fee =
+          constant Boolean.typ (not is_ethereum_custom_token)
       ; balance_change =
           Currency.Amount.Signed.Checked.(
             of_unsigned base_params.amount |> negate)
@@ -259,7 +262,6 @@ struct
       }
     in
     let bridge_proof_fee = constant Currency.Amount.typ bridge_proof_fee in
-    let is_ethereum_custom_token = Option.is_some ethereum_asset_id in
     let* recipient_payout =
       if is_ethereum_custom_token then Checked.return base_params.amount
       else

--- a/src/app/zeko/circuits/rule_bridge_finalize_deposit.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_deposit.ml
@@ -24,8 +24,9 @@ module type ASSET = sig
 
   val ethereum_asset_id : verified -> (F.var * F.var) option
 
-  val authenticated_registry_call :
-    verified -> Account_update.Checked.t option
+  val registry_binding : verified -> (Checked32.var * F.var) option Checked.t
+
+  val authenticated_registry_call : verified -> Account_update.Checked.t option
 
   val is_custom_token : bool
 
@@ -162,9 +163,7 @@ struct
     let* helper_token_id =
       make_checked
       @@ fun () ->
-      let account_id =
-        Account_id.Checked.create public_key token_id_l2
-      in
+      let account_id = Account_id.Checked.create public_key token_id_l2 in
       Account_id.Checked.derive_token_id ~owner:account_id
     in
     let@ () = with_label __LOC__ in
@@ -201,6 +200,26 @@ struct
     in
     let@ () = with_label __LOC__ in
     let base_params = Deposit_params.base params in
+    let* expected_registry_binding = Asset.registry_binding verified_asset in
+    let* () =
+      match
+        (expected_registry_binding, Deposit_params.registry_binding params)
+      with
+      | None, None ->
+          Checked.return ()
+      | ( Some (expected_index, expected_commitment)
+        , Some (_, actual_index, actual_commitment) ) ->
+          let* () =
+            assert_equal ~label:"bridge registry index" Checked32.typ
+              expected_index actual_index
+          in
+          assert_equal ~label:"bridge registry record commitment" F.typ
+            expected_commitment actual_commitment
+      | _ ->
+          failwith
+            "Deposit registry binding does not match the verified registry \
+             record"
+    in
     let* () =
       match
         (Asset.ethereum_asset_id verified_asset, Deposit_params.asset_id params)
@@ -335,9 +354,8 @@ struct
       ; token_id = token_id_l2
       ; may_use_token =
           constant May_use_token.typ
-            ( if Asset.is_custom_token then
-                Inherit_from_parent
-              else Parents_own_token )
+            ( if Asset.is_custom_token then Inherit_from_parent
+            else Parents_own_token )
       ; authorization_kind = constant A.typ None_given
       ; balance_change =
           Currency.Amount.Signed.Checked.of_unsigned recipient_payout
@@ -351,9 +369,8 @@ struct
       ; token_id = token_id_l2
       ; may_use_token =
           constant May_use_token.typ
-            ( if Asset.is_custom_token then
-                Inherit_from_parent
-              else Parents_own_token )
+            ( if Asset.is_custom_token then Inherit_from_parent
+            else Parents_own_token )
       ; authorization_kind = constant A.typ None_given
       ; balance_change =
           Currency.Amount.Signed.Checked.of_unsigned bridge_proof_fee
@@ -378,9 +395,7 @@ struct
           ; (sequencer_fee_payout, [])
           ]
     in
-    let*| out =
-      make_outputs ~chain:chain_l2 account_update calls
-    in
+    let*| out = make_outputs ~chain:chain_l2 account_update calls in
     Compile_simple.
       { prevs = Two_prevs (verify_check_accepted, verify_ase); out }
 

--- a/src/app/zeko/circuits/rule_bridge_finalize_deposit.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_deposit.ml
@@ -11,10 +11,29 @@ module A = struct
   type var = Checked.t
 end
 
+module type ASSET = sig
+  module Witness : SnarkType
+
+  type verified
+
+  val verify : Witness.var -> verified Checked.t
+
+  val vault_public_key : verified -> PC.var
+
+  val token_id_l2 : verified -> Token_id.Checked.t
+
+  val ethereum_asset_id : verified -> (F.var * F.var) option
+
+  val authenticated_registry_call :
+    verified -> Account_update.Checked.t option
+
+  val is_custom_token : bool
+
+  val is_ethereum_asset : bool
+end
+
 module Make (Inputs : sig
   val token_owner_l1 : Account_id.t option
-
-  val token_owner_l2 : Account_id.t option
 
   val holder_accounts_l1 : PC.t list
 
@@ -23,6 +42,8 @@ module Make (Inputs : sig
   val ethereum_asset_id : (F.t * F.t) option
 
   module Deposit_params : DEPOSIT_PARAMS
+
+  module Asset : ASSET
 
   val zeko_l2 : PC.t
 
@@ -61,8 +82,6 @@ end) =
 struct
   open Inputs
 
-  let token_id_l2 = token_owner_id token_owner_l2
-
   module Token_id = struct
     include Token_id
 
@@ -93,6 +112,7 @@ struct
     type t =
       { public_key : PC.t
       ; vk_hash : F.t
+      ; asset : Asset.Witness.t
       ; may_use_token : May_use_token.t
       ; inner_authorization_kind : A.t
       ; ase : Ase_inst.t
@@ -110,6 +130,7 @@ struct
     let* Witness.
            { public_key
            ; vk_hash
+           ; asset
            ; may_use_token
            ; inner_authorization_kind
            ; ase
@@ -119,6 +140,13 @@ struct
            ; helper_account_new
            } =
       exists Witness.typ ~compute:(V.get w)
+    in
+    let* verified_asset = Asset.verify asset in
+    let asset_public_key = Asset.vault_public_key verified_asset in
+    let token_id_l2 = Asset.token_id_l2 verified_asset in
+    let* () =
+      assert_equal ~label:"bridge asset vault public key" PC.typ public_key
+        asset_public_key
     in
     let* ( { params
            ; action_state = mid_outer_action_state'
@@ -135,7 +163,7 @@ struct
       make_checked
       @@ fun () ->
       let account_id =
-        Account_id.Checked.create public_key (constant Token_id.typ token_id_l2)
+        Account_id.Checked.create public_key token_id_l2
       in
       Account_id.Checked.derive_token_id ~owner:account_id
     in
@@ -173,6 +201,23 @@ struct
     in
     let@ () = with_label __LOC__ in
     let base_params = Deposit_params.base params in
+    let* () =
+      match
+        (Asset.ethereum_asset_id verified_asset, Deposit_params.asset_id params)
+      with
+      | Some (expected_high, expected_low), Some (actual_high, actual_low) ->
+          let* () =
+            assert_equal ~label:"bridge registry asset ID high" F.typ
+              expected_high actual_high
+          in
+          assert_equal ~label:"bridge registry asset ID low" F.typ expected_low
+            actual_low
+      | None, None ->
+          Checked.return ()
+      | _ ->
+          failwith
+            "Deposit asset schema does not match the verified registry record"
+    in
     let@ () = with_label __LOC__ in
     let prev_nonce =
       Mina_numbers.Account_nonce.Checked.Unsafe.of_field
@@ -246,11 +291,11 @@ struct
         Typ.(Checked32.typ * Deposit_params.typ)
         (deposit_index, params)
     in
-    let is_ethereum_custom_token = Option.is_some ethereum_asset_id in
+    let is_ethereum_custom_token = Asset.is_ethereum_asset in
     let account_update =
       { default_account_update with
         public_key
-      ; token_id = constant Token_id.typ token_id_l2
+      ; token_id = token_id_l2
       ; may_use_token
       ; authorization_kind = authorization_vk_hash vk_hash
       ; implicit_account_creation_fee =
@@ -287,14 +332,12 @@ struct
     let recipient_payout =
       { default_account_update with
         public_key = base_params.recipient
-      ; token_id = constant Token_id.typ token_id_l2
+      ; token_id = token_id_l2
       ; may_use_token =
           constant May_use_token.typ
-            ( match token_owner_l2 with
-            | Some _ ->
+            ( if Asset.is_custom_token then
                 Inherit_from_parent
-            | None ->
-                Parents_own_token )
+              else Parents_own_token )
       ; authorization_kind = constant A.typ None_given
       ; balance_change =
           Currency.Amount.Signed.Checked.of_unsigned recipient_payout
@@ -305,14 +348,12 @@ struct
     let sequencer_fee_payout =
       { default_account_update with
         public_key = constant PC.typ bridge_fee_recipient_l2
-      ; token_id = constant Token_id.typ token_id_l2
+      ; token_id = token_id_l2
       ; may_use_token =
           constant May_use_token.typ
-            ( match token_owner_l2 with
-            | Some _ ->
+            ( if Asset.is_custom_token then
                 Inherit_from_parent
-            | None ->
-                Parents_own_token )
+              else Parents_own_token )
       ; authorization_kind = constant A.typ None_given
       ; balance_change =
           Currency.Amount.Signed.Checked.of_unsigned bridge_proof_fee
@@ -321,13 +362,24 @@ struct
       }
     in
     let@ () = with_label __LOC__ in
+    let calls : Calls.t =
+      match Asset.authenticated_registry_call verified_asset with
+      | Some call ->
+          [ (helper_account, [])
+          ; (witness_inner, [])
+          ; (recipient_payout, [])
+          ; (sequencer_fee_payout, [])
+          ; (call, [])
+          ]
+      | None ->
+          [ (helper_account, [])
+          ; (witness_inner, [])
+          ; (recipient_payout, [])
+          ; (sequencer_fee_payout, [])
+          ]
+    in
     let*| out =
-      make_outputs ~chain:chain_l2 account_update
-        [ (helper_account, [])
-        ; (witness_inner, [])
-        ; (recipient_payout, [])
-        ; (sequencer_fee_payout, [])
-        ]
+      make_outputs ~chain:chain_l2 account_update calls
     in
     Compile_simple.
       { prevs = Two_prevs (verify_check_accepted, verify_ase); out }

--- a/src/app/zeko/circuits/rule_bridge_finalize_deposit.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_deposit.ml
@@ -20,6 +20,8 @@ module Make (Inputs : sig
 
   val ethereum_holder_account_l1 : PC.t option
 
+  val ethereum_asset_id : (F.t * F.t) option
+
   module Deposit_params : DEPOSIT_PARAMS
 
   val zeko_l2 : PC.t
@@ -41,6 +43,8 @@ module Make (Inputs : sig
             let holder_accounts_l1 = holder_accounts_l1
 
             let ethereum_holder_account_l1 = ethereum_holder_account_l1
+
+            let ethereum_asset_id = ethereum_asset_id
 
             let token_owner_l1 = token_owner_l1
 
@@ -255,45 +259,63 @@ struct
       }
     in
     let bridge_proof_fee = constant Currency.Amount.typ bridge_proof_fee in
+    let is_ethereum_custom_token = Option.is_some ethereum_asset_id in
     let* recipient_payout =
-      let* recipient_payout, `Underflow underflow =
-        Currency.Amount.Checked.sub_flagged base_params.amount bridge_proof_fee
-      in
-      let* () = Boolean.Assert.is_true (Boolean.not underflow) in
-      let account_creation_fee =
-        constant Currency.Amount.typ
-          (Currency.Amount.of_fee
-             Zeko_constants.constraint_constants.account_creation_fee )
-      in
-      let* paid_for_helper_account_creation, `Underflow underflow =
-        Currency.Amount.Checked.sub_flagged recipient_payout
-          account_creation_fee
-      in
-      let* () = Boolean.Assert.is_true (Boolean.not underflow) in
-      if_ ~typ:Currency.Amount.typ helper_account_new
-        ~then_:paid_for_helper_account_creation ~else_:recipient_payout
+      if is_ethereum_custom_token then Checked.return base_params.amount
+      else
+        let* recipient_payout, `Underflow underflow =
+          Currency.Amount.Checked.sub_flagged base_params.amount
+            bridge_proof_fee
+        in
+        let* () = Boolean.Assert.is_true (Boolean.not underflow) in
+        let account_creation_fee =
+          constant Currency.Amount.typ
+            (Currency.Amount.of_fee
+               Zeko_constants.constraint_constants.account_creation_fee )
+        in
+        let* paid_for_helper_account_creation, `Underflow underflow =
+          Currency.Amount.Checked.sub_flagged recipient_payout
+            account_creation_fee
+        in
+        let* () = Boolean.Assert.is_true (Boolean.not underflow) in
+        if_ ~typ:Currency.Amount.typ helper_account_new
+          ~then_:paid_for_helper_account_creation ~else_:recipient_payout
     in
 
     let recipient_payout =
       { default_account_update with
         public_key = base_params.recipient
       ; token_id = constant Token_id.typ token_id_l2
-      ; may_use_token = constant May_use_token.typ Parents_own_token
+      ; may_use_token =
+          constant May_use_token.typ
+            ( match token_owner_l2 with
+            | Some _ ->
+                Inherit_from_parent
+            | None ->
+                Parents_own_token )
       ; authorization_kind = constant A.typ None_given
       ; balance_change =
           Currency.Amount.Signed.Checked.of_unsigned recipient_payout
-      ; implicit_account_creation_fee = constant Boolean.typ true
+      ; implicit_account_creation_fee =
+          constant Boolean.typ (not is_ethereum_custom_token)
       }
     in
     let sequencer_fee_payout =
       { default_account_update with
         public_key = constant PC.typ bridge_fee_recipient_l2
       ; token_id = constant Token_id.typ token_id_l2
-      ; may_use_token = constant May_use_token.typ Parents_own_token
+      ; may_use_token =
+          constant May_use_token.typ
+            ( match token_owner_l2 with
+            | Some _ ->
+                Inherit_from_parent
+            | None ->
+                Parents_own_token )
       ; authorization_kind = constant A.typ None_given
       ; balance_change =
           Currency.Amount.Signed.Checked.of_unsigned bridge_proof_fee
-      ; implicit_account_creation_fee = constant Boolean.typ true
+      ; implicit_account_creation_fee =
+          constant Boolean.typ (not is_ethereum_custom_token)
       }
     in
     let@ () = with_label __LOC__ in

--- a/src/app/zeko/circuits/rule_bridge_finalize_withdrawal.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_withdrawal.ml
@@ -131,7 +131,8 @@ struct
         let* () =
           let* action =
             withdrawal_action ~chain_l2 ~holder_account_l2 ~token_owner_l2
-              ~ethereum_asset_id ~l2_holder_vk_hash
+              ~ethereum_asset_id ~ethereum_registry_binding:None
+              ~l2_holder_vk_hash
               ~bridge_fee_recipient_l2:(constant PC.typ bridge_fee_recipient_l2)
               ~bridge_proof_fee:(constant Currency.Amount.typ bridge_proof_fee)
               (module Withdrawal_params)

--- a/src/app/zeko/circuits/rule_bridge_finalize_withdrawal.ml
+++ b/src/app/zeko/circuits/rule_bridge_finalize_withdrawal.ml
@@ -16,6 +16,8 @@ module Make (Inputs : sig
 
   val token_owner_l2 : Account_id.t option
 
+  val ethereum_asset_id : (F.t * F.t) option
+
   val helper_token_owner_l1 : PC.t
 
   val zeko_l1 : PC.t
@@ -129,7 +131,7 @@ struct
         let* () =
           let* action =
             withdrawal_action ~chain_l2 ~holder_account_l2 ~token_owner_l2
-              ~l2_holder_vk_hash
+              ~ethereum_asset_id ~l2_holder_vk_hash
               ~bridge_fee_recipient_l2:(constant PC.typ bridge_fee_recipient_l2)
               ~bridge_proof_fee:(constant Currency.Amount.typ bridge_proof_fee)
               (module Withdrawal_params)

--- a/src/app/zeko/circuits/rule_bridge_inner_receive.ml
+++ b/src/app/zeko/circuits/rule_bridge_inner_receive.ml
@@ -5,42 +5,81 @@ module PC = Signature_lib.Public_key.Compressed
 open Bridge_state
 open Zeko_util
 
-module Make (Inputs : sig
-  val token_owner_l2 : Account_id.t option
+module type ASSET = sig
+  module Witness : SnarkType
 
+  type verified
+
+  val verify : Witness.var -> verified Checked.t
+
+  val vault_public_key : verified -> PC.var
+
+  val token_id_l2 : verified -> Token_id.Checked.t
+
+  val call_data : verified -> Currency.Amount.var -> F.var Checked.t
+
+  val authenticated_registry_call :
+    verified -> Account_update.Checked.t option
+
+  val is_custom_token : bool
+end
+
+module Make (Inputs : sig
   val chain_l2 : Mina_signature_kind.t
+
+  module Asset : ASSET
 end) =
 struct
   open Inputs
 
-  let token_id_l2 = token_owner_id token_owner_l2
-
   module Witness = struct
-    type t = { public_key : PC.t; vk_hash : F.t; amount : Currency.Amount.t }
+    type t =
+      { public_key : PC.t
+      ; vk_hash : F.t
+      ; asset : Asset.Witness.t
+      ; amount : Currency.Amount.t
+      }
     [@@deriving snarky]
   end
 
   (** Allow receiving any amount, even though access = Proof. *)
   let main (w : Witness.t V.t) =
     with_label ("main " ^ __LOC__) (fun () ->
-        let* Witness.{ public_key; vk_hash; amount } =
+        let* Witness.{ public_key; vk_hash; asset; amount } =
           exists Witness.typ ~compute:(V.get w)
         in
+        let* verified_asset = Asset.verify asset in
+        let token_id_l2 = Asset.token_id_l2 verified_asset in
+        let* () =
+          assert_equal ~label:"bridge receive vault public key" PC.typ
+            public_key (Asset.vault_public_key verified_asset)
+        in
+        let* call_data = Asset.call_data verified_asset amount in
         let account_update =
           { default_account_update with
             public_key
-          ; token_id = constant Token_id.typ token_id_l2
+          ; token_id = token_id_l2
           ; use_full_commitment =
-              constant Boolean.typ (Option.is_none token_owner_l2)
+              constant Boolean.typ (not Asset.is_custom_token)
           ; implicit_account_creation_fee =
-              constant Boolean.typ (Option.is_none token_owner_l2)
+              constant Boolean.typ (not Asset.is_custom_token)
           ; may_use_token =
               constant Account_update.May_use_token.typ Parents_own_token
           ; authorization_kind = authorization_vk_hash vk_hash
           ; balance_change = Currency.Amount.Signed.Checked.(of_unsigned amount)
+          ; call_data
           }
         in
-        let*| out = make_outputs ~chain:chain_l2 account_update [] in
+        let calls : Calls.t =
+          match Asset.authenticated_registry_call verified_asset with
+          | Some call ->
+            [ (call, []) ]
+          | None ->
+              []
+        in
+        let*| out =
+          make_outputs ~chain:chain_l2 account_update calls
+        in
         Compile_simple.{ prevs = No_prevs; out } )
 
   let rule : _ Compile_simple.branch lazy_t =

--- a/src/app/zeko/circuits/rule_bridge_inner_receive.ml
+++ b/src/app/zeko/circuits/rule_bridge_inner_receive.ml
@@ -18,8 +18,7 @@ module type ASSET = sig
 
   val call_data : verified -> Currency.Amount.var -> F.var Checked.t
 
-  val authenticated_registry_call :
-    verified -> Account_update.Checked.t option
+  val authenticated_registry_call : verified -> Account_update.Checked.t option
 
   val is_custom_token : bool
 end
@@ -52,7 +51,8 @@ struct
         let token_id_l2 = Asset.token_id_l2 verified_asset in
         let* () =
           assert_equal ~label:"bridge receive vault public key" PC.typ
-            public_key (Asset.vault_public_key verified_asset)
+            public_key
+            (Asset.vault_public_key verified_asset)
         in
         let* call_data = Asset.call_data verified_asset amount in
         let account_update =
@@ -73,13 +73,11 @@ struct
         let calls : Calls.t =
           match Asset.authenticated_registry_call verified_asset with
           | Some call ->
-            [ (call, []) ]
+              [ (call, []) ]
           | None ->
               []
         in
-        let*| out =
-          make_outputs ~chain:chain_l2 account_update calls
-        in
+        let*| out = make_outputs ~chain:chain_l2 account_update calls in
         Compile_simple.{ prevs = No_prevs; out } )
 
   let rule : _ Compile_simple.branch lazy_t =

--- a/src/app/zeko/circuits/rule_bridge_inner_receive.ml
+++ b/src/app/zeko/circuits/rule_bridge_inner_receive.ml
@@ -30,6 +30,10 @@ struct
           { default_account_update with
             public_key
           ; token_id = constant Token_id.typ token_id_l2
+          ; use_full_commitment =
+              constant Boolean.typ (Option.is_none token_owner_l2)
+          ; implicit_account_creation_fee =
+              constant Boolean.typ (Option.is_none token_owner_l2)
           ; may_use_token =
               constant Account_update.May_use_token.typ Parents_own_token
           ; authorization_kind = authorization_vk_hash vk_hash

--- a/src/app/zeko/circuits/rule_commit.ml
+++ b/src/app/zeko/circuits/rule_commit.ml
@@ -579,18 +579,14 @@ struct
       assert_vk_hash_if ~label:"registered token admin VK" active admin_zkapp
         Inputs.ethereum_asset_approved_mft_admin_vk_hash
     in
-    let (authority_x :: authority_is_odd :: _) = admin_zkapp.app_state in
-    let configured_authority = Inputs.ethereum_asset_registration_authority in
-    let* () =
-      assert_equal_if ~label:"registered token admin authority x" active F.typ
-        authority_x
-        (constant F.typ configured_authority.x)
+    let (authority_x :: authority_is_odd_field :: _) = admin_zkapp.app_state in
+    let* authority_is_odd = Boolean.of_field authority_is_odd_field in
+    let admin_authority : PC.var =
+      { x = authority_x; is_odd = authority_is_odd }
     in
     let* () =
-      assert_equal_if ~label:"registered token admin authority parity" active
-        F.typ authority_is_odd
-        (constant F.typ
-           (if configured_authority.is_odd then Field.one else Field.zero) )
+      assert_equal_if ~label:"registered token admin authority revoked" active
+        PC.typ admin_authority (constant PC.typ PC.empty)
     in
     let* () =
       authenticate_account_if ~label:"registered vault ledger opening"

--- a/src/app/zeko/circuits/rule_commit.ml
+++ b/src/app/zeko/circuits/rule_commit.ml
@@ -138,6 +138,22 @@ module Make (Inputs : sig
   val emergency_da_public_key : PC.t
 
   val ethereum_asset_registry_public_key : PC.t option
+
+  val ethereum_asset_registration_authority : PC.t
+
+  val ethereum_asset_registry_schema_version : Checked32.t
+
+  val ethereum_asset_approved_mft_standard_vk_id : F.t
+
+  val ethereum_asset_approved_mft_token_vk_hash : F.t
+
+  val ethereum_asset_approved_mft_admin_vk_hash : F.t
+
+  val ethereum_asset_universal_bridge_vk_id : F.t
+
+  val ethereum_asset_universal_bridge_vk_hash : F.t
+
+  val ethereum_asset_vault_public_key : PC.t
 end) =
 struct
   open Inputs
@@ -154,6 +170,123 @@ struct
         let length = Account_set.height
       end)
 
+  module Registry_path = struct
+    module Step = struct
+      type t = { hash_other : F.t; is_right : Zeko_util.Boolean.t }
+      [@@deriving snarky]
+
+      let to_yojson ({ hash_other; is_right } : t) =
+        `Assoc
+          [ ("hash_other", Field.to_yojson hash_other)
+          ; ("is_right", `Bool is_right)
+          ]
+
+      let of_yojson json =
+        let open Yojson.Safe.Util in
+        try
+          let hash_other =
+            match member "hash_other" json |> Field.of_yojson with
+            | Ok hash ->
+                hash
+            | Error error ->
+                failwith error
+          in
+          Ok ({ hash_other; is_right = member "is_right" json |> to_bool } : t)
+        with exn -> Error (Exn.to_string exn)
+    end
+
+    include
+      SnarkList
+        (Step)
+        (struct
+          let length = Zeko_constants.constraint_constants.ledger_depth
+        end)
+
+    let to_yojson path = `List (List.map path ~f:Step.to_yojson)
+
+    let of_yojson = function
+      | `List values ->
+          List.fold_right values ~init:(Ok []) ~f:(fun value acc ->
+              match (Step.of_yojson value, acc) with
+              | Ok value, Ok rest ->
+                  Ok (value :: rest)
+              | Error error, _ | _, Error error ->
+                  Error error )
+      | _ ->
+          Error "registry account path must be a JSON list"
+  end
+
+  module Registration_witness = struct
+    type t =
+      { did_append : Zeko_util.Boolean.t
+      ; candidate : Asset_registry.Asset_record.t
+      ; append_path : Asset_registry.Path.t
+      ; token_owner_acc : Account.t
+      ; token_owner_path : Registry_path.t
+      ; admin_acc : Account.t
+      ; admin_path : Registry_path.t
+      ; vault_acc : Account.t
+      ; vault_path : Registry_path.t
+      ; circulation_acc : Account.t
+      ; circulation_path : Registry_path.t
+      }
+    [@@deriving snarky]
+
+    let to_yojson
+        ({ did_append
+         ; candidate
+         ; append_path
+         ; token_owner_acc
+         ; token_owner_path
+         ; admin_acc
+         ; admin_path
+         ; vault_acc
+         ; vault_path
+         ; circulation_acc
+         ; circulation_path
+         } :
+          t ) =
+      `Assoc
+        [ ("did_append", `Bool did_append)
+        ; ("candidate", Asset_registry.Asset_record.to_yojson candidate)
+        ; ("append_path", Asset_registry.Path.to_yojson append_path)
+        ; ("token_owner_acc", Account.to_yojson token_owner_acc)
+        ; ("token_owner_path", Registry_path.to_yojson token_owner_path)
+        ; ("admin_acc", Account.to_yojson admin_acc)
+        ; ("admin_path", Registry_path.to_yojson admin_path)
+        ; ("vault_acc", Account.to_yojson vault_acc)
+        ; ("vault_path", Registry_path.to_yojson vault_path)
+        ; ("circulation_acc", Account.to_yojson circulation_acc)
+        ; ("circulation_path", Registry_path.to_yojson circulation_path)
+        ]
+
+    let of_yojson json =
+      let open Yojson.Safe.Util in
+      let get parse name =
+        match member name json |> parse with
+        | Ok value ->
+            value
+        | Error error ->
+            failwith error
+      in
+      try
+        Ok
+          ( { did_append = member "did_append" json |> to_bool
+            ; candidate = get Asset_registry.Asset_record.of_yojson "candidate"
+            ; append_path = get Asset_registry.Path.of_yojson "append_path"
+            ; token_owner_acc = get Account.of_yojson "token_owner_acc"
+            ; token_owner_path = get Registry_path.of_yojson "token_owner_path"
+            ; admin_acc = get Account.of_yojson "admin_acc"
+            ; admin_path = get Registry_path.of_yojson "admin_path"
+            ; vault_acc = get Account.of_yojson "vault_acc"
+            ; vault_path = get Registry_path.of_yojson "vault_path"
+            ; circulation_acc = get Account.of_yojson "circulation_acc"
+            ; circulation_path = get Registry_path.of_yojson "circulation_path"
+            }
+            : t )
+      with exn -> Error (Exn.to_string exn)
+  end
+
   module Base_witness = struct
     type t =
       { public_key : PC.t  (** Our public key on the L2 *)
@@ -165,9 +298,11 @@ struct
       ; da_multisig : Multisig.Witness.t
       ; slot_range : Slot_range.t
       ; emergency_mode : Zeko_util.Boolean.t
-      ; ethereum_asset_registry_root : F.t
-      ; ethereum_asset_registry_count : F.t
-      ; ethereum_asset_registry_schema : F.t
+      ; old_ethereum_asset_registry_acc : Account.t
+      ; old_ethereum_asset_registry_path : Registry_path.t
+      ; new_ethereum_asset_registry_acc : Account.t
+      ; new_ethereum_asset_registry_path : Registry_path.t
+      ; ethereum_asset_registration : Registration_witness.t
       }
     [@@deriving snarky]
   end
@@ -186,6 +321,15 @@ struct
     Checked.List.foldi path ~init ~f:(fun height acc PathElt.{ right_side } ->
         make_checked @@ fun () -> Ledger_hash.merge_var ~height acc right_side )
 
+  let implied_registry_root (account : Account.var) (path : Registry_path.var) :
+      F.var Checked.t =
+    let* init = Account.Checked.digest account in
+    Checked.List.foldi path ~init
+      ~f:(fun height acc Registry_path.Step.{ hash_other; is_right } ->
+        let* left = Field.Checked.if_ is_right ~then_:hash_other ~else_:acc in
+        let* right = Field.Checked.if_ is_right ~then_:acc ~else_:hash_other in
+        make_checked @@ fun () -> Ledger_hash.merge_var ~height left right )
+
   let get_zkapp (a : Account.var) : Zkapp_account.Checked.t Checked.t =
     let hash, content = a.zkapp in
     let* content =
@@ -201,6 +345,304 @@ struct
       with_label __LOC__ (fun () -> Field.Checked.Assert.equal hash digest)
     in
     content
+
+  let checked32_of_field field =
+    let* value =
+      exists Checked32.typ
+        ~compute:
+          (let+| value = As_prover.read_var field in
+           Field.to_string value |> Checked32.of_string )
+    in
+    let*| () =
+      assert_equal ~label:"32-bit registry account state" F.typ field
+        (Checked32.Checked.to_field value)
+    in
+    value
+
+  let registry_state_of_account ~registry_public_key (account : Account.var) =
+    let* () =
+      PC.Checked.Assert.equal account.public_key
+        (constant PC.typ registry_public_key)
+    in
+    let* () =
+      assert_equal ~label:"registry account token ID" Token_id.typ
+        account.token_id
+        (constant Token_id.typ Token_id.default)
+    in
+    let* zkapp = get_zkapp account in
+    let (root :: leaf_count_field :: schema_version_field :: _) =
+      zkapp.app_state
+    in
+    let* leaf_count = checked32_of_field leaf_count_field in
+    let* schema_version = checked32_of_field schema_version_field in
+    let* () =
+      assert_equal ~label:"registry account schema" Checked32.typ schema_version
+        (Checked32.Checked.constant
+           (Checked32.of_int
+              Zeko_constants.Ethereum_asset_registry.schema_version ) )
+    in
+    let* has_valid_count =
+      Checked32.Checked.(
+        leaf_count
+        < constant
+            (Checked32.of_int
+               (Zeko_constants.Ethereum_asset_registry.max_assets + 1) ))
+    in
+    let*| () = Boolean.Assert.is_true has_valid_count in
+    ( { Asset_registry.Registry_state.root; leaf_count; schema_version }
+      : Asset_registry.Registry_state.var )
+
+  let assert_equal_if ~label condition typ left right =
+    let* equal = var_equal typ left right in
+    with_label label (fun () ->
+        let open Boolean.Expr in
+        ((not !condition) || equal) |> assert_ )
+
+  let assert_true_if ~label condition value =
+    with_label label (fun () ->
+        let open Boolean.Expr in
+        ((not !condition) || !value) |> assert_ )
+
+  let authenticate_account_if ~label ~ledger_root ~active account path =
+    let* root = implied_registry_root account path in
+    assert_equal_if ~label active Ledger_hash.typ ledger_root
+      (Ledger_hash.var_of_hash_packed root)
+
+  let immutable_vk_permission =
+    (Permissions.Auth_required.Impossible, Mina_numbers.Txn_version.current)
+
+  let expected_token_owner_permissions : Permissions.t =
+    { Permissions.user_default with
+      access = Proof
+    ; set_permissions = Impossible
+    ; set_verification_key = immutable_vk_permission
+    }
+
+  let expected_token_admin_permissions : Permissions.t =
+    { Permissions.user_default with
+      set_permissions = Impossible
+    ; set_verification_key = immutable_vk_permission
+    }
+
+  let expected_vault_permissions : Permissions.t =
+    { Permissions.user_default with
+      send = Proof
+    ; set_permissions = Impossible
+    ; set_verification_key = immutable_vk_permission
+    }
+
+  let expected_circulation_permissions : Permissions.t =
+    { Permissions.user_default with send = None; set_permissions = Impossible }
+
+  let assert_vk_hash_if ~label active zkapp expected =
+    let verification_key = zkapp.Zkapp_account.Poly.verification_key in
+    let* () =
+      assert_true_if ~label:(label ^ " installed") active
+        (Zkapp_basic.Flagged_option.is_some verification_key)
+    in
+    assert_equal_if ~label active F.typ
+      (Data_as_hash.hash (Zkapp_basic.Flagged_option.data verification_key))
+      (constant F.typ expected)
+
+  let validate_registration_accounts ~target_ledger
+      ~(old_state : Asset_registry.Registry_state.var)
+      ~(new_state : Asset_registry.Registry_state.var)
+      (registration : Registration_witness.var) =
+    let active = registration.did_append in
+    let candidate = registration.candidate in
+    let* expected_count =
+      Checked32.Checked.succ_if old_state.leaf_count active
+    in
+    let* () =
+      assert_equal ~label:"registry count advances by at most one" Checked32.typ
+        new_state.leaf_count expected_count
+    in
+    let* candidate_leaf =
+      Asset_registry.Asset_record.commitment_var candidate
+    in
+    let* old_root =
+      Asset_registry.implied_root_var
+        ~leaf:(constant F.typ Field.zero)
+        ~index:old_state.leaf_count registration.append_path
+    in
+    let* appended_root =
+      Asset_registry.implied_root_var ~leaf:candidate_leaf
+        ~index:old_state.leaf_count registration.append_path
+    in
+    let* expected_root =
+      Field.Checked.if_ active ~then_:appended_root ~else_:old_state.root
+    in
+    let* () =
+      assert_equal ~label:"registry append root transition" F.typ new_state.root
+        expected_root
+    in
+    let* () =
+      assert_equal_if ~label:"registry empty append slot" active F.typ
+        old_state.root old_root
+    in
+    let* () =
+      assert_equal_if ~label:"registry append index" active Checked32.typ
+        candidate.registry_index old_state.leaf_count
+    in
+    let* () =
+      assert_equal_if ~label:"registry append schema" active Checked32.typ
+        candidate.schema_version
+        (Checked32.Checked.constant
+           Inputs.ethereum_asset_registry_schema_version )
+    in
+    let* () =
+      assert_equal_if ~label:"registry append MFT standard ID" active F.typ
+        candidate.mft_standard_vk_id
+        (constant F.typ Inputs.ethereum_asset_approved_mft_standard_vk_id)
+    in
+    let* () =
+      assert_equal_if ~label:"registry append universal bridge ID" active F.typ
+        candidate.universal_bridge_vk_id
+        (constant F.typ Inputs.ethereum_asset_universal_bridge_vk_id)
+    in
+    let* () =
+      assert_equal_if ~label:"registry append shared vault" active PC.typ
+        candidate.vault_public_key
+        (constant PC.typ Inputs.ethereum_asset_vault_public_key)
+    in
+    let owner_id =
+      Account_id.Checked.create candidate.token_owner_l2
+        (constant Token_id.typ Token_id.default)
+    in
+    let* derived_token_id =
+      make_checked (fun () ->
+          Account_id.Checked.derive_token_id ~owner:owner_id )
+    in
+    let* () =
+      assert_equal_if ~label:"registry append derived token ID" active
+        Token_id.typ candidate.token_id_l2 derived_token_id
+    in
+    let* () =
+      authenticate_account_if ~label:"registered token owner ledger opening"
+        ~ledger_root:target_ledger ~active registration.token_owner_acc
+        registration.token_owner_path
+    in
+    let* () =
+      assert_equal_if ~label:"registered token owner public key" active PC.typ
+        registration.token_owner_acc.public_key candidate.token_owner_l2
+    in
+    let* () =
+      assert_equal_if ~label:"registered token owner token ID" active
+        Token_id.typ registration.token_owner_acc.token_id
+        (constant Token_id.typ Token_id.default)
+    in
+    let* () =
+      assert_equal_if ~label:"registered token owner permissions" active
+        Permissions.typ registration.token_owner_acc.permissions
+        (constant Permissions.typ expected_token_owner_permissions)
+    in
+    let* token_owner_zkapp = get_zkapp registration.token_owner_acc in
+    let* () =
+      assert_vk_hash_if ~label:"registered token owner VK" active
+        token_owner_zkapp Inputs.ethereum_asset_approved_mft_token_vk_hash
+    in
+    let (owner_decimals :: admin_x :: admin_is_odd_field :: paused :: _) =
+      token_owner_zkapp.app_state
+    in
+    let* () =
+      assert_equal_if ~label:"registered token decimals" active F.typ
+        owner_decimals
+        (Checked32.Checked.to_field candidate.decimals)
+    in
+    let* admin_is_odd = Boolean.of_field admin_is_odd_field in
+    let admin_public_key : PC.var = { x = admin_x; is_odd = admin_is_odd } in
+    let* () =
+      assert_equal_if ~label:"registered token is unpaused" active F.typ paused
+        (constant F.typ Field.zero)
+    in
+    let* () =
+      authenticate_account_if ~label:"registered token admin ledger opening"
+        ~ledger_root:target_ledger ~active registration.admin_acc
+        registration.admin_path
+    in
+    let* () =
+      assert_equal_if ~label:"registered token admin public key" active PC.typ
+        registration.admin_acc.public_key admin_public_key
+    in
+    let* () =
+      assert_equal_if ~label:"registered token admin token ID" active
+        Token_id.typ registration.admin_acc.token_id
+        (constant Token_id.typ Token_id.default)
+    in
+    let* () =
+      assert_equal_if ~label:"registered token admin permissions" active
+        Permissions.typ registration.admin_acc.permissions
+        (constant Permissions.typ expected_token_admin_permissions)
+    in
+    let* admin_zkapp = get_zkapp registration.admin_acc in
+    let* () =
+      assert_vk_hash_if ~label:"registered token admin VK" active admin_zkapp
+        Inputs.ethereum_asset_approved_mft_admin_vk_hash
+    in
+    let (authority_x :: authority_is_odd :: _) = admin_zkapp.app_state in
+    let configured_authority = Inputs.ethereum_asset_registration_authority in
+    let* () =
+      assert_equal_if ~label:"registered token admin authority x" active F.typ
+        authority_x
+        (constant F.typ configured_authority.x)
+    in
+    let* () =
+      assert_equal_if ~label:"registered token admin authority parity" active
+        F.typ authority_is_odd
+        (constant F.typ
+           (if configured_authority.is_odd then Field.one else Field.zero) )
+    in
+    let* () =
+      authenticate_account_if ~label:"registered vault ledger opening"
+        ~ledger_root:target_ledger ~active registration.vault_acc
+        registration.vault_path
+    in
+    let* () =
+      assert_equal_if ~label:"registered vault public key" active PC.typ
+        registration.vault_acc.public_key candidate.vault_public_key
+    in
+    let* () =
+      assert_equal_if ~label:"registered vault token ID" active Token_id.typ
+        registration.vault_acc.token_id derived_token_id
+    in
+    let* () =
+      assert_equal_if ~label:"registered vault inventory" active
+        Currency.Amount.typ
+        (Currency.Balance.Checked.to_amount registration.vault_acc.balance)
+        candidate.inventory_cap
+    in
+    let* () =
+      assert_equal_if ~label:"registered vault permissions" active
+        Permissions.typ registration.vault_acc.permissions
+        (constant Permissions.typ expected_vault_permissions)
+    in
+    let* vault_zkapp = get_zkapp registration.vault_acc in
+    let* () =
+      assert_vk_hash_if ~label:"registered vault VK" active vault_zkapp
+        Inputs.ethereum_asset_universal_bridge_vk_hash
+    in
+    let* () =
+      authenticate_account_if ~label:"registered circulation ledger opening"
+        ~ledger_root:target_ledger ~active registration.circulation_acc
+        registration.circulation_path
+    in
+    let* () =
+      assert_equal_if ~label:"registered circulation public key" active PC.typ
+        registration.circulation_acc.public_key candidate.token_owner_l2
+    in
+    let* () =
+      assert_equal_if ~label:"registered circulation token ID" active
+        Token_id.typ registration.circulation_acc.token_id derived_token_id
+    in
+    let* () =
+      assert_equal_if ~label:"registered circulation supply" active
+        Currency.Amount.typ
+        (Currency.Balance.Checked.to_amount registration.circulation_acc.balance)
+        candidate.inventory_cap
+    in
+    assert_equal_if ~label:"registered circulation permissions" active
+      Permissions.typ registration.circulation_acc.permissions
+      (constant Permissions.typ expected_circulation_permissions)
 
   type da_mode = Multisig | Emergency of Emergency_da_folder.Stmt.var
 
@@ -219,9 +661,11 @@ struct
          ; da_multisig
          ; slot_range
          ; emergency_mode
-         ; ethereum_asset_registry_root
-         ; ethereum_asset_registry_count
-         ; ethereum_asset_registry_schema
+         ; old_ethereum_asset_registry_acc
+         ; old_ethereum_asset_registry_path
+         ; new_ethereum_asset_registry_acc
+         ; new_ethereum_asset_registry_path
+         ; ethereum_asset_registration
          }
           : Base_witness.var ) =
       w
@@ -249,6 +693,43 @@ struct
          }
           : Txn_state.Zeko_stmt.var ) =
       txn_stmt
+    in
+    let* ethereum_asset_registry_state =
+      match Inputs.ethereum_asset_registry_public_key with
+      | None ->
+          Checked.return None
+      | Some registry_public_key ->
+          let* old_registry_root =
+            implied_registry_root old_ethereum_asset_registry_acc
+              old_ethereum_asset_registry_path
+          in
+          let* new_registry_root =
+            implied_registry_root new_ethereum_asset_registry_acc
+              new_ethereum_asset_registry_path
+          in
+          let* () =
+            assert_equal ~label:"source registry account ledger opening"
+              Ledger_hash.typ source_ledger
+              (Ledger_hash.var_of_hash_packed old_registry_root)
+          in
+          let* () =
+            assert_equal ~label:"target registry account ledger opening"
+              Ledger_hash.typ target_ledger
+              (Ledger_hash.var_of_hash_packed new_registry_root)
+          in
+          let* old_state =
+            registry_state_of_account ~registry_public_key
+              old_ethereum_asset_registry_acc
+          in
+          let* new_state =
+            registry_state_of_account ~registry_public_key
+              new_ethereum_asset_registry_acc
+          in
+          let* () =
+            validate_registration_accounts ~target_ledger ~old_state ~new_state
+              ethereum_asset_registration
+          in
+          Checked.return (Some new_state)
     in
     with_label __LOC__
     @@ fun () ->
@@ -543,18 +1024,23 @@ struct
        an executable precondition. Bind the checkpoint into the signed
        sequencer child's inert call data instead. *)
     let* ethereum_asset_registry_call_data =
-      match Inputs.ethereum_asset_registry_public_key with
-      | None ->
+      match
+        ( Inputs.ethereum_asset_registry_public_key
+        , ethereum_asset_registry_state )
+      with
+      | None, None ->
           Checked.return (constant F.typ Field.zero)
-      | Some registry_public_key ->
+      | Some registry_public_key, Some registry_state ->
           var_to_hash
             ~init:Zeko_constants.ethereum_asset_registry_checkpoint_salt
             Typ.(array ~length:4 F.typ)
             [| constant F.typ registry_public_key.x
-             ; ethereum_asset_registry_root
-             ; ethereum_asset_registry_count
-             ; ethereum_asset_registry_schema
+             ; registry_state.root
+             ; Checked32.Checked.to_field registry_state.leaf_count
+             ; Checked32.Checked.to_field registry_state.schema_version
             |]
+      | _ ->
+          failwith "inconsistent Ethereum asset registry circuit configuration"
     in
     let sequencer_account_update =
       { default_account_update with
@@ -594,9 +1080,7 @@ struct
       | Some emergency_da ->
           [ (sequencer_account_update, []); (emergency_da, []) ]
     in
-    let*| out =
-      make_outputs ~chain:chain_l1 account_update calls
-    in
+    let*| out = make_outputs ~chain:chain_l1 account_update calls in
     out
 
   let rule : _ Compile_simple.branch lazy_t =

--- a/src/app/zeko/circuits/rule_commit.ml
+++ b/src/app/zeko/circuits/rule_commit.ml
@@ -139,8 +139,6 @@ module Make (Inputs : sig
 
   val ethereum_asset_registry_public_key : PC.t option
 
-  val ethereum_asset_registration_authority : PC.t
-
   val ethereum_asset_registry_schema_version : Checked32.t
 
   val ethereum_asset_approved_mft_standard_vk_id : F.t

--- a/src/app/zeko/circuits/rule_commit.ml
+++ b/src/app/zeko/circuits/rule_commit.ml
@@ -136,6 +136,8 @@ module Make (Inputs : sig
   val max_sequencer_inactivity : int
 
   val emergency_da_public_key : PC.t
+
+  val ethereum_asset_registry_public_key : PC.t option
 end) =
 struct
   open Inputs
@@ -163,6 +165,9 @@ struct
       ; da_multisig : Multisig.Witness.t
       ; slot_range : Slot_range.t
       ; emergency_mode : Zeko_util.Boolean.t
+      ; ethereum_asset_registry_root : F.t
+      ; ethereum_asset_registry_count : F.t
+      ; ethereum_asset_registry_schema : F.t
       }
     [@@deriving snarky]
   end
@@ -214,6 +219,9 @@ struct
          ; da_multisig
          ; slot_range
          ; emergency_mode
+         ; ethereum_asset_registry_root
+         ; ethereum_asset_registry_count
+         ; ethereum_asset_registry_schema
          }
           : Base_witness.var ) =
       w
@@ -537,6 +545,36 @@ struct
       ; use_full_commitment = Boolean.true_
       }
     in
+    let ethereum_asset_registry_account_update_opt =
+      Option.map Inputs.ethereum_asset_registry_public_key
+        ~f:(fun registry_public_key ->
+          let registry_state : Asset_registry.Registry_state.var =
+            { root = ethereum_asset_registry_root
+            ; leaf_count =
+                Zeko_util.Checked32.Checked.Unsafe.of_field
+                  ethereum_asset_registry_count
+            ; schema_version =
+                Zeko_util.Checked32.Checked.Unsafe.of_field
+                  ethereum_asset_registry_schema
+            }
+          in
+          { default_account_update with
+            public_key = constant PC.typ registry_public_key
+          ; preconditions =
+              { default_account_update.preconditions with
+                account =
+                  { default_account_update.preconditions.account with
+                    state =
+                      Asset_registry.Registry_state.fine
+                        { root = Some registry_state.root
+                        ; leaf_count = Some registry_state.leaf_count
+                        ; schema_version = Some registry_state.schema_version
+                        }
+                      |> var_to_precondition_fine
+                  }
+              }
+          } )
+    in
     let emergency_da_account_update_opt =
       match da_mode with
       | Emergency emergency_da_stmt ->
@@ -560,15 +598,25 @@ struct
     in
 
     (* Assemble some stuff to help the prover and calculate public output *)
+    let calls : Calls.t =
+      match
+        ( ethereum_asset_registry_account_update_opt
+        , emergency_da_account_update_opt )
+      with
+      | None, None ->
+          [ (sequencer_account_update, []) ]
+      | Some registry, None ->
+          [ (sequencer_account_update, []); (registry, []) ]
+      | None, Some emergency_da ->
+          [ (sequencer_account_update, []); (emergency_da, []) ]
+      | Some registry, Some emergency_da ->
+          [ (sequencer_account_update, [])
+          ; (registry, [])
+          ; (emergency_da, [])
+          ]
+    in
     let*| out =
-      make_outputs ~chain:chain_l1 account_update
-        ( (sequencer_account_update, [])
-        ::
-        ( match emergency_da_account_update_opt with
-        | None ->
-            []
-        | Some emergency_da_au ->
-            [ (emergency_da_au, []) ] ) )
+      make_outputs ~chain:chain_l1 account_update calls
     in
     out
 

--- a/src/app/zeko/circuits/rule_commit.ml
+++ b/src/app/zeko/circuits/rule_commit.ml
@@ -538,42 +538,31 @@ struct
       }
     in
 
+    (* Ethereum settlement needs the L2 registry checkpoint in the Pickles-bound
+       call forest, but Mina L1 has no registry account whose state can satisfy
+       an executable precondition. Bind the checkpoint into the signed
+       sequencer child's inert call data instead. *)
+    let* ethereum_asset_registry_call_data =
+      match Inputs.ethereum_asset_registry_public_key with
+      | None ->
+          Checked.return (constant F.typ Field.zero)
+      | Some registry_public_key ->
+          var_to_hash
+            ~init:Zeko_constants.ethereum_asset_registry_checkpoint_salt
+            Typ.(array ~length:4 F.typ)
+            [| constant F.typ registry_public_key.x
+             ; ethereum_asset_registry_root
+             ; ethereum_asset_registry_count
+             ; ethereum_asset_registry_schema
+            |]
+    in
     let sequencer_account_update =
       { default_account_update with
         public_key = Even_PC.to_pc_var sequencer
+      ; call_data = ethereum_asset_registry_call_data
       ; authorization_kind = authorization_signed ()
       ; use_full_commitment = Boolean.true_
       }
-    in
-    let ethereum_asset_registry_account_update_opt =
-      Option.map Inputs.ethereum_asset_registry_public_key
-        ~f:(fun registry_public_key ->
-          let registry_state : Asset_registry.Registry_state.var =
-            { root = ethereum_asset_registry_root
-            ; leaf_count =
-                Zeko_util.Checked32.Checked.Unsafe.of_field
-                  ethereum_asset_registry_count
-            ; schema_version =
-                Zeko_util.Checked32.Checked.Unsafe.of_field
-                  ethereum_asset_registry_schema
-            }
-          in
-          { default_account_update with
-            public_key = constant PC.typ registry_public_key
-          ; preconditions =
-              { default_account_update.preconditions with
-                account =
-                  { default_account_update.preconditions.account with
-                    state =
-                      Asset_registry.Registry_state.fine
-                        { root = Some registry_state.root
-                        ; leaf_count = Some registry_state.leaf_count
-                        ; schema_version = Some registry_state.schema_version
-                        }
-                      |> var_to_precondition_fine
-                  }
-              }
-          } )
     in
     let emergency_da_account_update_opt =
       match da_mode with
@@ -599,21 +588,11 @@ struct
 
     (* Assemble some stuff to help the prover and calculate public output *)
     let calls : Calls.t =
-      match
-        ( ethereum_asset_registry_account_update_opt
-        , emergency_da_account_update_opt )
-      with
-      | None, None ->
+      match emergency_da_account_update_opt with
+      | None ->
           [ (sequencer_account_update, []) ]
-      | Some registry, None ->
-          [ (sequencer_account_update, []); (registry, []) ]
-      | None, Some emergency_da ->
+      | Some emergency_da ->
           [ (sequencer_account_update, []); (emergency_da, []) ]
-      | Some registry, Some emergency_da ->
-          [ (sequencer_account_update, [])
-          ; (registry, [])
-          ; (emergency_da, [])
-          ]
     in
     let*| out =
       make_outputs ~chain:chain_l1 account_update calls

--- a/src/app/zeko/circuits/rule_commit.ml
+++ b/src/app/zeko/circuits/rule_commit.ml
@@ -1025,14 +1025,8 @@ struct
       | None, None ->
           Checked.return (constant F.typ Field.zero)
       | Some registry_public_key, Some registry_state ->
-          var_to_hash
-            ~init:Zeko_constants.ethereum_asset_registry_checkpoint_salt
-            Typ.(array ~length:4 F.typ)
-            [| constant F.typ registry_public_key.x
-             ; registry_state.root
-             ; Checked32.Checked.to_field registry_state.leaf_count
-             ; Checked32.Checked.to_field registry_state.schema_version
-            |]
+          Asset_registry.Checkpoint.commitment_var ~registry_public_key
+            registry_state
       | _ ->
           failwith "inconsistent Ethereum asset registry circuit configuration"
     in

--- a/src/app/zeko/circuits/zeko_util.ml
+++ b/src/app/zeko/circuits/zeko_util.ml
@@ -114,6 +114,12 @@ module F = struct
 
   let pp : Format.formatter -> field -> unit =
    fun fmt f -> Format.pp_print_string fmt @@ Field.to_string f
+
+  let equal = Field.equal
+
+  let to_yojson = Field.to_yojson
+
+  let of_yojson = Field.of_yojson
 end
 
 module type V_S = sig

--- a/src/app/zeko/circuits/zeko_util.mli
+++ b/src/app/zeko/circuits/zeko_util.mli
@@ -53,6 +53,12 @@ module F : sig
   val typ : (var, t) Typ.t
 
   val pp : Format.formatter -> Pasta_bindings.Fp.t -> unit
+
+  val equal : t -> t -> bool
+
+  val to_yojson : t -> Yojson.Safe.t
+
+  val of_yojson : Yojson.Safe.t -> (t, string) Result.t
 end
 
 module type SnarkType = sig

--- a/src/app/zeko/sequencer/cli.ml
+++ b/src/app/zeko/sequencer/cli.ml
@@ -143,18 +143,18 @@ let generate_circuits_config =
        and ethereum_bridge_address =
          flag "--ethereum-bridge-address" (optional string)
            ~doc:"string Ethereum bridge proxy address to bind as an L1 holder"
-       and ethereum_token_asset_id =
-         flag "--ethereum-token-asset-id" (optional string)
-           ~doc:"bytes32 Immutable ERC20 bridge asset ID"
-       and ethereum_token_address =
-         flag "--ethereum-token-address" (optional string)
-           ~doc:"address Canonical ERC20 contract address"
-       and ethereum_token_owner_l2 =
-         flag "--ethereum-token-owner-l2" (optional string)
-           ~doc:"public-key Mina FungibleToken owner public key"
-       and ethereum_token_vault_l2 =
-         flag "--ethereum-token-vault-l2" (optional string)
-           ~doc:"public-key Proof-controlled ERC20 bridge vault public key"
+       and ethereum_asset_registry_l2 =
+         flag "--ethereum-asset-registry-l2" (optional string)
+           ~doc:"public-key Append-only Ethereum asset registry zkApp"
+       and ethereum_shared_vault_l2 =
+         flag "--ethereum-shared-vault-l2" (optional string)
+           ~doc:"public-key Shared proof-controlled multi-token bridge vault"
+       and ethereum_mft_standard_vk_id =
+         flag "--ethereum-mft-standard-vk-id" (optional string)
+           ~doc:"field Approved Mina FungibleToken implementation identifier"
+       and ethereum_universal_bridge_vk_id =
+         flag "--ethereum-universal-bridge-vk-id" (optional string)
+           ~doc:"field Universal bridge circuit/version identifier"
        in
        fun () ->
          let generate_keypair () =
@@ -167,42 +167,39 @@ let generate_circuits_config =
          let emergency_da = generate_keypair () in
          let bridge_fee_recipient_l1 = generate_keypair () in
          let bridge_fee_recipient_l2 = generate_keypair () in
-         let ethereum_token =
+         let ethereum_assets =
            match
-             ( ethereum_token_asset_id
-             , ethereum_token_address
-             , ethereum_token_owner_l2
-             , ethereum_token_vault_l2 )
+             ( ethereum_asset_registry_l2
+             , ethereum_shared_vault_l2
+             , ethereum_mft_standard_vk_id
+             , ethereum_universal_bridge_vk_id )
            with
            | None, None, None, None ->
                None
-           | ( Some asset_id
-             , Some ethereum_token_address
-             , Some token_owner_l2
-             , Some holder_account_l2 ) ->
+           | ( Some registry_public_key
+             , Some vault_public_key
+             , Some approved_mft_standard_vk_id
+             , Some universal_bridge_vk_id ) ->
                if Option.is_none ethereum_bridge_address then
                  failwith
                    "--ethereum-bridge-address is required when configuring an \
-                    Ethereum token"
+                    Ethereum asset registry"
                else
                  Some
-                   { Zeko_circuits_config.Ethereum_token.asset_id =
-                       Zeko_circuits_config.normalize_bytes32_exn
-                         ~label:"Ethereum token asset ID" asset_id
-                   ; ethereum_token_address =
-                       Zeko_circuits_config.normalize_ethereum_address_exn
-                         ~label:"Ethereum token address" ethereum_token_address
-                   ; token_owner_l2 =
-                       Public_key.Compressed.of_base58_check_exn token_owner_l2
-                   ; holder_account_l2 =
+                   { Zeko_circuits_config.Ethereum_assets.registry_public_key =
                        Public_key.Compressed.of_base58_check_exn
-                         holder_account_l2
+                         registry_public_key
+                   ; vault_public_key =
+                       Public_key.Compressed.of_base58_check_exn
+                         vault_public_key
+                   ; approved_mft_standard_vk_id
+                   ; universal_bridge_vk_id
                    }
            | _ ->
                failwith
-                 "--ethereum-token-asset-id, --ethereum-token-owner-l2, and \
-                  --ethereum-token-vault-l2 must be supplied together with \
-                  --ethereum-token-address"
+                 "--ethereum-asset-registry-l2, --ethereum-shared-vault-l2, \
+                  --ethereum-mft-standard-vk-id, and \
+                  --ethereum-universal-bridge-vk-id must be supplied together"
          in
          let t : Zeko_circuits_config.t =
            { chain_l1 = Testnet
@@ -216,7 +213,8 @@ let generate_circuits_config =
            ; ethereum_holder_account_l1 =
                Option.map ethereum_bridge_address
                  ~f:Zeko_circuits_config.ethereum_address_to_public_key
-           ; ethereum_token
+           ; ethereum_token = None
+           ; ethereum_assets
            ; helper_token_owner_l1 = fst helper_token_owner_l1
            ; zeko_l1 = fst zeko_l1
            ; emergency_da_public_key = fst emergency_da

--- a/src/app/zeko/sequencer/cli.ml
+++ b/src/app/zeko/sequencer/cli.ml
@@ -146,15 +146,27 @@ let generate_circuits_config =
        and ethereum_asset_registry_l2 =
          flag "--ethereum-asset-registry-l2" (optional string)
            ~doc:"public-key Append-only Ethereum asset registry zkApp"
+       and ethereum_registration_authority_l2 =
+         flag "--ethereum-registration-authority-l2" (optional string)
+           ~doc:"public-key Bridge administrator authorizing registry appends"
        and ethereum_shared_vault_l2 =
          flag "--ethereum-shared-vault-l2" (optional string)
            ~doc:"public-key Shared proof-controlled multi-token bridge vault"
        and ethereum_mft_standard_vk_id =
          flag "--ethereum-mft-standard-vk-id" (optional string)
            ~doc:"field Approved Mina FungibleToken implementation identifier"
+       and ethereum_mft_token_vk_hash =
+         flag "--ethereum-mft-token-vk-hash" (optional string)
+           ~doc:"field Approved Mina FungibleToken verification-key hash"
+       and ethereum_mft_admin_vk_hash =
+         flag "--ethereum-mft-admin-vk-hash" (optional string)
+           ~doc:"field Approved Mina FungibleTokenAdmin verification-key hash"
        and ethereum_universal_bridge_vk_id =
          flag "--ethereum-universal-bridge-vk-id" (optional string)
            ~doc:"field Universal bridge circuit/version identifier"
+       and ethereum_universal_bridge_vk_hash =
+         flag "--ethereum-universal-bridge-vk-hash" (optional string)
+           ~doc:"field Universal bridge L2 verification-key hash"
        in
        fun () ->
          let generate_keypair () =
@@ -170,16 +182,24 @@ let generate_circuits_config =
          let ethereum_assets =
            match
              ( ethereum_asset_registry_l2
+             , ethereum_registration_authority_l2
              , ethereum_shared_vault_l2
              , ethereum_mft_standard_vk_id
-             , ethereum_universal_bridge_vk_id )
+             , ethereum_mft_token_vk_hash
+             , ethereum_mft_admin_vk_hash
+             , ethereum_universal_bridge_vk_id
+             , ethereum_universal_bridge_vk_hash )
            with
-           | None, None, None, None ->
+           | None, None, None, None, None, None, None, None ->
                None
            | ( Some registry_public_key
+             , Some registration_authority
              , Some vault_public_key
              , Some approved_mft_standard_vk_id
-             , Some universal_bridge_vk_id ) ->
+             , Some approved_mft_token_vk_hash
+             , Some approved_mft_admin_vk_hash
+             , Some universal_bridge_vk_id
+             , Some universal_bridge_vk_hash ) ->
                if Option.is_none ethereum_bridge_address then
                  failwith
                    "--ethereum-bridge-address is required when configuring an \
@@ -189,17 +209,27 @@ let generate_circuits_config =
                    { Zeko_circuits_config.Ethereum_assets.registry_public_key =
                        Public_key.Compressed.of_base58_check_exn
                          registry_public_key
+                   ; registration_authority =
+                       Public_key.Compressed.of_base58_check_exn
+                         registration_authority
                    ; vault_public_key =
                        Public_key.Compressed.of_base58_check_exn
                          vault_public_key
                    ; approved_mft_standard_vk_id
+                   ; approved_mft_token_vk_hash
+                   ; approved_mft_admin_vk_hash
                    ; universal_bridge_vk_id
+                   ; universal_bridge_vk_hash
                    }
            | _ ->
                failwith
-                 "--ethereum-asset-registry-l2, --ethereum-shared-vault-l2, \
-                  --ethereum-mft-standard-vk-id, and \
-                  --ethereum-universal-bridge-vk-id must be supplied together"
+                 "--ethereum-asset-registry-l2, \
+                  --ethereum-registration-authority-l2, \
+                  --ethereum-shared-vault-l2, --ethereum-mft-standard-vk-id, \
+                  --ethereum-mft-token-vk-hash, --ethereum-mft-admin-vk-hash, \
+                  --ethereum-universal-bridge-vk-id, and \
+                  --ethereum-universal-bridge-vk-hash must be supplied \
+                  together"
          in
          let t : Zeko_circuits_config.t =
            { chain_l1 = Testnet

--- a/src/app/zeko/sequencer/cli.ml
+++ b/src/app/zeko/sequencer/cli.ml
@@ -143,6 +143,18 @@ let generate_circuits_config =
        and ethereum_bridge_address =
          flag "--ethereum-bridge-address" (optional string)
            ~doc:"string Ethereum bridge proxy address to bind as an L1 holder"
+       and ethereum_token_asset_id =
+         flag "--ethereum-token-asset-id" (optional string)
+           ~doc:"bytes32 Immutable ERC20 bridge asset ID"
+       and ethereum_token_address =
+         flag "--ethereum-token-address" (optional string)
+           ~doc:"address Canonical ERC20 contract address"
+       and ethereum_token_owner_l2 =
+         flag "--ethereum-token-owner-l2" (optional string)
+           ~doc:"public-key Mina FungibleToken owner public key"
+       and ethereum_token_vault_l2 =
+         flag "--ethereum-token-vault-l2" (optional string)
+           ~doc:"public-key Proof-controlled ERC20 bridge vault public key"
        in
        fun () ->
          let generate_keypair () =
@@ -155,6 +167,43 @@ let generate_circuits_config =
          let emergency_da = generate_keypair () in
          let bridge_fee_recipient_l1 = generate_keypair () in
          let bridge_fee_recipient_l2 = generate_keypair () in
+         let ethereum_token =
+           match
+             ( ethereum_token_asset_id
+             , ethereum_token_address
+             , ethereum_token_owner_l2
+             , ethereum_token_vault_l2 )
+           with
+           | None, None, None, None ->
+               None
+           | ( Some asset_id
+             , Some ethereum_token_address
+             , Some token_owner_l2
+             , Some holder_account_l2 ) ->
+               if Option.is_none ethereum_bridge_address then
+                 failwith
+                   "--ethereum-bridge-address is required when configuring an \
+                    Ethereum token"
+               else
+                 Some
+                   { Zeko_circuits_config.Ethereum_token.asset_id =
+                       Zeko_circuits_config.normalize_bytes32_exn
+                         ~label:"Ethereum token asset ID" asset_id
+                   ; ethereum_token_address =
+                       Zeko_circuits_config.normalize_ethereum_address_exn
+                         ~label:"Ethereum token address" ethereum_token_address
+                   ; token_owner_l2 =
+                       Public_key.Compressed.of_base58_check_exn token_owner_l2
+                   ; holder_account_l2 =
+                       Public_key.Compressed.of_base58_check_exn
+                         holder_account_l2
+                   }
+           | _ ->
+               failwith
+                 "--ethereum-token-asset-id, --ethereum-token-owner-l2, and \
+                  --ethereum-token-vault-l2 must be supplied together with \
+                  --ethereum-token-address"
+         in
          let t : Zeko_circuits_config.t =
            { chain_l1 = Testnet
            ; chain_l2 = Testnet
@@ -167,6 +216,7 @@ let generate_circuits_config =
            ; ethereum_holder_account_l1 =
                Option.map ethereum_bridge_address
                  ~f:Zeko_circuits_config.ethereum_address_to_public_key
+           ; ethereum_token
            ; helper_token_owner_l1 = fst helper_token_owner_l1
            ; zeko_l1 = fst zeko_l1
            ; emergency_da_public_key = fst emergency_da

--- a/src/app/zeko/sequencer/deploy.ml
+++ b/src/app/zeko/sequencer/deploy.ml
@@ -50,7 +50,9 @@ let generate ~l1_uri ~sender_pk ~ledger_input ~faucet_aid ~pause_key
       let%bind nonce =
         Gql_client.infer_nonce ~logger l1_uri sender_pk >>| Or_error.ok_exn
       in
-      let%bind `Inner inner_account, `Holder holder_account =
+      let%bind ( `Inner inner_account
+                , `Holder holder_account
+                , `Ethereum_asset_registry registry_account ) =
         Sequencer_lib.Deploy.Z.Inner.initial_accounts ()
       in
       let old_ledger_witness, new_ledger, imt_hash, imt =
@@ -68,11 +70,9 @@ let generate ~l1_uri ~sender_pk ~ledger_input ~faucet_aid ~pause_key
               }
             in
             let genesis_accounts =
-              [ inner_account
-              ; holder_account
-              ; sequencer_account
-              ; fee_recipient_account
-              ]
+              [ inner_account; holder_account ]
+              @ Option.to_list registry_account
+              @ [ sequencer_account; fee_recipient_account ]
               @ ( match prefund_account with
                 | Some (signer, amount) ->
                     [ { Account.empty with
@@ -135,10 +135,25 @@ let generate ~l1_uri ~sender_pk ~ledger_input ~faucet_aid ~pause_key
             List.iteri [ inner_account; holder_account ] ~f:(fun i acc ->
                 L.set_at_index_exn ledger i acc ) ;
 
+            let registry_account_diff =
+              Option.bind registry_account ~f:(fun registry_account ->
+                  let account_id = Account.identifier registry_account in
+                  match L.location_of_account ledger account_id with
+                  | Some _ ->
+                      None
+                  | None ->
+                      L.create_new_account_exn ledger account_id
+                        registry_account ;
+                      Some
+                        ( L.index_of_account_exn ledger account_id
+                        , registry_account ) )
+            in
             let accounts_diff =
               (0, inner_account) :: (1, holder_account)
               ::
-              ( match faucet_aid with
+              ( Option.to_list registry_account_diff
+              @
+              match faucet_aid with
               | None ->
                   []
               | Some faucet_aid ->

--- a/src/app/zeko/sequencer/deploy.ml
+++ b/src/app/zeko/sequencer/deploy.ml
@@ -51,8 +51,8 @@ let generate ~l1_uri ~sender_pk ~ledger_input ~faucet_aid ~pause_key
         Gql_client.infer_nonce ~logger l1_uri sender_pk >>| Or_error.ok_exn
       in
       let%bind ( `Inner inner_account
-                , `Holder holder_account
-                , `Ethereum_asset_registry registry_account ) =
+               , `Holder holder_account
+               , `Ethereum_asset_registry registry_account ) =
         Sequencer_lib.Deploy.Z.Inner.initial_accounts ()
       in
       let old_ledger_witness, new_ledger, imt_hash, imt =
@@ -150,26 +150,25 @@ let generate ~l1_uri ~sender_pk ~ledger_input ~faucet_aid ~pause_key
             in
             let accounts_diff =
               (0, inner_account) :: (1, holder_account)
-              ::
-              ( Option.to_list registry_account_diff
-              @
-              match faucet_aid with
-              | None ->
-                  []
-              | Some faucet_aid ->
-                  let account =
-                    Account.create faucet_aid Currency.Balance.max_int
-                  in
-                  let location = L.location_of_account ledger faucet_aid in
-                  let () =
-                    match location with
-                    | None ->
-                        L.create_new_account_exn ledger faucet_aid account
-                    | Some location ->
-                        L.set ledger location account
-                  in
-                  let index = L.index_of_account_exn ledger faucet_aid in
-                  [ (index, account) ] )
+              :: ( Option.to_list registry_account_diff
+                 @
+                 match faucet_aid with
+                 | None ->
+                     []
+                 | Some faucet_aid ->
+                     let account =
+                       Account.create faucet_aid Currency.Balance.max_int
+                     in
+                     let location = L.location_of_account ledger faucet_aid in
+                     let () =
+                       match location with
+                       | None ->
+                           L.create_new_account_exn ledger faucet_aid account
+                       | Some location ->
+                           L.set ledger location account
+                     in
+                     let index = L.index_of_account_exn ledger faucet_aid in
+                     [ (index, account) ] )
             in
 
             printf "New ledger hash: %s\n%!"

--- a/src/app/zeko/sequencer/lib/archive.ml
+++ b/src/app/zeko/sequencer/lib/archive.ml
@@ -92,19 +92,41 @@ module Account_update_actions = struct
 end
 
 module Ethereum_withdrawal = struct
+  type asset =
+    { token : string; asset_id : string; params_fields : Field.t list }
+
   type t =
     { recipient : Signature_lib.Public_key.Compressed.t
     ; amount : Currency.Amount.t
+    ; asset : asset option
     }
 
-  let to_yojson { recipient = { x; is_odd }; amount } =
-    `Assoc
+  let to_yojson { recipient = { x; is_odd }; amount; asset } =
+    let fields =
       [ ("recipientX", `String (Field.to_string x))
       ; ("recipientIsOdd", `Bool is_odd)
       ; ( "amount"
-        , `String
-            (Currency.Amount.to_uint64 amount |> Unsigned.UInt64.to_string) )
+        , `String (Currency.Amount.to_uint64 amount |> Unsigned.UInt64.to_string)
+        )
       ]
+    in
+    let fields =
+      match asset with
+      | None ->
+          fields
+      | Some { token; asset_id; params_fields } ->
+          ( "asset"
+          , `Assoc
+              [ ("token", `String token)
+              ; ("assetId", `String asset_id)
+              ; ( "paramsFields"
+                , `List
+                    (List.map params_fields ~f:(fun field ->
+                         `String (Field.to_string field) ) ) )
+              ] )
+          :: fields
+    in
+    `Assoc fields
 
   let of_yojson json =
     let open Yojson.Safe.Util in
@@ -117,6 +139,19 @@ module Ethereum_withdrawal = struct
         ; amount =
             json |> member "amount" |> to_string |> Unsigned.UInt64.of_string
             |> Currency.Amount.of_uint64
+        ; asset =
+            ( match json |> member "asset" with
+            | `Null ->
+                None
+            | asset ->
+                Some
+                  { token = asset |> member "token" |> to_string
+                  ; asset_id = asset |> member "assetId" |> to_string
+                  ; params_fields =
+                      asset |> member "paramsFields" |> to_list
+                      |> List.map ~f:(fun field ->
+                             field |> to_string |> Field.of_string )
+                  } )
         }
     with exn -> Error (Exn.to_string exn)
 end
@@ -152,8 +187,7 @@ module Kvdb = struct
                   ^ Token_id.to_string (Account_id.token_id key) )
               ])
       | Ethereum_withdrawal ->
-          Bigstring.of_string
-            ("ethereum-withdrawal-" ^ Field.to_string key)
+          Bigstring.of_string ("ethereum-withdrawal-" ^ Field.to_string key)
 
     let serialize_value : type k v. (k * v) t -> v -> Bigstring.t =
      fun pair_type value ->
@@ -209,8 +243,7 @@ module Archive = struct
   let store_ethereum_withdrawal t ~aux withdrawal =
     Kvdb.set t Ethereum_withdrawal ~key:aux ~data:withdrawal
 
-  let find_ethereum_withdrawal t ~aux =
-    Kvdb.get t Ethereum_withdrawal ~key:aux
+  let find_ethereum_withdrawal t ~aux = Kvdb.get t Ethereum_withdrawal ~key:aux
 
   let add_actions t ?(height = 0) account_update_id
       (account_update : Account_update.t) transaction_info (account : Account.t)

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -624,6 +624,228 @@ module Withdrawal_request = struct
               Ok forest ) )
 end
 
+module Ethereum_token_withdrawal_request = struct
+  type t =
+    { withdrawal_params : Bridge_state.Withdrawal_params_ethereum_token.t }
+
+  let make_inner_action t withdrawal_params =
+    Snark_params.Tick.run_and_check_exn
+      (let open Snark_params.Tick.Checked.Let_syntax in
+      let%bind params =
+        Snark_params.Tick.exists
+          Bridge_state.Withdrawal_params_ethereum_token.typ ~compute:(fun _ ->
+            withdrawal_params )
+      in
+      let%map action =
+        Bridge_state.withdrawal_action
+          ~chain_l2:Zeko_circuits_config.Inputs.chain_l2
+          ~holder_account_l2:
+            Zeko_circuits_config.Inputs.Ethereum_token.holder_account_l2
+          ~token_owner_l2:
+            (Some Zeko_circuits_config.Inputs.Ethereum_token.token_owner_l2)
+          ~ethereum_asset_id:
+            (Some
+               ( Zeko_circuits_config.Inputs.Ethereum_token
+                 .ethereum_asset_id_high
+               , Zeko_circuits_config.Inputs.Ethereum_token
+                 .ethereum_asset_id_low ) )
+          ~l2_holder_vk_hash:
+            (Snark_params.Tick.constant F.typ
+               t.verification_keys.bridge_ethereum_token_l2 )
+          ~bridge_fee_recipient_l2:
+            (Snark_params.Tick.constant Public_key.Compressed.typ
+               Zeko_circuits_config.Inputs.bridge_fee_recipient_l2 )
+          ~bridge_proof_fee:
+            (Snark_params.Tick.constant Currency.Amount.typ Currency.Amount.zero)
+          (module Bridge_state.Withdrawal_params_ethereum_token)
+          params
+      in
+      Snark_params.Tick.As_prover.read Rollup_state.Inner_action.typ action)
+
+  let make_witness t withdrawal_params =
+    let witness = make_inner_action t withdrawal_params in
+    Bridge.Inner_action_witness.
+      { public_key = Zeko_circuits_config.Inputs.inner_public_key
+      ; witness =
+          { aux = witness.aux
+          ; children =
+              Zkapp_command.Call_forest.map witness.children
+                ~f:Account_update.read_all_proofs_from_disk
+          }
+      }
+
+  let make_inner_receive_witness t amount =
+    Bridge.Inner_receive_ethereum_token.of_serializable
+      ~vk_hash:t.verification_keys.bridge_ethereum_token_l2
+      { public_key =
+          Zeko_circuits_config.Inputs.Ethereum_token.holder_account_l2
+      ; amount
+      }
+
+  let replace_vault_tree ~replacement (forest : precomputed_forest) =
+    match forest with
+    | ( { elt = { calls = debit :: _vault :: rest; _ } as owner_elt; _ } as
+      owner_tree )
+      :: outer_rest ->
+        let replacement =
+          match replacement with
+          | [ replacement ] ->
+              replacement
+          | _ ->
+              failwith
+                "Ethereum token inner-receive proof must contain one tree"
+        in
+        { owner_tree with
+          elt = { owner_elt with calls = debit :: replacement :: rest }
+        }
+        :: outer_rest
+        |> Utils.rehash_forest
+             ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+    | _ ->
+        failwith
+          "Ethereum token withdrawal has an invalid owner/debit/vault forest"
+
+  let precompute_forest t withdrawal_params =
+    try
+      let action = make_inner_action t withdrawal_params in
+      let inner_receive_witness =
+        make_inner_receive_witness t withdrawal_params.custom.base.amount
+      in
+      let _stmt, (inner_receive_body, _, inner_receive_calls) =
+        run_and_check_exn inner_receive_witness
+          Snark_params.Tick.Typ.(Mina_base.Zkapp_statement.typ * V.typ)
+          Bridge_inst_ethereum_token.Rule_bridge_inner_receive.main
+      in
+      let replacement =
+        Zkapp_command.Call_forest.cons
+          ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+          ~calls:inner_receive_calls
+          (Account_update.with_aux
+             ~body:
+               ( match Is_compile_simple_real.is_compile_simple_real with
+               | Some _ ->
+                   inner_receive_body
+               | None ->
+                   { inner_receive_body with authorization_kind = None_given }
+               )
+             ~authorization:Control.Poly.None_given )
+          []
+        |> Zkapp_command.Call_forest.map
+             ~f:Account_update.read_all_proofs_from_disk
+      in
+      let witness =
+        Bridge.Inner_action_witness.of_serializable
+          ~proof_cache_db:(Proof_cache_tag.create_identity_db ())
+          ~vk_hash:t.verification_keys.inner_rules
+          { public_key = Zeko_circuits_config.Inputs.inner_public_key
+          ; witness =
+              { aux = action.aux
+              ; children =
+                  action.children
+                  |> Zkapp_command.Call_forest.map
+                       ~f:Account_update.read_all_proofs_from_disk
+                  |> replace_vault_tree ~replacement
+              }
+          }
+      in
+      let _stmt, (body, _, calls) =
+        run_and_check_exn witness
+          Snark_params.Tick.Typ.(Mina_base.Zkapp_statement.typ * V.typ)
+          Inner_rules_inst.Rule_inner_action_witness_inst.main
+      in
+      Zkapp_command.Call_forest.cons
+        ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 ~calls
+        (Account_update.with_aux
+           ~body:
+             ( match Is_compile_simple_real.is_compile_simple_real with
+             | Some _ ->
+                 body
+             | None ->
+                 { body with authorization_kind = None_given } )
+           ~authorization:Control.Poly.None_given )
+        []
+      |> Zkapp_command.Call_forest.map
+           ~f:Account_update.read_all_proofs_from_disk
+      |> Utils.rehash_forest
+           ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+      |> Or_error.return
+    with exn -> Error (Error.of_exn exn)
+
+  let key withdrawal_params =
+    let (Typ typ) = Bridge_state.Withdrawal_params_ethereum_token.typ in
+    typ.value_to_fields withdrawal_params
+    |> fst
+    |> Random_oracle.hash
+         ~init:(Hash_prefix_create.salt Zeko_constants.bridge_prover_cache)
+    |> Field.to_string
+
+  let f ~t ~logger ({ withdrawal_params } : t) =
+    if not Zeko_circuits_config.Inputs.Ethereum_token.enabled then
+      Or_error.error_string "Ethereum token bridge is not configured"
+    else
+      let%map.Result (_ : precomputed_forest) =
+        precompute_forest t withdrawal_params
+      in
+      let key = key withdrawal_params in
+      ( key
+      , Proofs_memory.prove t.proofs_memory key ~f:(fun () ->
+            let%map result =
+              try_with (fun () ->
+                  let%bind inner_receive_forest =
+                    match%map
+                      Zeko_prover.Client.inner_receive_ethereum_token t.provers
+                        { public_key =
+                            Zeko_circuits_config.Inputs.Ethereum_token
+                            .holder_account_l2
+                        ; amount = withdrawal_params.custom.base.amount
+                        }
+                    with
+                    | Ok ((body, _, calls), proof) ->
+                        Utils.attach_proof_to_forest
+                          ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+                          ~proof_cache_db:t.proof_cache_db ~body ~calls ~proof
+                    | Error error ->
+                        Error.raise error
+                  in
+                  let action = make_inner_action t withdrawal_params in
+                  let witness =
+                    Bridge.Inner_action_witness.
+                      { public_key =
+                          Zeko_circuits_config.Inputs.inner_public_key
+                      ; witness =
+                          { aux = action.aux
+                          ; children =
+                              action.children
+                              |> Zkapp_command.Call_forest.map
+                                   ~f:Account_update.read_all_proofs_from_disk
+                              |> replace_vault_tree
+                                   ~replacement:inner_receive_forest
+                          }
+                      }
+                  in
+                  match%map
+                    Zeko_prover.Client.inner_action_witness t.provers witness
+                  with
+                  | Ok ((body, _, calls), proof) ->
+                      Utils.attach_proof_to_forest
+                        ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+                        ~proof_cache_db:t.proof_cache_db ~body ~calls ~proof
+                      |> Utils.rehash_forest
+                           ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+                  | Error error ->
+                      Error.raise error )
+              >>| Result.map_error ~f:(fun error ->
+                      Error.of_string (Exn.to_string error) )
+            in
+            match result with
+            | Ok forest ->
+                Ok forest
+            | Error error ->
+                [%log warn] "Ethereum token withdrawal proof failed: %s"
+                  (Error.to_string_mach error) ;
+                Error error ) )
+end
+
 module Finalize_deposit = struct
   type t =
     { ase_source : Ase.With_length.Stmt.t
@@ -896,6 +1118,237 @@ module Finalize_deposit = struct
               Error (Error.of_string e)
           | Ok forest ->
               Ok forest ) )
+end
+
+module Finalize_ethereum_token_deposit = struct
+  type t =
+    { ase_source : Ase.With_length.Stmt.t
+    ; check_accepted_init :
+        Bridge_inst_ethereum_token.Check_accepted.Definition.Init.t
+    ; prev_next_deposit : Zeko_util.Checked32.t
+    ; prev_nonce : Zeko_util.Checked32.t
+    ; helper_account_new : Zeko_util.Boolean.t
+    }
+  [@@deriving snarky]
+
+  type t_ =
+    { ase_source : Ase.With_length.Stmt.t
+    ; check_accepted_init :
+        Bridge_inst_ethereum_token.Check_accepted.Definition.Init.t
+    ; prev_next_deposit : Zeko_util.Checked32.t
+    ; prev_nonce : Zeko_util.Checked32.t
+    ; helper_account_new : Zeko_util.Boolean.t
+    ; ase_elems : Field.t list
+    ; check_accepted_elems :
+        Bridge_inst_ethereum_token.Check_accepted.Definition.Elem.t list
+    }
+
+  let deposit_and_rest = function
+    | deposit :: rest ->
+        Ok (deposit, rest)
+    | [] ->
+        Or_error.error_string
+          "Finalize_ethereum_token_deposit: missing deposit witness action"
+
+  let precompute_forest t
+      ({ ase_source
+       ; ase_elems
+       ; check_accepted_init
+       ; check_accepted_elems
+       ; prev_next_deposit
+       ; prev_nonce
+       ; helper_account_new
+       } :
+        t_ ) =
+    let open Or_error.Let_syntax in
+    let%bind deposit, check_accepted_elems =
+      deposit_and_rest check_accepted_elems
+    in
+    let deposit_hash =
+      Zkapp_account.Actions_impl.hash [ Utils.actions_of_outer_action deposit ]
+    in
+    let ase =
+      let target =
+        fold
+          ~init_fn:(Ase.M_with_length.init ~check:None)
+          ~step_fn:Ase.M_with_length.step ~init_typ:Ase.M_with_length.Init.typ
+          ~stmt_typ:Ase.M_with_length.Stmt.typ ~elm_typ:F.typ ase_source
+          ase_elems
+      in
+      Bridge_inst_ethereum_token.Rule_bridge_finalize_deposit.Ase_inst.make
+        ~proof:
+          (Compile_simple.Proof.of_pickles
+             Pickles_types.Nat.(Pickles.Proof.dummy N2.n N2.n ~domain_log2:14) )
+        ~proof_source:ase_source ~proof_target:target ase_source []
+    in
+    let check_accepted =
+      let source : Bridge.Check_accepted_ethereum_token.Stmt.t =
+        { params = check_accepted_init.params
+        ; action_state =
+            Zkapp_account.Actions_impl.push_hash
+              (Rollup_state.Outer_action_state.raw
+                 check_accepted_init.original_action_state )
+              deposit_hash
+            |> Rollup_state.Outer_action_state.unsafe_value_of_field
+        ; deposit_index = check_accepted_init.deposit_index
+        ; n_steps = Zeko_util.Checked32.zero
+        ; is_rejected = false
+        ; is_accepted = false
+        }
+      in
+      let target =
+        fold
+          ~init_fn:
+            (Bridge_inst_ethereum_token.Check_accepted.Definition.init
+               ~check:None )
+          ~step_fn:Bridge_inst_ethereum_token.Check_accepted.Definition.step
+          ~init_typ:
+            Bridge_inst_ethereum_token.Check_accepted.Definition.Init.typ
+          ~stmt_typ:
+            Bridge_inst_ethereum_token.Check_accepted.Definition.Stmt.typ
+          ~elm_typ:Bridge_inst_ethereum_token.Check_accepted.Definition.Elem.typ
+          check_accepted_init check_accepted_elems
+      in
+      Bridge_inst_ethereum_token.Rule_bridge_finalize_deposit
+      .Check_accepted_inst
+      .make
+        ~proof:
+          (Compile_simple.Proof.of_pickles
+             Pickles_types.Nat.(Pickles.Proof.dummy N2.n N2.n ~domain_log2:14) )
+        ~proof_source:source ~proof_target:target check_accepted_init []
+    in
+    let witness : Bridge.Finalize_ethereum_token_deposit.t =
+      { vk_hash = t.verification_keys.bridge_ethereum_token_l2
+      ; public_key =
+          Zeko_circuits_config.Inputs.Ethereum_token.holder_account_l2
+      ; may_use_token =
+          Bridge_inst_ethereum_token.Rule_bridge_finalize_deposit.May_use_token
+          .Parents_own_token
+      ; inner_authorization_kind =
+          Zeko_circuits.Rule_bridge_finalize_deposit.A.None_given
+      ; ase
+      ; check_accepted
+      ; prev_next_deposit
+      ; prev_nonce
+      ; helper_account_new
+      }
+    in
+    try
+      let _stmt, (body, _, calls) =
+        run_and_check_exn witness
+          Snark_params.Tick.Typ.(Mina_base.Zkapp_statement.typ * V.typ)
+          Bridge_inst_ethereum_token.Rule_bridge_finalize_deposit.main
+      in
+      let account_update =
+        Account_update.with_aux
+          ~body:
+            ( match Is_compile_simple_real.is_compile_simple_real with
+            | Some _ ->
+                body
+            | None ->
+                { body with authorization_kind = None_given } )
+          ~authorization:Control.Poly.None_given
+      in
+      Zkapp_command.Call_forest.cons
+        ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 ~calls
+        account_update []
+      |> Zkapp_command.Call_forest.map
+           ~f:Account_update.read_all_proofs_from_disk
+      |> Utils.rehash_forest
+           ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+      |> Or_error.return
+    with exn -> Error (Error.of_exn exn)
+
+  let key
+      ({ ase_source
+       ; check_accepted_init
+       ; prev_next_deposit
+       ; prev_nonce
+       ; helper_account_new
+       ; ase_elems
+       ; check_accepted_elems
+       } :
+        t_ ) =
+    let (Typ typ) = typ in
+    let (Typ check_accepted_elems_typ) =
+      Bridge_inst_ethereum_token.Check_accepted.Definition.Elem.typ
+    in
+    let fields =
+      typ.value_to_fields
+        { ase_source
+        ; check_accepted_init
+        ; prev_next_deposit
+        ; prev_nonce
+        ; helper_account_new
+        }
+      |> fst
+    in
+    let check_accepted_fields =
+      List.concat_map check_accepted_elems ~f:(fun elem ->
+          check_accepted_elems_typ.value_to_fields elem |> fst |> Array.to_list )
+      |> Array.of_list
+    in
+    Array.concat [ fields; Array.of_list ase_elems; check_accepted_fields ]
+    |> Random_oracle.hash
+         ~init:(Hash_prefix_create.salt Zeko_constants.bridge_prover_cache)
+    |> Field.to_string
+
+  let f ~t ~logger (request : t_) =
+    if not Zeko_circuits_config.Inputs.Ethereum_token.enabled then
+      Or_error.error_string "Ethereum token bridge is not configured"
+    else
+      let%map.Result (_ : precomputed_forest) = precompute_forest t request in
+      let key = key request in
+      ( key
+      , Proofs_memory.prove t.proofs_memory key ~f:(fun () ->
+            let%map result =
+              try_with (fun () ->
+                  let deposit, check_accepted_elems =
+                    deposit_and_rest request.check_accepted_elems
+                    |> Or_error.ok_exn
+                  in
+                  let deposit_hash =
+                    Zkapp_account.Actions_impl.hash
+                      [ Utils.actions_of_outer_action deposit ]
+                  in
+                  match%map
+                    Zeko_prover.Client.finalize_ethereum_token_deposit t.provers
+                      ~public_key:
+                        Zeko_circuits_config.Inputs.Ethereum_token
+                        .holder_account_l2
+                      ~may_use_token:
+                        Bridge_inst_ethereum_token.Rule_bridge_finalize_deposit
+                        .May_use_token
+                        .Parents_own_token
+                      ~inner_authorization_kind:
+                        Zeko_circuits.Rule_bridge_finalize_deposit.A.None_given
+                      ~ase:(request.ase_source, request.ase_elems)
+                      ~check_accepted:
+                        ( request.check_accepted_init
+                        , deposit_hash
+                        , check_accepted_elems )
+                      ~prev_next_deposit:request.prev_next_deposit
+                      ~prev_nonce:request.prev_nonce
+                      ~helper_account_new:request.helper_account_new
+                  with
+                  | Error error ->
+                      Error.raise error
+                  | Ok ((body, _, calls), proof) ->
+                      Utils.attach_proof_to_forest
+                        ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+                        ~proof_cache_db:t.proof_cache_db ~body ~calls ~proof
+                      |> Utils.rehash_forest
+                           ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 )
+              >>| Result.map_error ~f:(fun error ->
+                      Error.of_string (Exn.to_string error) )
+            in
+            match result with
+            | Ok forest ->
+                Ok forest
+            | Error error ->
+                [%log warn] "Ethereum token deposit proof failed: %s"
+                  (Error.to_string_mach error) ;
+                Error error ) )
 end
 
 module Finalize_cancelled_deposit = struct

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -557,6 +557,12 @@ module Withdrawal_request = struct
     |> Field.to_string
 
   let f ~t ~logger ({ withdrawal_params; transferrer } : t) =
+    let%bind.Result () =
+      Bridge_state.Ethereum_address.validate_for
+        (Bridge_state.Withdrawal_recipient_domain.of_ethereum_holder_account
+           Zeko_circuits_config.Inputs.ethereum_holder_account_l1 )
+        withdrawal_params.recipient
+    in
     let bridge_fee = Zeko_circuits_config.Inputs.bridge_proof_fee in
     let%bind.Result expected_amount =
       Currency.Amount.add withdrawal_params.amount bridge_fee

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -655,8 +655,11 @@ module Ethereum_token_withdrawal_request = struct
                      ~holder_account_l2:record.vault_public_key
                      ~token_owner_l2:(Some token_owner_l2)
                      ~ethereum_asset_id:
+                       (Some (record.asset_id_high, record.asset_id_low))
+                     ~ethereum_registry_binding:
                        (Some
-                          (record.asset_id_high, record.asset_id_low))
+                          ( record.registry_index
+                          , Asset_registry.Asset_record.commitment record ) )
                      ~l2_holder_vk_hash:
                        (Snark_params.Tick.constant F.typ
                           bridge_ethereum_token_l2_vk_hash )
@@ -826,8 +829,7 @@ module Ethereum_token_withdrawal_request = struct
                   let%bind inner_receive_forest =
                     match%map
                       Zeko_prover.Client.inner_receive_ethereum_token t.provers
-                        { public_key =
-                            asset.record.vault_public_key
+                        { public_key = asset.record.vault_public_key
                         ; asset
                         ; amount = withdrawal_params.custom.base.amount
                         }
@@ -842,8 +844,7 @@ module Ethereum_token_withdrawal_request = struct
                   let action =
                     make_inner_action
                       ~bridge_ethereum_token_l2_vk_hash:
-                        t.verification_keys.bridge_ethereum_token_l2
-                      ~asset
+                        t.verification_keys.bridge_ethereum_token_l2 ~asset
                       withdrawal_params
                   in
                   let witness =
@@ -888,8 +889,7 @@ module Register_ethereum_asset = struct
   type t =
     { old_state : Asset_registry.Registry_state.t
     ; candidate : Asset_registry.Asset_record.t
-    ; existing :
-        (Asset_registry.Asset_record.t * Asset_registry.Path.t) list
+    ; existing : (Asset_registry.Asset_record.t * Asset_registry.Path.t) list
     ; append_path : Asset_registry.Path.t
     }
   [@@deriving yojson]
@@ -900,12 +900,13 @@ module Register_ethereum_asset = struct
 
   let elems ({ existing; _ } : t) :
       Bridge.Ethereum_asset_registry.Scan.Elem.t list =
-    List.map existing ~f:(fun (record, path) ->
-        ({ active = true; record; path } :
-          Bridge.Ethereum_asset_registry.Scan.Elem.t ) )
+    List.map existing
+      ~f:(fun (record, path) : Bridge.Ethereum_asset_registry.Scan.Elem.t ->
+        { active = true; record; path } )
 
   let key request =
-    to_yojson request |> Yojson.Safe.to_string |> Md5.digest_string |> Md5.to_hex
+    to_yojson request |> Yojson.Safe.to_string |> Md5.digest_string
+    |> Md5.to_hex
 
   let f ~t ~logger request =
     if not Zeko_circuits_config.Inputs.Ethereum_assets.enabled then

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -628,46 +628,53 @@ module Ethereum_token_withdrawal_request = struct
   type t =
     { withdrawal_params : Bridge_state.Withdrawal_params_ethereum_token.t }
 
-  let make_inner_action t withdrawal_params =
-    Snark_params.Tick.run_and_check_exn
-      (let open Snark_params.Tick.Checked.Let_syntax in
-      let%bind params =
-        Snark_params.Tick.exists
-          Bridge_state.Withdrawal_params_ethereum_token.typ ~compute:(fun _ ->
-            withdrawal_params )
-      in
-      let%map action =
-        make_checked (fun () ->
-            Run.run_checked
-              (Bridge_state.withdrawal_action
-                 ~chain_l2:Zeko_circuits_config.Inputs.chain_l2
-                 ~holder_account_l2:
-                   Zeko_circuits_config.Inputs.Ethereum_token.holder_account_l2
-                 ~token_owner_l2:
-                   (Some
-                      Zeko_circuits_config.Inputs.Ethereum_token.token_owner_l2 )
-                 ~ethereum_asset_id:
-                   (Some
-                      ( Zeko_circuits_config.Inputs.Ethereum_token
-                        .ethereum_asset_id_high
-                      , Zeko_circuits_config.Inputs.Ethereum_token
-                        .ethereum_asset_id_low ) )
-                 ~l2_holder_vk_hash:
-                   (Snark_params.Tick.constant F.typ
-                      t.verification_keys.bridge_ethereum_token_l2 )
-                 ~bridge_fee_recipient_l2:
-                   (Snark_params.Tick.constant Public_key.Compressed.typ
-                      Zeko_circuits_config.Inputs.bridge_fee_recipient_l2 )
-                 ~bridge_proof_fee:
-                   (Snark_params.Tick.constant Currency.Amount.typ
-                      Currency.Amount.zero )
-                 (module Bridge_state.Withdrawal_params_ethereum_token)
-                 params ) )
-      in
-      Snark_params.Tick.As_prover.read Rollup_state.Inner_action.typ action)
+  let with_stage stage f = try f () with exn -> Exn.reraise exn stage
 
-  let make_witness t withdrawal_params =
-    let witness = make_inner_action t withdrawal_params in
+  let make_inner_action ~bridge_ethereum_token_l2_vk_hash withdrawal_params =
+    with_stage "run checked ERC20 withdrawal action" (fun () ->
+        Snark_params.Tick.run_and_check_exn
+          (let open Snark_params.Tick.Checked.Let_syntax in
+          let%bind params =
+            Snark_params.Tick.exists
+              Bridge_state.Withdrawal_params_ethereum_token.typ
+              ~compute:(fun _ -> withdrawal_params)
+          in
+          let%map action =
+            make_checked (fun () ->
+                Run.run_checked
+                  (Bridge_state.withdrawal_action
+                     ~chain_l2:Zeko_circuits_config.Inputs.chain_l2
+                     ~holder_account_l2:
+                       Zeko_circuits_config.Inputs.Ethereum_token
+                       .holder_account_l2
+                     ~token_owner_l2:
+                       (Some
+                          Zeko_circuits_config.Inputs.Ethereum_token
+                          .token_owner_l2 )
+                     ~ethereum_asset_id:
+                       (Some
+                          ( Zeko_circuits_config.Inputs.Ethereum_token
+                            .ethereum_asset_id_high
+                          , Zeko_circuits_config.Inputs.Ethereum_token
+                            .ethereum_asset_id_low ) )
+                     ~l2_holder_vk_hash:
+                       (Snark_params.Tick.constant F.typ
+                          bridge_ethereum_token_l2_vk_hash )
+                     ~bridge_fee_recipient_l2:
+                       (Snark_params.Tick.constant Public_key.Compressed.typ
+                          Zeko_circuits_config.Inputs.bridge_fee_recipient_l2 )
+                     ~bridge_proof_fee:
+                       (Snark_params.Tick.constant Currency.Amount.typ
+                          Currency.Amount.zero )
+                     (module Bridge_state.Withdrawal_params_ethereum_token)
+                     params ) )
+          in
+          Snark_params.Tick.As_prover.read Rollup_state.Inner_action.typ action) )
+
+  let make_witness ~bridge_ethereum_token_l2_vk_hash withdrawal_params =
+    let witness =
+      make_inner_action ~bridge_ethereum_token_l2_vk_hash withdrawal_params
+    in
     Bridge.Inner_action_witness.
       { public_key = Zeko_circuits_config.Inputs.inner_public_key
       ; witness =
@@ -678,9 +685,9 @@ module Ethereum_token_withdrawal_request = struct
           }
       }
 
-  let make_inner_receive_witness t amount =
+  let make_inner_receive_witness ~bridge_ethereum_token_l2_vk_hash amount =
     Bridge.Inner_receive_ethereum_token.of_serializable
-      ~vk_hash:t.verification_keys.bridge_ethereum_token_l2
+      ~vk_hash:bridge_ethereum_token_l2_vk_hash
       { public_key =
           Zeko_circuits_config.Inputs.Ethereum_token.holder_account_l2
       ; amount
@@ -709,16 +716,24 @@ module Ethereum_token_withdrawal_request = struct
         failwith
           "Ethereum token withdrawal has an invalid owner/debit/vault forest"
 
-  let precompute_forest t withdrawal_params =
+  let precompute_forest_with_vk_hashes ~bridge_ethereum_token_l2_vk_hash
+      ~inner_rules_vk_hash withdrawal_params =
     try
-      let action = make_inner_action t withdrawal_params in
+      let action =
+        with_stage "make ERC20 withdrawal action" (fun () ->
+            make_inner_action ~bridge_ethereum_token_l2_vk_hash
+              withdrawal_params )
+      in
       let inner_receive_witness =
-        make_inner_receive_witness t withdrawal_params.custom.base.amount
+        with_stage "make ERC20 inner-receive witness" (fun () ->
+            make_inner_receive_witness ~bridge_ethereum_token_l2_vk_hash
+              withdrawal_params.custom.base.amount )
       in
       let _stmt, (inner_receive_body, _, inner_receive_calls) =
-        run_and_check_exn inner_receive_witness
-          Snark_params.Tick.Typ.(Mina_base.Zkapp_statement.typ * V.typ)
-          Bridge_inst_ethereum_token.Rule_bridge_inner_receive.main
+        with_stage "check ERC20 inner-receive witness" (fun () ->
+            run_and_check_exn inner_receive_witness
+              Snark_params.Tick.Typ.(Mina_base.Zkapp_statement.typ * V.typ)
+              Bridge_inst_ethereum_token.Rule_bridge_inner_receive.main )
       in
       let replacement =
         Zkapp_command.Call_forest.cons
@@ -738,24 +753,26 @@ module Ethereum_token_withdrawal_request = struct
              ~f:Account_update.read_all_proofs_from_disk
       in
       let witness =
-        Bridge.Inner_action_witness.of_serializable
-          ~proof_cache_db:(Proof_cache_tag.create_identity_db ())
-          ~vk_hash:t.verification_keys.inner_rules
-          { public_key = Zeko_circuits_config.Inputs.inner_public_key
-          ; witness =
-              { aux = action.aux
-              ; children =
-                  action.children
-                  |> Zkapp_command.Call_forest.map
-                       ~f:Account_update.read_all_proofs_from_disk
-                  |> replace_vault_tree ~replacement
-              }
-          }
+        with_stage "make ERC20 inner-action witness" (fun () ->
+            Bridge.Inner_action_witness.of_serializable
+              ~proof_cache_db:(Proof_cache_tag.create_identity_db ())
+              ~vk_hash:inner_rules_vk_hash
+              { public_key = Zeko_circuits_config.Inputs.inner_public_key
+              ; witness =
+                  { aux = action.aux
+                  ; children =
+                      action.children
+                      |> Zkapp_command.Call_forest.map
+                           ~f:Account_update.read_all_proofs_from_disk
+                      |> replace_vault_tree ~replacement
+                  }
+              } )
       in
       let _stmt, (body, _, calls) =
-        run_and_check_exn witness
-          Snark_params.Tick.Typ.(Mina_base.Zkapp_statement.typ * V.typ)
-          Inner_rules_inst.Rule_inner_action_witness_inst.main
+        with_stage "check ERC20 inner-action witness" (fun () ->
+            run_and_check_exn witness
+              Snark_params.Tick.Typ.(Mina_base.Zkapp_statement.typ * V.typ)
+              Inner_rules_inst.Rule_inner_action_witness_inst.main )
       in
       Zkapp_command.Call_forest.cons
         ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 ~calls
@@ -774,6 +791,12 @@ module Ethereum_token_withdrawal_request = struct
            ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
       |> Or_error.return
     with exn -> Error (Error.of_exn exn)
+
+  let precompute_forest t withdrawal_params =
+    precompute_forest_with_vk_hashes
+      ~bridge_ethereum_token_l2_vk_hash:
+        t.verification_keys.bridge_ethereum_token_l2
+      ~inner_rules_vk_hash:t.verification_keys.inner_rules withdrawal_params
 
   let key withdrawal_params =
     let (Typ typ) = Bridge_state.Withdrawal_params_ethereum_token.typ in
@@ -811,7 +834,12 @@ module Ethereum_token_withdrawal_request = struct
                     | Error error ->
                         Error.raise error
                   in
-                  let action = make_inner_action t withdrawal_params in
+                  let action =
+                    make_inner_action
+                      ~bridge_ethereum_token_l2_vk_hash:
+                        t.verification_keys.bridge_ethereum_token_l2
+                      withdrawal_params
+                  in
                   let witness =
                     Bridge.Inner_action_witness.
                       { public_key =

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -626,11 +626,19 @@ end
 
 module Ethereum_token_withdrawal_request = struct
   type t =
-    { withdrawal_params : Bridge_state.Withdrawal_params_ethereum_token.t }
+    { withdrawal_params : Bridge_state.Withdrawal_params_ethereum_token.t
+    ; asset : Bridge_inst_ethereum_token.Registry.Membership_witness.t
+    }
 
   let with_stage stage f = try f () with exn -> Exn.reraise exn stage
 
-  let make_inner_action ~bridge_ethereum_token_l2_vk_hash withdrawal_params =
+  let make_inner_action ~bridge_ethereum_token_l2_vk_hash
+      ~(asset : Bridge_inst_ethereum_token.Registry.Membership_witness.t)
+      withdrawal_params =
+    let record = asset.record in
+    let token_owner_l2 =
+      Account_id.create record.token_owner_l2 Token_id.default
+    in
     with_stage "run checked ERC20 withdrawal action" (fun () ->
         Snark_params.Tick.run_and_check_exn
           (let open Snark_params.Tick.Checked.Let_syntax in
@@ -644,19 +652,11 @@ module Ethereum_token_withdrawal_request = struct
                 Run.run_checked
                   (Bridge_state.withdrawal_action
                      ~chain_l2:Zeko_circuits_config.Inputs.chain_l2
-                     ~holder_account_l2:
-                       Zeko_circuits_config.Inputs.Ethereum_token
-                       .holder_account_l2
-                     ~token_owner_l2:
-                       (Some
-                          Zeko_circuits_config.Inputs.Ethereum_token
-                          .token_owner_l2 )
+                     ~holder_account_l2:record.vault_public_key
+                     ~token_owner_l2:(Some token_owner_l2)
                      ~ethereum_asset_id:
                        (Some
-                          ( Zeko_circuits_config.Inputs.Ethereum_token
-                            .ethereum_asset_id_high
-                          , Zeko_circuits_config.Inputs.Ethereum_token
-                            .ethereum_asset_id_low ) )
+                          (record.asset_id_high, record.asset_id_low))
                      ~l2_holder_vk_hash:
                        (Snark_params.Tick.constant F.typ
                           bridge_ethereum_token_l2_vk_hash )
@@ -671,9 +671,10 @@ module Ethereum_token_withdrawal_request = struct
           in
           Snark_params.Tick.As_prover.read Rollup_state.Inner_action.typ action) )
 
-  let make_witness ~bridge_ethereum_token_l2_vk_hash withdrawal_params =
+  let make_witness ~bridge_ethereum_token_l2_vk_hash ~asset withdrawal_params =
     let witness =
-      make_inner_action ~bridge_ethereum_token_l2_vk_hash withdrawal_params
+      make_inner_action ~bridge_ethereum_token_l2_vk_hash ~asset
+        withdrawal_params
     in
     Bridge.Inner_action_witness.
       { public_key = Zeko_circuits_config.Inputs.inner_public_key
@@ -685,13 +686,12 @@ module Ethereum_token_withdrawal_request = struct
           }
       }
 
-  let make_inner_receive_witness ~bridge_ethereum_token_l2_vk_hash amount =
+  let make_inner_receive_witness ~bridge_ethereum_token_l2_vk_hash
+      ~(asset : Bridge_inst_ethereum_token.Registry.Membership_witness.t) amount
+      =
     Bridge.Inner_receive_ethereum_token.of_serializable
       ~vk_hash:bridge_ethereum_token_l2_vk_hash
-      { public_key =
-          Zeko_circuits_config.Inputs.Ethereum_token.holder_account_l2
-      ; amount
-      }
+      { public_key = asset.record.vault_public_key; asset; amount }
 
   let replace_vault_tree ~replacement (forest : precomputed_forest) =
     match forest with
@@ -717,16 +717,16 @@ module Ethereum_token_withdrawal_request = struct
           "Ethereum token withdrawal has an invalid owner/debit/vault forest"
 
   let precompute_forest_with_vk_hashes ~bridge_ethereum_token_l2_vk_hash
-      ~inner_rules_vk_hash withdrawal_params =
+      ~inner_rules_vk_hash ~asset withdrawal_params =
     try
       let action =
         with_stage "make ERC20 withdrawal action" (fun () ->
-            make_inner_action ~bridge_ethereum_token_l2_vk_hash
+            make_inner_action ~bridge_ethereum_token_l2_vk_hash ~asset
               withdrawal_params )
       in
       let inner_receive_witness =
         with_stage "make ERC20 inner-receive witness" (fun () ->
-            make_inner_receive_witness ~bridge_ethereum_token_l2_vk_hash
+            make_inner_receive_witness ~bridge_ethereum_token_l2_vk_hash ~asset
               withdrawal_params.custom.base.amount )
       in
       let _stmt, (inner_receive_body, _, inner_receive_calls) =
@@ -792,28 +792,33 @@ module Ethereum_token_withdrawal_request = struct
       |> Or_error.return
     with exn -> Error (Error.of_exn exn)
 
-  let precompute_forest t withdrawal_params =
+  let precompute_forest t ~asset withdrawal_params =
     precompute_forest_with_vk_hashes
       ~bridge_ethereum_token_l2_vk_hash:
         t.verification_keys.bridge_ethereum_token_l2
-      ~inner_rules_vk_hash:t.verification_keys.inner_rules withdrawal_params
+      ~inner_rules_vk_hash:t.verification_keys.inner_rules ~asset
+      withdrawal_params
 
-  let key withdrawal_params =
+  let key ~asset withdrawal_params =
     let (Typ typ) = Bridge_state.Withdrawal_params_ethereum_token.typ in
-    typ.value_to_fields withdrawal_params
-    |> fst
+    let (Typ asset_typ) =
+      Bridge_inst_ethereum_token.Registry.Membership_witness.typ
+    in
+    Array.append
+      (typ.value_to_fields withdrawal_params |> fst)
+      (asset_typ.value_to_fields asset |> fst)
     |> Random_oracle.hash
          ~init:(Hash_prefix_create.salt Zeko_constants.bridge_prover_cache)
     |> Field.to_string
 
-  let f ~t ~logger ({ withdrawal_params } : t) =
-    if not Zeko_circuits_config.Inputs.Ethereum_token.enabled then
+  let f ~t ~logger ({ withdrawal_params; asset } : t) =
+    if not Zeko_circuits_config.Inputs.Ethereum_assets.enabled then
       Or_error.error_string "Ethereum token bridge is not configured"
     else
       let%map.Result (_ : precomputed_forest) =
-        precompute_forest t withdrawal_params
+        precompute_forest t ~asset withdrawal_params
       in
-      let key = key withdrawal_params in
+      let key = key ~asset withdrawal_params in
       ( key
       , Proofs_memory.prove t.proofs_memory key ~f:(fun () ->
             let%map result =
@@ -822,8 +827,8 @@ module Ethereum_token_withdrawal_request = struct
                     match%map
                       Zeko_prover.Client.inner_receive_ethereum_token t.provers
                         { public_key =
-                            Zeko_circuits_config.Inputs.Ethereum_token
-                            .holder_account_l2
+                            asset.record.vault_public_key
+                        ; asset
                         ; amount = withdrawal_params.custom.base.amount
                         }
                     with
@@ -838,6 +843,7 @@ module Ethereum_token_withdrawal_request = struct
                     make_inner_action
                       ~bridge_ethereum_token_l2_vk_hash:
                         t.verification_keys.bridge_ethereum_token_l2
+                      ~asset
                       withdrawal_params
                   in
                   let witness =
@@ -876,6 +882,62 @@ module Ethereum_token_withdrawal_request = struct
                 [%log warn] "Ethereum token withdrawal proof failed: %s"
                   (Error.to_string_mach error) ;
                 Error error ) )
+end
+
+module Register_ethereum_asset = struct
+  type t =
+    { old_state : Asset_registry.Registry_state.t
+    ; candidate : Asset_registry.Asset_record.t
+    ; existing :
+        (Asset_registry.Asset_record.t * Asset_registry.Path.t) list
+    ; append_path : Asset_registry.Path.t
+    }
+  [@@deriving yojson]
+
+  let init ({ old_state; candidate; _ } : t) :
+      Bridge.Ethereum_asset_registry.Scan.Init.t =
+    { old_state; candidate }
+
+  let elems ({ existing; _ } : t) :
+      Bridge.Ethereum_asset_registry.Scan.Elem.t list =
+    List.map existing ~f:(fun (record, path) ->
+        ({ active = true; record; path } :
+          Bridge.Ethereum_asset_registry.Scan.Elem.t ) )
+
+  let key request =
+    to_yojson request |> Yojson.Safe.to_string |> Md5.digest_string |> Md5.to_hex
+
+  let f ~t ~logger request =
+    if not Zeko_circuits_config.Inputs.Ethereum_assets.enabled then
+      Or_error.error_string "Ethereum asset registry is not configured"
+    else
+      let key = key request in
+      Ok
+        ( key
+        , Proofs_memory.prove t.proofs_memory key ~f:(fun () ->
+              let%map result =
+                try_with (fun () ->
+                    match%map
+                      Zeko_prover.Client.register_ethereum_asset t.provers
+                        ~init:(init request) ~elems:(elems request)
+                        ~append_path:request.append_path
+                    with
+                    | Ok ((body, _, calls), proof) ->
+                        Utils.attach_proof_to_forest
+                          ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+                          ~proof_cache_db:t.proof_cache_db ~body ~calls ~proof
+                    | Error error ->
+                        Error.raise error )
+                >>| Result.map_error ~f:(fun error ->
+                        Error.of_string (Exn.to_string error) )
+              in
+              match result with
+              | Ok forest ->
+                  Ok forest
+              | Error error ->
+                  [%log warn] "Ethereum asset registration proof failed: %s"
+                    (Error.to_string_hum error) ;
+                  Error error ) )
 end
 
 module Finalize_deposit = struct
@@ -962,6 +1024,7 @@ module Finalize_deposit = struct
     let witness : Bridge.Finalize_deposit.t =
       { vk_hash = t.verification_keys.bridge_mina_l2
       ; public_key = Zeko_circuits_config.Inputs.holder_account_l2
+      ; asset = ()
       ; may_use_token =
           Bridge_inst_mina.Rule_bridge_finalize_deposit.May_use_token.No
       ; inner_authorization_kind =
@@ -1157,6 +1220,7 @@ module Finalize_ethereum_token_deposit = struct
     { ase_source : Ase.With_length.Stmt.t
     ; check_accepted_init :
         Bridge_inst_ethereum_token.Check_accepted.Definition.Init.t
+    ; asset : Bridge_inst_ethereum_token.Registry.Membership_witness.t
     ; prev_next_deposit : Zeko_util.Checked32.t
     ; prev_nonce : Zeko_util.Checked32.t
     ; helper_account_new : Zeko_util.Boolean.t
@@ -1167,6 +1231,7 @@ module Finalize_ethereum_token_deposit = struct
     { ase_source : Ase.With_length.Stmt.t
     ; check_accepted_init :
         Bridge_inst_ethereum_token.Check_accepted.Definition.Init.t
+    ; asset : Bridge_inst_ethereum_token.Registry.Membership_witness.t
     ; prev_next_deposit : Zeko_util.Checked32.t
     ; prev_nonce : Zeko_util.Checked32.t
     ; helper_account_new : Zeko_util.Boolean.t
@@ -1187,6 +1252,7 @@ module Finalize_ethereum_token_deposit = struct
        ; ase_elems
        ; check_accepted_init
        ; check_accepted_elems
+       ; asset
        ; prev_next_deposit
        ; prev_nonce
        ; helper_account_new
@@ -1251,8 +1317,8 @@ module Finalize_ethereum_token_deposit = struct
     in
     let witness : Bridge.Finalize_ethereum_token_deposit.t =
       { vk_hash = t.verification_keys.bridge_ethereum_token_l2
-      ; public_key =
-          Zeko_circuits_config.Inputs.Ethereum_token.holder_account_l2
+      ; public_key = asset.record.vault_public_key
+      ; asset
       ; may_use_token =
           Bridge_inst_ethereum_token.Rule_bridge_finalize_deposit.May_use_token
           .Parents_own_token
@@ -1294,6 +1360,7 @@ module Finalize_ethereum_token_deposit = struct
   let key
       ({ ase_source
        ; check_accepted_init
+       ; asset
        ; prev_next_deposit
        ; prev_nonce
        ; helper_account_new
@@ -1309,6 +1376,7 @@ module Finalize_ethereum_token_deposit = struct
       typ.value_to_fields
         { ase_source
         ; check_accepted_init
+        ; asset
         ; prev_next_deposit
         ; prev_nonce
         ; helper_account_new
@@ -1326,7 +1394,7 @@ module Finalize_ethereum_token_deposit = struct
     |> Field.to_string
 
   let f ~t ~logger (request : t_) =
-    if not Zeko_circuits_config.Inputs.Ethereum_token.enabled then
+    if not Zeko_circuits_config.Inputs.Ethereum_assets.enabled then
       Or_error.error_string "Ethereum token bridge is not configured"
     else
       let%map.Result (_ : precomputed_forest) = precompute_forest t request in
@@ -1345,9 +1413,8 @@ module Finalize_ethereum_token_deposit = struct
                   in
                   match%map
                     Zeko_prover.Client.finalize_ethereum_token_deposit t.provers
-                      ~public_key:
-                        Zeko_circuits_config.Inputs.Ethereum_token
-                        .holder_account_l2
+                      ~public_key:request.asset.record.vault_public_key
+                      ~asset:request.asset
                       ~may_use_token:
                         Bridge_inst_ethereum_token.Rule_bridge_finalize_deposit
                         .May_use_token

--- a/src/app/zeko/sequencer/lib/bridge_prover.ml
+++ b/src/app/zeko/sequencer/lib/bridge_prover.ml
@@ -637,28 +637,32 @@ module Ethereum_token_withdrawal_request = struct
             withdrawal_params )
       in
       let%map action =
-        Bridge_state.withdrawal_action
-          ~chain_l2:Zeko_circuits_config.Inputs.chain_l2
-          ~holder_account_l2:
-            Zeko_circuits_config.Inputs.Ethereum_token.holder_account_l2
-          ~token_owner_l2:
-            (Some Zeko_circuits_config.Inputs.Ethereum_token.token_owner_l2)
-          ~ethereum_asset_id:
-            (Some
-               ( Zeko_circuits_config.Inputs.Ethereum_token
-                 .ethereum_asset_id_high
-               , Zeko_circuits_config.Inputs.Ethereum_token
-                 .ethereum_asset_id_low ) )
-          ~l2_holder_vk_hash:
-            (Snark_params.Tick.constant F.typ
-               t.verification_keys.bridge_ethereum_token_l2 )
-          ~bridge_fee_recipient_l2:
-            (Snark_params.Tick.constant Public_key.Compressed.typ
-               Zeko_circuits_config.Inputs.bridge_fee_recipient_l2 )
-          ~bridge_proof_fee:
-            (Snark_params.Tick.constant Currency.Amount.typ Currency.Amount.zero)
-          (module Bridge_state.Withdrawal_params_ethereum_token)
-          params
+        make_checked (fun () ->
+            Run.run_checked
+              (Bridge_state.withdrawal_action
+                 ~chain_l2:Zeko_circuits_config.Inputs.chain_l2
+                 ~holder_account_l2:
+                   Zeko_circuits_config.Inputs.Ethereum_token.holder_account_l2
+                 ~token_owner_l2:
+                   (Some
+                      Zeko_circuits_config.Inputs.Ethereum_token.token_owner_l2 )
+                 ~ethereum_asset_id:
+                   (Some
+                      ( Zeko_circuits_config.Inputs.Ethereum_token
+                        .ethereum_asset_id_high
+                      , Zeko_circuits_config.Inputs.Ethereum_token
+                        .ethereum_asset_id_low ) )
+                 ~l2_holder_vk_hash:
+                   (Snark_params.Tick.constant F.typ
+                      t.verification_keys.bridge_ethereum_token_l2 )
+                 ~bridge_fee_recipient_l2:
+                   (Snark_params.Tick.constant Public_key.Compressed.typ
+                      Zeko_circuits_config.Inputs.bridge_fee_recipient_l2 )
+                 ~bridge_proof_fee:
+                   (Snark_params.Tick.constant Currency.Amount.typ
+                      Currency.Amount.zero )
+                 (module Bridge_state.Withdrawal_params_ethereum_token)
+                 params ) )
       in
       Snark_params.Tick.As_prover.read Rollup_state.Inner_action.typ action)
 

--- a/src/app/zeko/sequencer/lib/committer.ml
+++ b/src/app/zeko/sequencer/lib/committer.ml
@@ -93,7 +93,7 @@ let prove_commit ~logger ~proof_cache_db ~provers ~(executor : Executor.t)
   in
   let old_inner_acc, old_inner_acc_path = get_inner_acc old_inner_ledger in
   let new_inner_acc, new_inner_acc_path = get_inner_acc new_inner_ledger in
-  let ethereum_asset_registry_state ledger =
+  let ethereum_asset_registry_account ledger =
     if Zeko_circuits_config.Inputs.Ethereum_assets.enabled then
       let account_id =
         Account_id.create
@@ -102,23 +102,170 @@ let prove_commit ~logger ~proof_cache_db ~provers ~(executor : Executor.t)
       in
       let index = Sparse_ledger.find_index_exn ledger account_id in
       let account = Sparse_ledger.get_exn ledger index in
-      let app_state =
-        (Option.value_exn account.zkapp).app_state |> Zkapp_state.V.to_list
+      let path =
+        Sparse_ledger.path_exn ledger index
+        |> List.map ~f:(function
+             | `Left hash ->
+                 ( { hash_other = hash; is_right = false }
+                   : Outer_rules_inst.Rule_commit_inst.Registry_path.Step.t )
+             | `Right hash ->
+                 { hash_other = hash; is_right = true } )
       in
-      ( List.nth_exn app_state 0
-      , List.nth_exn app_state 1
-      , List.nth_exn app_state 2 )
-    else (Field.zero, Field.zero, Field.zero)
+      let state =
+        (Option.value_exn account.zkapp).app_state
+        |> Asset_registry.Registry_state.value_of_app_state
+      in
+      (account, path, state)
+    else
+      let path =
+        List.init Zeko_constants.constraint_constants.ledger_depth
+          ~f:(fun _ : Outer_rules_inst.Rule_commit_inst.Registry_path.Step.t ->
+            { hash_other = Field.zero; is_right = false } )
+      in
+      ( Account.empty
+      , path
+      , { Asset_registry.Registry_state.root = Field.zero
+        ; leaf_count = Zeko_util.Checked32.zero
+        ; schema_version = Zeko_util.Checked32.zero
+        } )
   in
-  let ( old_ethereum_asset_registry_root
-      , old_ethereum_asset_registry_count
-      , old_ethereum_asset_registry_schema ) =
-    ethereum_asset_registry_state old_inner_ledger
+  let ( old_ethereum_asset_registry_acc
+      , old_ethereum_asset_registry_path
+      , old_ethereum_asset_registry_state ) =
+    ethereum_asset_registry_account old_inner_ledger
   in
-  let ( ethereum_asset_registry_root
-      , ethereum_asset_registry_count
-      , ethereum_asset_registry_schema ) =
-    ethereum_asset_registry_state new_inner_ledger
+  let ( new_ethereum_asset_registry_acc
+      , new_ethereum_asset_registry_path
+      , ethereum_asset_registry_state ) =
+    ethereum_asset_registry_account new_inner_ledger
+  in
+  let ethereum_asset_registration =
+    let module Registration =
+      Outer_rules_inst.Rule_commit_inst.Registration_witness
+    in
+    let empty_path () =
+      List.init Zeko_constants.constraint_constants.ledger_depth
+        ~f:(fun _ : Outer_rules_inst.Rule_commit_inst.Registry_path.Step.t ->
+          { hash_other = Field.zero; is_right = false } )
+    in
+    let dummy_candidate : Asset_registry.Asset_record.t =
+      { schema_version = Zeko_util.Checked32.zero
+      ; registry_index = Zeko_util.Checked32.zero
+      ; asset_id_high = Field.zero
+      ; asset_id_low = Field.zero
+      ; ethereum_token_address = Field.zero
+      ; token_owner_l2 = Signature_lib.Public_key.Compressed.empty
+      ; token_id_l2 = Token_id.default
+      ; decimals = Zeko_util.Checked32.zero
+      ; inventory_cap = Currency.Amount.zero
+      ; mft_standard_vk_id = Field.zero
+      ; vault_public_key = Signature_lib.Public_key.Compressed.empty
+      ; universal_bridge_vk_id = Field.zero
+      }
+    in
+    let dummy () : Registration.t =
+      { did_append = false
+      ; candidate = dummy_candidate
+      ; append_path =
+          List.init Zeko_constants.Ethereum_asset_registry.depth ~f:(fun _ ->
+              Field.zero )
+      ; token_owner_acc = Account.empty
+      ; token_owner_path = empty_path ()
+      ; admin_acc = Account.empty
+      ; admin_path = empty_path ()
+      ; vault_acc = Account.empty
+      ; vault_path = empty_path ()
+      ; circulation_acc = Account.empty
+      ; circulation_path = empty_path ()
+      }
+    in
+    if not Zeko_circuits_config.Inputs.Ethereum_assets.enabled then dummy ()
+    else
+      let old_count =
+        Zeko_util.Checked32.to_int old_ethereum_asset_registry_state.leaf_count
+      in
+      let new_count =
+        Zeko_util.Checked32.to_int ethereum_asset_registry_state.leaf_count
+      in
+      match new_count - old_count with
+      | 0 ->
+          dummy ()
+      | 1 ->
+          let candidate =
+            Ethereum_settlement_export.registry_records_from_archive ~archive
+            |> Fn.flip List.nth_exn old_count
+          in
+          let account_opening account_id =
+            let index =
+              Sparse_ledger.find_index_exn new_inner_ledger account_id
+            in
+            let account = Sparse_ledger.get_exn new_inner_ledger index in
+            let path =
+              Sparse_ledger.path_exn new_inner_ledger index
+              |> List.map ~f:(function
+                   | `Left hash ->
+                       ( { hash_other = hash; is_right = false }
+                         : Outer_rules_inst.Rule_commit_inst.Registry_path.Step
+                           .t )
+                   | `Right hash ->
+                       { hash_other = hash; is_right = true } )
+            in
+            (account, path)
+          in
+          let owner_id =
+            Account_id.create candidate.token_owner_l2 Token_id.default
+          in
+          let token_owner_acc, token_owner_path = account_opening owner_id in
+          let owner_state =
+            (Option.value_exn token_owner_acc.zkapp).app_state
+            |> Zkapp_state.V.to_list
+          in
+          let admin_public_key =
+            let (Typ typ) = Signature_lib.Public_key.Compressed.typ in
+            typ.value_of_fields
+              ( [| List.nth_exn owner_state 1; List.nth_exn owner_state 2 |]
+              , typ.constraint_system_auxiliary () )
+          in
+          let admin_acc, admin_path =
+            Account_id.create admin_public_key Token_id.default
+            |> account_opening
+          in
+          let vault_acc, vault_path =
+            Account_id.create candidate.vault_public_key candidate.token_id_l2
+            |> account_opening
+          in
+          let circulation_acc, circulation_path =
+            Account_id.create candidate.token_owner_l2 candidate.token_id_l2
+            |> account_opening
+          in
+          { did_append = true
+          ; candidate
+          ; append_path =
+              (let records =
+                 Ethereum_settlement_export.registry_records_from_archive
+                   ~archive
+               in
+               let tree =
+                 List.take records old_count
+                 |> List.fold
+                      ~init:(Asset_registry.Merkle_list.empty ())
+                      ~f:Asset_registry.Merkle_list.append_exn
+               in
+               Asset_registry.Merkle_list.path tree ~index:old_count )
+          ; token_owner_acc
+          ; token_owner_path
+          ; admin_acc
+          ; admin_path
+          ; vault_acc
+          ; vault_path
+          ; circulation_acc
+          ; circulation_path
+          }
+      | delta ->
+          failwithf
+            "PoC settlement supports at most one Ethereum asset registration \
+             per commit, observed count delta %d"
+            delta ()
   in
   let%bind outer_state, inner_ase_source, emergency_mode =
     let%map outer_account =
@@ -218,8 +365,9 @@ let prove_commit ~logger ~proof_cache_db ~provers ~(executor : Executor.t)
       Zeko_prover.Client.outer_commit provers ~txn_snark ~public_key:zkapp_pk
         ~inner_ase_source ~new_inner_actions ~old_inner_acc ~old_inner_acc_path
         ~new_inner_acc ~new_inner_acc_path ~unprocessed_actions ~da_multisig
-        ~slot_range ~emergency_mode ~ethereum_asset_registry_root
-        ~ethereum_asset_registry_count ~ethereum_asset_registry_schema
+        ~slot_range ~emergency_mode ~old_ethereum_asset_registry_acc
+        ~old_ethereum_asset_registry_path ~new_ethereum_asset_registry_acc
+        ~new_ethereum_asset_registry_path ~ethereum_asset_registration
     in
     let%map settlement_export =
       match Is_compile_simple_real.is_compile_simple_real with
@@ -239,12 +387,20 @@ let prove_commit ~logger ~proof_cache_db ~provers ~(executor : Executor.t)
             ?asset_registry_batch:
               ( if Zeko_circuits_config.Inputs.Ethereum_assets.enabled then
                 Ethereum_settlement_export.asset_registry_batch_json ~archive
-                  ~old_root:old_ethereum_asset_registry_root
-                  ~old_count:old_ethereum_asset_registry_count
-                  ~old_schema:old_ethereum_asset_registry_schema
-                  ~new_root:ethereum_asset_registry_root
-                  ~new_count:ethereum_asset_registry_count
-                  ~new_schema:ethereum_asset_registry_schema
+                  ~old_root:old_ethereum_asset_registry_state.root
+                  ~old_count:
+                    (Zeko_util.Checked32.to_field
+                       old_ethereum_asset_registry_state.leaf_count )
+                  ~old_schema:
+                    (Zeko_util.Checked32.to_field
+                       old_ethereum_asset_registry_state.schema_version )
+                  ~new_root:ethereum_asset_registry_state.root
+                  ~new_count:
+                    (Zeko_util.Checked32.to_field
+                       ethereum_asset_registry_state.leaf_count )
+                  ~new_schema:
+                    (Zeko_util.Checked32.to_field
+                       ethereum_asset_registry_state.schema_version )
               else None )
           >>| Option.some
     in

--- a/src/app/zeko/sequencer/lib/committer.ml
+++ b/src/app/zeko/sequencer/lib/committer.ml
@@ -93,6 +93,33 @@ let prove_commit ~logger ~proof_cache_db ~provers ~(executor : Executor.t)
   in
   let old_inner_acc, old_inner_acc_path = get_inner_acc old_inner_ledger in
   let new_inner_acc, new_inner_acc_path = get_inner_acc new_inner_ledger in
+  let ethereum_asset_registry_state ledger =
+    if Zeko_circuits_config.Inputs.Ethereum_assets.enabled then
+      let account_id =
+        Account_id.create
+          Zeko_circuits_config.Inputs.Ethereum_assets.registry_public_key
+          Token_id.default
+      in
+      let index = Sparse_ledger.find_index_exn ledger account_id in
+      let account = Sparse_ledger.get_exn ledger index in
+      let app_state =
+        (Option.value_exn account.zkapp).app_state |> Zkapp_state.V.to_list
+      in
+      ( List.nth_exn app_state 0
+      , List.nth_exn app_state 1
+      , List.nth_exn app_state 2 )
+    else (Field.zero, Field.zero, Field.zero)
+  in
+  let ( old_ethereum_asset_registry_root
+      , old_ethereum_asset_registry_count
+      , old_ethereum_asset_registry_schema ) =
+    ethereum_asset_registry_state old_inner_ledger
+  in
+  let ( ethereum_asset_registry_root
+      , ethereum_asset_registry_count
+      , ethereum_asset_registry_schema ) =
+    ethereum_asset_registry_state new_inner_ledger
+  in
   let%bind outer_state, inner_ase_source, emergency_mode =
     let%map outer_account =
       Gql_client.infer_state ~logger l1_uri ~zkapp_pk
@@ -191,7 +218,8 @@ let prove_commit ~logger ~proof_cache_db ~provers ~(executor : Executor.t)
       Zeko_prover.Client.outer_commit provers ~txn_snark ~public_key:zkapp_pk
         ~inner_ase_source ~new_inner_actions ~old_inner_acc ~old_inner_acc_path
         ~new_inner_acc ~new_inner_acc_path ~unprocessed_actions ~da_multisig
-        ~slot_range ~emergency_mode
+        ~slot_range ~emergency_mode ~ethereum_asset_registry_root
+        ~ethereum_asset_registry_count ~ethereum_asset_registry_schema
     in
     let%map settlement_export =
       match Is_compile_simple_real.is_compile_simple_real with
@@ -208,6 +236,16 @@ let prove_commit ~logger ~proof_cache_db ~provers ~(executor : Executor.t)
             ~inner_action_batch:
               (Ethereum_settlement_export.inner_action_batch_json ~archive
                  new_inner_action_records )
+            ?asset_registry_batch:
+              ( if Zeko_circuits_config.Inputs.Ethereum_assets.enabled then
+                Ethereum_settlement_export.asset_registry_batch_json ~archive
+                  ~old_root:old_ethereum_asset_registry_root
+                  ~old_count:old_ethereum_asset_registry_count
+                  ~old_schema:old_ethereum_asset_registry_schema
+                  ~new_root:ethereum_asset_registry_root
+                  ~new_count:ethereum_asset_registry_count
+                  ~new_schema:ethereum_asset_registry_schema
+              else None )
           >>| Option.some
     in
     (* see #286 *)

--- a/src/app/zeko/sequencer/lib/deploy.ml
+++ b/src/app/zeko/sequencer/lib/deploy.ml
@@ -71,10 +71,8 @@ module Z = struct
       let%map registry_vk =
         if Zeko_circuits_config.Inputs.Ethereum_assets.enabled then
           Compile_simple.Verification_key.of_tag
-            (Lazy.force
-               Bridge_inst_ethereum_token.Registry.registry_tag )
-          |> Promise.to_deferred
-          >>| Option.some
+            (Lazy.force Bridge_inst_ethereum_token.Registry.registry_tag)
+          |> Promise.to_deferred >>| Option.some
         else return None
       in
       let inner_account =
@@ -137,16 +135,14 @@ module Z = struct
               ; leaf_count = Zeko_util.Checked32.of_int 0
               ; schema_version =
                   Zeko_circuits_config.Inputs.Ethereum_assets
-                    .registry_schema_version
+                  .registry_schema_version
               }
             in
             { Account.empty with
               public_key =
                 Zeko_circuits_config.Inputs.Ethereum_assets.registry_public_key
             ; permissions =
-                ( if
-                  Option.is_some
-                    Is_compile_simple_real.is_compile_simple_real
+                ( if Option.is_some Is_compile_simple_real.is_compile_simple_real
                 then proof_permissions_with_unconditional_access
                 else none_permissions )
             ; zkapp =
@@ -289,8 +285,8 @@ let deploy_holder_exn ~signature_kind ~(signer : Keypair.t)
   let%map _, `Holder holder_update, _ =
     L.with_ephemeral_ledger ~depth:35 ~f:(fun ledger ->
         let%bind ( `Inner inner_account
-                  , `Holder holder_account
-                  , `Ethereum_asset_registry _ ) =
+                 , `Holder holder_account
+                 , `Ethereum_asset_registry _ ) =
           Z.Inner.initial_accounts ()
         in
         List.iter [ inner_account; holder_account ] ~f:(fun acc ->
@@ -363,8 +359,8 @@ let deploy_token_owner_exn ~signature_kind ~(signer : Keypair.t)
   let%map _, _, `Token_owner token_owner_update =
     L.with_ledger ~depth:35 ~f:(fun ledger ->
         let%bind ( `Inner inner_account
-                  , `Holder holder_account
-                  , `Ethereum_asset_registry _ ) =
+                 , `Holder holder_account
+                 , `Ethereum_asset_registry _ ) =
           Z.Inner.initial_accounts ()
         in
         List.iter [ inner_account; holder_account ] ~f:(fun acc ->

--- a/src/app/zeko/sequencer/lib/deploy.ml
+++ b/src/app/zeko/sequencer/lib/deploy.ml
@@ -27,6 +27,13 @@ module Z = struct
     ; access = Proof
     }
 
+  (* Mina checks [access] even for precondition-only account updates.  Zeko
+     circuits use [None_given] calls to authenticate account state without
+     mutating it, so these accounts must admit that read path.  The individual
+     mutation permissions remain unchanged. *)
+  let proof_permissions_with_unconditional_access : Permissions.t =
+    { proof_permissions with access = None }
+
   let none_permissions : Permissions.t =
     { edit_state = None
     ; send = None
@@ -78,7 +85,7 @@ module Z = struct
             ( if
               (* see #286 *)
               Option.is_some Is_compile_simple_real.is_compile_simple_real
-            then { proof_permissions with access = None }
+            then proof_permissions_with_unconditional_access
             else none_permissions )
         ; zkapp =
             Some
@@ -140,7 +147,7 @@ module Z = struct
                 ( if
                   Option.is_some
                     Is_compile_simple_real.is_compile_simple_real
-                then proof_permissions
+                then proof_permissions_with_unconditional_access
                 else none_permissions )
             ; zkapp =
                 Some
@@ -207,7 +214,7 @@ module Z = struct
               ( if
                 (* see #286 *)
                 Option.is_some Is_compile_simple_real.is_compile_simple_real
-              then { proof_permissions with access = None }
+              then proof_permissions_with_unconditional_access
               else none_permissions )
         }
       in
@@ -232,7 +239,7 @@ module Z = struct
               ( if
                 (* see #286 *)
                 Option.is_some Is_compile_simple_real.is_compile_simple_real
-              then { proof_permissions with access = None }
+              then proof_permissions_with_unconditional_access
               else none_permissions )
         }
       in

--- a/src/app/zeko/sequencer/lib/deploy.ml
+++ b/src/app/zeko/sequencer/lib/deploy.ml
@@ -56,10 +56,19 @@ module Z = struct
         Compile_simple.Verification_key.of_tag (Lazy.force Inner_rules_inst.tag)
         |> Promise.to_deferred
       in
-      let%map holder_vk =
+      let%bind holder_vk =
         Compile_simple.Verification_key.of_tag
           (Lazy.force Bridge_inst_mina.System_L2.tag)
         |> Promise.to_deferred
+      in
+      let%map registry_vk =
+        if Zeko_circuits_config.Inputs.Ethereum_assets.enabled then
+          Compile_simple.Verification_key.of_tag
+            (Lazy.force
+               Bridge_inst_ethereum_token.Registry.registry_tag )
+          |> Promise.to_deferred
+          >>| Option.some
+        else return None
       in
       let inner_account =
         { Account.empty with
@@ -114,7 +123,48 @@ module Z = struct
               }
         }
       in
-      (`Inner inner_account, `Holder holder_account)
+      let registry_account =
+        Option.map registry_vk ~f:(fun registry_vk ->
+            let registry_state : Asset_registry.Registry_state.t =
+              { root = Asset_registry.Merkle_list.empty_root
+              ; leaf_count = Zeko_util.Checked32.of_int 0
+              ; schema_version =
+                  Zeko_circuits_config.Inputs.Ethereum_assets
+                    .registry_schema_version
+              }
+            in
+            { Account.empty with
+              public_key =
+                Zeko_circuits_config.Inputs.Ethereum_assets.registry_public_key
+            ; permissions =
+                ( if
+                  Option.is_some
+                    Is_compile_simple_real.is_compile_simple_real
+                then proof_permissions
+                else none_permissions )
+            ; zkapp =
+                Some
+                  { Zkapp_account.default with
+                    app_state =
+                      Utils.value_to_zkapp_state Fn.id Field.zero
+                        Asset_registry.Registry_state.typ registry_state
+                  ; verification_key =
+                      Some
+                        (Verification_key_wire.Stable.Latest.M.of_binable
+                           ( match
+                               Is_compile_simple_real.is_compile_simple_real
+                             with
+                           | Some eq ->
+                               let _, vk_eq = Type_equal.detuple2 eq in
+                               Type_equal.conv vk_eq registry_vk
+                           | None ->
+                               Pickles.Side_loaded.Verification_key.dummy ) )
+                  }
+            } )
+      in
+      ( `Inner inner_account
+      , `Holder holder_account
+      , `Ethereum_asset_registry registry_account )
   end
 
   module Outer = struct
@@ -231,7 +281,9 @@ let deploy_holder_exn ~signature_kind ~(signer : Keypair.t)
     ~(account_creation_fee : Currency.Fee.t) () =
   let%map _, `Holder holder_update, _ =
     L.with_ephemeral_ledger ~depth:35 ~f:(fun ledger ->
-        let%bind `Inner inner_account, `Holder holder_account =
+        let%bind ( `Inner inner_account
+                  , `Holder holder_account
+                  , `Ethereum_asset_registry _ ) =
           Z.Inner.initial_accounts ()
         in
         List.iter [ inner_account; holder_account ] ~f:(fun acc ->
@@ -303,7 +355,9 @@ let deploy_token_owner_exn ~signature_kind ~(signer : Keypair.t)
     ~(nonce : Account.Nonce.t) ~(account_creation_fee : Currency.Fee.t) () =
   let%map _, _, `Token_owner token_owner_update =
     L.with_ledger ~depth:35 ~f:(fun ledger ->
-        let%bind `Inner inner_account, `Holder holder_account =
+        let%bind ( `Inner inner_account
+                  , `Holder holder_account
+                  , `Ethereum_asset_registry _ ) =
           Z.Inner.initial_accounts ()
         in
         List.iter [ inner_account; holder_account ] ~f:(fun acc ->

--- a/src/app/zeko/sequencer/lib/ethereum_settlement_export.ml
+++ b/src/app/zeko/sequencer/lib/ethereum_settlement_export.ml
@@ -84,7 +84,9 @@ let fields_json fields =
   |> fun fields -> `List fields
 
 let padded_hex_digits field =
-  let digits = field_to_hex field |> String.chop_prefix_if_exists ~prefix:"0x" in
+  let digits =
+    field_to_hex field |> String.chop_prefix_if_exists ~prefix:"0x"
+  in
   String.make (64 - String.length digits) '0' ^ digits
 
 let field_suffix_hex field length =
@@ -95,6 +97,27 @@ let asset_id_hex high low =
   "0x" ^ field_suffix_hex high 32 ^ field_suffix_hex low 32
 
 let ethereum_address_hex field = "0x" ^ field_suffix_hex field 40
+
+let packed_public_key_hex ({ x; is_odd } : Signature_lib.Public_key.Compressed.t)
+    =
+  let digits = padded_hex_digits x in
+  let first =
+    match String.get digits 0 with
+    | '0' .. '9' as digit ->
+        Char.to_int digit - Char.to_int '0'
+    | 'a' .. 'f' as digit ->
+        10 + Char.to_int digit - Char.to_int 'a'
+    | _ ->
+        failwith "invalid field hex digit"
+  in
+  if first >= 8 then
+    failwith "Mina compressed public-key x-coordinate already uses parity bit" ;
+  let first = if is_odd then first + 8 else first in
+  let packed = Bytes.of_string digits in
+  Bytes.set packed 0
+    (Char.lowercase
+       (Char.of_int_exn (if first < 10 then 48 + first else 87 + first)) ) ;
+  "0x" ^ Bytes.to_string packed
 
 let asset_record_of_event fields =
   let (Typ typ) = Asset_registry.Asset_record.typ in
@@ -115,24 +138,21 @@ let canonical_asset_record_json
      ; universal_bridge_vk_id
      } :
       Asset_registry.Asset_record.t ) =
-  if token_owner_l2.is_odd || vault_public_key.is_odd then
-    failwith
-      "Ethereum asset registry export requires even owner and vault public keys" ;
   `Assoc
     [ ("schemaVersion", `Int (Zeko_util.Checked32.to_int schema_version))
     ; ("registryIndex", `Int (Zeko_util.Checked32.to_int registry_index))
     ; ("assetId", `String (asset_id_hex asset_id_high asset_id_low))
     ; ("ethereumToken", `String (ethereum_address_hex ethereum_token_address))
-    ; ("tokenOwnerL2", `String (field_to_hex token_owner_l2.x))
+    ; ("tokenOwnerL2", `String (packed_public_key_hex token_owner_l2))
     ; ( "tokenIdL2"
       , `String (field_to_hex (Token_id.to_field_unsafe token_id_l2)) )
     ; ("decimals", `Int (Zeko_util.Checked32.to_int decimals))
     ; ( "inventoryCap"
       , `Intlit
-          (Currency.Amount.to_uint64 inventory_cap
-          |> Unsigned.UInt64.to_string ) )
+          (Currency.Amount.to_uint64 inventory_cap |> Unsigned.UInt64.to_string)
+      )
     ; ("mftStandardVkId", `String (field_to_hex mft_standard_vk_id))
-    ; ("vaultPublicKey", `String (field_to_hex vault_public_key.x))
+    ; ("vaultPublicKey", `String (packed_public_key_hex vault_public_key))
     ; ("universalBridgeVkId", `String (field_to_hex universal_bridge_vk_id))
     ]
 
@@ -143,8 +163,7 @@ let registry_records_from_archive ~(archive : Archive.t) =
       Token_id.default
   in
   Archive.get_events archive account_id
-  |> List.concat_map ~f:(fun
-                          { Archive.Account_update_events.events; _ } ->
+  |> List.concat_map ~f:(fun { Archive.Account_update_events.events; _ } ->
          events )
   |> List.map ~f:asset_record_of_event
 
@@ -172,8 +191,8 @@ let asset_registry_batch_json ~(archive : Archive.t) ~old_root ~old_count
     let records = registry_records_from_archive ~archive in
     if List.length records < new_count then
       failwithf
-        "Ethereum asset registry archive contains %d records, expected at least \
-         %d"
+        "Ethereum asset registry archive contains %d records, expected at \
+         least %d"
         (List.length records) new_count () ;
     let records = List.take records new_count in
     List.iteri records ~f:(fun index record ->
@@ -183,9 +202,8 @@ let asset_registry_batch_json ~(archive : Archive.t) ~old_root ~old_count
                (Zeko_util.Checked32.to_int record.registry_index)
                index )
         then
-          failwithf
-            "Ethereum asset registry archive is not dense at index %d" index ()
-        ) ;
+          failwithf "Ethereum asset registry archive is not dense at index %d"
+            index () ) ;
     let tree = ref (Asset_registry.Merkle_list.empty ()) in
     List.take records old_count
     |> List.iter ~f:(fun record ->
@@ -195,12 +213,8 @@ let asset_registry_batch_json ~(archive : Archive.t) ~old_root ~old_count
     let appends =
       List.drop records old_count
       |> List.map ~f:(fun record ->
-             let index =
-               Zeko_util.Checked32.to_int record.registry_index
-             in
-             let append_path =
-               Asset_registry.Merkle_list.path !tree ~index
-             in
+             let index = Zeko_util.Checked32.to_int record.registry_index in
+             let append_path = Asset_registry.Merkle_list.path !tree ~index in
              tree := Asset_registry.Merkle_list.append_exn !tree record ;
              `Assoc
                [ ("record", canonical_asset_record_json record)
@@ -214,15 +228,15 @@ let asset_registry_batch_json ~(archive : Archive.t) ~old_root ~old_count
         [ ( "registryPublicKey"
           , `String
               (field_to_hex
-                 Zeko_circuits_config.Inputs.Ethereum_assets
-                   .registry_public_key.x ) )
+                 Zeko_circuits_config.Inputs.Ethereum_assets.registry_public_key
+                   .x ) )
         ; ("root", `String (field_to_hex new_root))
         ; ("count", `Int new_count)
         ; ("schemaVersion", `Int new_schema)
         ; ("oldRoot", `String (field_to_hex old_root))
         ; ("oldCount", `Int old_count)
         ; ("appends", `List appends)
-        ])
+        ] )
 
 let ethereum_address_of_compressed
     ({ Signature_lib.Public_key.Compressed.Poly.x; is_odd } :
@@ -330,9 +344,7 @@ let account_update_body_input_json (body : Account_update.Body.t) =
              [ ("value", `String (field_to_hex value)); ("bits", `Int bits) ] )
   in
   `Assoc
-    [ ("fieldElements", fields_json field_elements)
-    ; ("packed", `List packed)
-    ]
+    [ ("fieldElements", fields_json field_elements); ("packed", `List packed) ]
 
 let rec call_forest_json
     (calls :
@@ -349,7 +361,7 @@ let rec call_forest_json
            [ ( "accountUpdateBody"
              , account_update_body_input_json account_update.body )
            ; ("calls", call_forest_json calls)
-           ] ))
+           ] ) )
 
 let binding_json ~signature_kind ~(body : Account_update.Body.t) ~calls
     ~state_before =
@@ -360,8 +372,7 @@ let binding_json ~signature_kind ~(body : Account_update.Body.t) ~calls
   in
   `Assoc
     [ ("minaSignatureKind", signature_kind)
-    ; ( "accountUpdateBody"
-      , account_update_body_input_json body )
+    ; ("accountUpdateBody", account_update_body_input_json body)
     ; ("actions", `List (List.map body.actions ~f:fields_json))
     ; ("stateBefore", `Assoc [ ("fields", fields_json state_fields) ])
     ; ("callForest", call_forest_json calls)
@@ -416,8 +427,7 @@ let proof_wire_json (proof : Pickles.Side_loaded.Proof.t) =
   (Yojson.Safe.to_string proof_wire, Yojson.Safe.to_string public_input_skeleton)
 
 let create_with_verification_key ?inner_action_batch ?asset_registry_batch
-    ~signature_kind
-    ~(body : Account_update.Body.t) ~calls ~state_before
+    ~signature_kind ~(body : Account_update.Body.t) ~calls ~state_before
     ~(proof : Compile_simple.Proof.t)
     ~(verification_key : Compile_simple.Verification_key.t) =
   let open Deferred.Or_error.Let_syntax in

--- a/src/app/zeko/sequencer/lib/ethereum_settlement_export.ml
+++ b/src/app/zeko/sequencer/lib/ethereum_settlement_export.ml
@@ -228,10 +228,9 @@ let asset_registry_batch_json ~(archive : Archive.t) ~old_root ~old_count
         [ ( "registryPublicKey"
           , `String
               (packed_public_key_hex
-                 Zeko_circuits_config.Inputs.Ethereum_assets
-                   .registry_public_key ) )
-        ; ( "checkpointVersion"
-          , `Int Asset_registry.Checkpoint.version )
+                 Zeko_circuits_config.Inputs.Ethereum_assets.registry_public_key )
+          )
+        ; ("checkpointVersion", `Int Asset_registry.Checkpoint.version)
         ; ("root", `String (field_to_hex new_root))
         ; ("count", `Int new_count)
         ; ("schemaVersion", `Int new_schema)
@@ -241,15 +240,15 @@ let asset_registry_batch_json ~(archive : Archive.t) ~old_root ~old_count
         ] )
 
 let ethereum_address_of_compressed
-    (({ Signature_lib.Public_key.Compressed.Poly.x; _ } :
-       Signature_lib.Public_key.Compressed.t ) as recipient) =
+    ( ({ Signature_lib.Public_key.Compressed.Poly.x; _ } :
+        Signature_lib.Public_key.Compressed.t ) as recipient ) =
   match Bridge_state.Ethereum_address.validate recipient with
   | Error _ ->
       None
   | Ok () ->
-    let hex = field_to_hex x |> String.chop_prefix_if_exists ~prefix:"0x" in
-    let hex = String.make (64 - String.length hex) '0' ^ hex in
-    Some ("0x" ^ String.suffix hex 40)
+      let hex = field_to_hex x |> String.chop_prefix_if_exists ~prefix:"0x" in
+      let hex = String.make (64 - String.length hex) '0' ^ hex in
+      Some ("0x" ^ String.suffix hex 40)
 
 let configured_ethereum_bridge_address () =
   match Zeko_circuits_config.t.ethereum_holder_account_l1 with
@@ -287,8 +286,8 @@ let ethereum_withdrawal_preimage_json
           [ ("recipient", `String recipient)
           ; ( "amount"
             , `Intlit
-                ( Currency.Amount.to_uint64 amount
-                |> Unsigned.UInt64.to_string ) )
+                (Currency.Amount.to_uint64 amount |> Unsigned.UInt64.to_string)
+            )
           ] )
   | Some { token; asset_id; params_fields } ->
       ( "tokenWithdrawal"
@@ -298,8 +297,8 @@ let ethereum_withdrawal_preimage_json
           ; ("recipient", `String recipient)
           ; ( "amount"
             , `Intlit
-                ( Currency.Amount.to_uint64 amount
-                |> Unsigned.UInt64.to_string ) )
+                (Currency.Amount.to_uint64 amount |> Unsigned.UInt64.to_string)
+            )
           ; ("paramsFields", fields_json (Array.of_list params_fields))
           ] )
 

--- a/src/app/zeko/sequencer/lib/ethereum_settlement_export.ml
+++ b/src/app/zeko/sequencer/lib/ethereum_settlement_export.ml
@@ -227,9 +227,11 @@ let asset_registry_batch_json ~(archive : Archive.t) ~old_root ~old_count
       (`Assoc
         [ ( "registryPublicKey"
           , `String
-              (field_to_hex
-                 Zeko_circuits_config.Inputs.Ethereum_assets.registry_public_key
-                   .x ) )
+              (packed_public_key_hex
+                 Zeko_circuits_config.Inputs.Ethereum_assets
+                   .registry_public_key ) )
+        ; ( "checkpointVersion"
+          , `Int Asset_registry.Checkpoint.version )
         ; ("root", `String (field_to_hex new_root))
         ; ("count", `Int new_count)
         ; ("schemaVersion", `Int new_schema)
@@ -239,16 +241,15 @@ let asset_registry_batch_json ~(archive : Archive.t) ~old_root ~old_count
         ] )
 
 let ethereum_address_of_compressed
-    ({ Signature_lib.Public_key.Compressed.Poly.x; is_odd } :
-      Signature_lib.Public_key.Compressed.t ) =
-  if is_odd then None
-  else
+    (({ Signature_lib.Public_key.Compressed.Poly.x; _ } :
+       Signature_lib.Public_key.Compressed.t ) as recipient) =
+  match Bridge_state.Ethereum_address.validate recipient with
+  | Error _ ->
+      None
+  | Ok () ->
     let hex = field_to_hex x |> String.chop_prefix_if_exists ~prefix:"0x" in
     let hex = String.make (64 - String.length hex) '0' ^ hex in
-    let high = String.prefix hex 24 in
-    if String.for_all high ~f:(Char.equal '0') then
-      Some ("0x" ^ String.suffix hex 40)
-    else None
+    Some ("0x" ^ String.suffix hex 40)
 
 let configured_ethereum_bridge_address () =
   match Zeko_circuits_config.t.ethereum_holder_account_l1 with
@@ -272,30 +273,35 @@ let configured_ethereum_bridge_address () =
 
 let ethereum_withdrawal_preimage_json
     ({ recipient; amount; asset } : Archive.Ethereum_withdrawal.t) =
-  ethereum_address_of_compressed recipient
-  |> Option.map ~f:(fun recipient ->
-         match asset with
-         | None ->
-             ( "withdrawal"
-             , `Assoc
-                 [ ("recipient", `String recipient)
-                 ; ( "amount"
-                   , `Intlit
-                       ( Currency.Amount.to_uint64 amount
-                       |> Unsigned.UInt64.to_string ) )
-                 ] )
-         | Some { token; asset_id; params_fields } ->
-             ( "tokenWithdrawal"
-             , `Assoc
-                 [ ("token", `String token)
-                 ; ("assetId", `String asset_id)
-                 ; ("recipient", `String recipient)
-                 ; ( "amount"
-                   , `Intlit
-                       ( Currency.Amount.to_uint64 amount
-                       |> Unsigned.UInt64.to_string ) )
-                 ; ("paramsFields", fields_json (Array.of_list params_fields))
-                 ] ) )
+  let recipient =
+    ethereum_address_of_compressed recipient
+    |> Option.value_exn
+         ~message:
+           "Ethereum settlement withdrawal recipient is not an even 160-bit \
+            address"
+  in
+  match asset with
+  | None ->
+      ( "withdrawal"
+      , `Assoc
+          [ ("recipient", `String recipient)
+          ; ( "amount"
+            , `Intlit
+                ( Currency.Amount.to_uint64 amount
+                |> Unsigned.UInt64.to_string ) )
+          ] )
+  | Some { token; asset_id; params_fields } ->
+      ( "tokenWithdrawal"
+      , `Assoc
+          [ ("token", `String token)
+          ; ("assetId", `String asset_id)
+          ; ("recipient", `String recipient)
+          ; ( "amount"
+            , `Intlit
+                ( Currency.Amount.to_uint64 amount
+                |> Unsigned.UInt64.to_string ) )
+          ; ("paramsFields", fields_json (Array.of_list params_fields))
+          ] )
 
 let inner_action_batch_json ~(archive : Archive.t)
     (records : Archive.Account_update_actions.t list) =
@@ -309,15 +315,16 @@ let inner_action_batch_json ~(archive : Archive.t)
           failwith "Ethereum settlement requires three-field inner actions" ;
         let withdrawal =
           Archive.find_ethereum_withdrawal archive ~aux:fields.(1)
-          |> Option.bind ~f:ethereum_withdrawal_preimage_json
+          |> Option.value_exn
+               ~message:
+                 (sprintf
+                    "Ethereum settlement archive has no withdrawal preimage \
+                     for action auxiliary %s"
+                    (field_to_hex fields.(1)) )
+          |> ethereum_withdrawal_preimage_json
         in
         let fields = [ ("fields", fields_json fields) ] in
-        `Assoc
-          ( match withdrawal with
-          | Some withdrawal ->
-              withdrawal :: fields
-          | None ->
-              fields ) )
+        `Assoc (withdrawal :: fields) )
   in
   `Assoc
     [ ("bridgeAddress", `String (configured_ethereum_bridge_address ()))

--- a/src/app/zeko/sequencer/lib/ethereum_settlement_export.ml
+++ b/src/app/zeko/sequencer/lib/ethereum_settlement_export.ml
@@ -12,6 +12,7 @@ type t =
   ; outer_account_public_key : string
   ; binding : Yojson.Safe.t
   ; inner_action_batch : Yojson.Safe.t option
+  ; asset_registry_batch : Yojson.Safe.t option
   }
 
 let proof_json (t : t) : Yojson.Safe.t =
@@ -23,12 +24,15 @@ let proof_json (t : t) : Yojson.Safe.t =
     ; ("binding", t.binding)
     ]
   in
-  `Assoc
-    ( match t.inner_action_batch with
-    | Some batch ->
-        ("innerActionBatch", batch) :: fields
-    | None ->
-        fields )
+  let fields =
+    Option.value_map t.inner_action_batch ~default:fields ~f:(fun batch ->
+        ("innerActionBatch", batch) :: fields )
+  in
+  let fields =
+    Option.value_map t.asset_registry_batch ~default:fields ~f:(fun batch ->
+        ("assetRegistryBatch", batch) :: fields )
+  in
+  `Assoc fields
 
 let to_gateway_json t (command : Zkapp_command.Stable.Latest.t) =
   let command_base64 = Zkapp_command.to_base64 command in
@@ -78,6 +82,147 @@ let fields_json fields =
   fields |> Array.to_list
   |> List.map ~f:(fun field -> `String (field_to_hex field))
   |> fun fields -> `List fields
+
+let padded_hex_digits field =
+  let digits = field_to_hex field |> String.chop_prefix_if_exists ~prefix:"0x" in
+  String.make (64 - String.length digits) '0' ^ digits
+
+let field_suffix_hex field length =
+  let digits = padded_hex_digits field in
+  String.suffix digits length
+
+let asset_id_hex high low =
+  "0x" ^ field_suffix_hex high 32 ^ field_suffix_hex low 32
+
+let ethereum_address_hex field = "0x" ^ field_suffix_hex field 40
+
+let asset_record_of_event fields =
+  let (Typ typ) = Asset_registry.Asset_record.typ in
+  typ.value_of_fields (fields, typ.constraint_system_auxiliary ())
+
+let canonical_asset_record_json
+    ({ schema_version
+     ; registry_index
+     ; asset_id_high
+     ; asset_id_low
+     ; ethereum_token_address
+     ; token_owner_l2
+     ; token_id_l2
+     ; decimals
+     ; inventory_cap
+     ; mft_standard_vk_id
+     ; vault_public_key
+     ; universal_bridge_vk_id
+     } :
+      Asset_registry.Asset_record.t ) =
+  if token_owner_l2.is_odd || vault_public_key.is_odd then
+    failwith
+      "Ethereum asset registry export requires even owner and vault public keys" ;
+  `Assoc
+    [ ("schemaVersion", `Int (Zeko_util.Checked32.to_int schema_version))
+    ; ("registryIndex", `Int (Zeko_util.Checked32.to_int registry_index))
+    ; ("assetId", `String (asset_id_hex asset_id_high asset_id_low))
+    ; ("ethereumToken", `String (ethereum_address_hex ethereum_token_address))
+    ; ("tokenOwnerL2", `String (field_to_hex token_owner_l2.x))
+    ; ( "tokenIdL2"
+      , `String (field_to_hex (Token_id.to_field_unsafe token_id_l2)) )
+    ; ("decimals", `Int (Zeko_util.Checked32.to_int decimals))
+    ; ( "inventoryCap"
+      , `Intlit
+          (Currency.Amount.to_uint64 inventory_cap
+          |> Unsigned.UInt64.to_string ) )
+    ; ("mftStandardVkId", `String (field_to_hex mft_standard_vk_id))
+    ; ("vaultPublicKey", `String (field_to_hex vault_public_key.x))
+    ; ("universalBridgeVkId", `String (field_to_hex universal_bridge_vk_id))
+    ]
+
+let registry_records_from_archive ~(archive : Archive.t) =
+  let account_id =
+    Account_id.create
+      Zeko_circuits_config.Inputs.Ethereum_assets.registry_public_key
+      Token_id.default
+  in
+  Archive.get_events archive account_id
+  |> List.concat_map ~f:(fun
+                          { Archive.Account_update_events.events; _ } ->
+         events )
+  |> List.map ~f:asset_record_of_event
+
+let int_of_field label field =
+  Option.try_with (fun () -> Field.to_string field |> Int.of_string)
+  |> Option.value_exn
+       ~message:(sprintf "%s does not fit an OCaml integer" label)
+
+let asset_registry_batch_json ~(archive : Archive.t) ~old_root ~old_count
+    ~old_schema ~new_root ~new_count ~new_schema =
+  let old_count = int_of_field "old asset registry count" old_count in
+  let new_count = int_of_field "new asset registry count" new_count in
+  let old_schema = int_of_field "old asset registry schema" old_schema in
+  let new_schema = int_of_field "new asset registry schema" new_schema in
+  if Int.equal old_count new_count then None
+  else if new_count < old_count then
+    failwith "Ethereum asset registry count regressed"
+  else if
+    not
+      ( Int.equal old_schema new_schema
+      && Int.equal new_schema
+           Zeko_constants.Ethereum_asset_registry.schema_version )
+  then failwith "Ethereum asset registry schema drifted"
+  else
+    let records = registry_records_from_archive ~archive in
+    if List.length records < new_count then
+      failwithf
+        "Ethereum asset registry archive contains %d records, expected at least \
+         %d"
+        (List.length records) new_count () ;
+    let records = List.take records new_count in
+    List.iteri records ~f:(fun index record ->
+        if
+          not
+            (Int.equal
+               (Zeko_util.Checked32.to_int record.registry_index)
+               index )
+        then
+          failwithf
+            "Ethereum asset registry archive is not dense at index %d" index ()
+        ) ;
+    let tree = ref (Asset_registry.Merkle_list.empty ()) in
+    List.take records old_count
+    |> List.iter ~f:(fun record ->
+           tree := Asset_registry.Merkle_list.append_exn !tree record ) ;
+    if not (Field.equal (Asset_registry.Merkle_list.root !tree) old_root) then
+      failwith "Ethereum asset registry archive does not match old root" ;
+    let appends =
+      List.drop records old_count
+      |> List.map ~f:(fun record ->
+             let index =
+               Zeko_util.Checked32.to_int record.registry_index
+             in
+             let append_path =
+               Asset_registry.Merkle_list.path !tree ~index
+             in
+             tree := Asset_registry.Merkle_list.append_exn !tree record ;
+             `Assoc
+               [ ("record", canonical_asset_record_json record)
+               ; ("appendPath", fields_json (Array.of_list append_path))
+               ] )
+    in
+    if not (Field.equal (Asset_registry.Merkle_list.root !tree) new_root) then
+      failwith "Ethereum asset registry archive does not match new root" ;
+    Some
+      (`Assoc
+        [ ( "registryPublicKey"
+          , `String
+              (field_to_hex
+                 Zeko_circuits_config.Inputs.Ethereum_assets
+                   .registry_public_key.x ) )
+        ; ("root", `String (field_to_hex new_root))
+        ; ("count", `Int new_count)
+        ; ("schemaVersion", `Int new_schema)
+        ; ("oldRoot", `String (field_to_hex old_root))
+        ; ("oldCount", `Int old_count)
+        ; ("appends", `List appends)
+        ])
 
 let ethereum_address_of_compressed
     ({ Signature_lib.Public_key.Compressed.Poly.x; is_odd } :
@@ -174,9 +319,7 @@ let signature_kind_json = function
       Or_error.error_string
         "the Ethereum settlement PoC supports mainnet/testnet Mina hash domains"
 
-let binding_json ~signature_kind ~(body : Account_update.Body.t) ~state_before =
-  let open Or_error.Let_syntax in
-  let%map signature_kind = signature_kind_json signature_kind in
+let account_update_body_input_json (body : Account_update.Body.t) =
   let { Random_oracle_input.Chunked.field_elements; packeds } =
     Account_update.Body.to_input body
   in
@@ -186,18 +329,42 @@ let binding_json ~signature_kind ~(body : Account_update.Body.t) ~state_before =
            `Assoc
              [ ("value", `String (field_to_hex value)); ("bits", `Int bits) ] )
   in
+  `Assoc
+    [ ("fieldElements", fields_json field_elements)
+    ; ("packed", `List packed)
+    ]
+
+let rec call_forest_json
+    (calls :
+      ( Account_update.Stable.V1.t
+      , Zkapp_command.Digest.Account_update.t
+      , Zkapp_command.Digest.Forest.t )
+      Zkapp_command.Call_forest.t ) =
+  `List
+    (List.map calls ~f:(fun tree ->
+         let { Zkapp_command.Call_forest.Tree.account_update; calls; _ } =
+           With_stack_hash.elt tree
+         in
+         `Assoc
+           [ ( "accountUpdateBody"
+             , account_update_body_input_json account_update.body )
+           ; ("calls", call_forest_json calls)
+           ] ))
+
+let binding_json ~signature_kind ~(body : Account_update.Body.t) ~calls
+    ~state_before =
+  let open Or_error.Let_syntax in
+  let%map signature_kind = signature_kind_json signature_kind in
   let state_fields =
     Utils.value_to_fields Rollup_state.Outer_state.typ state_before
   in
   `Assoc
     [ ("minaSignatureKind", signature_kind)
     ; ( "accountUpdateBody"
-      , `Assoc
-          [ ("fieldElements", fields_json field_elements)
-          ; ("packed", `List packed)
-          ] )
+      , account_update_body_input_json body )
     ; ("actions", `List (List.map body.actions ~f:fields_json))
     ; ("stateBefore", `Assoc [ ("fields", fields_json state_fields) ])
+    ; ("callForest", call_forest_json calls)
     ]
 
 let app_statement_json ~signature_kind ~body ~calls =
@@ -248,7 +415,8 @@ let proof_wire_json (proof : Pickles.Side_loaded.Proof.t) =
   in
   (Yojson.Safe.to_string proof_wire, Yojson.Safe.to_string public_input_skeleton)
 
-let create_with_verification_key ?inner_action_batch ~signature_kind
+let create_with_verification_key ?inner_action_batch ?asset_registry_batch
+    ~signature_kind
     ~(body : Account_update.Body.t) ~calls ~state_before
     ~(proof : Compile_simple.Proof.t)
     ~(verification_key : Compile_simple.Verification_key.t) =
@@ -267,7 +435,7 @@ let create_with_verification_key ?inner_action_batch ~signature_kind
   let proof_json, public_input_skeleton_json = proof_wire_json proof in
   let%map vk_json = verification_key_json verification_key |> Deferred.return
   and binding =
-    binding_json ~signature_kind ~body ~state_before |> Deferred.return
+    binding_json ~signature_kind ~body ~calls ~state_before |> Deferred.return
   in
   { vk_json
   ; proof_json
@@ -277,10 +445,12 @@ let create_with_verification_key ?inner_action_batch ~signature_kind
       Signature_lib.Public_key.Compressed.to_base58_check body.public_key
   ; binding
   ; inner_action_batch
+  ; asset_registry_batch
   }
 
-let create ?inner_action_batch ~signature_kind ~(body : Account_update.Body.t)
-    ~calls ~state_before ~(proof : Compile_simple.Proof.t) =
+let create ?inner_action_batch ?asset_registry_batch ~signature_kind
+    ~(body : Account_update.Body.t) ~calls ~state_before
+    ~(proof : Compile_simple.Proof.t) =
   let open Deferred.Or_error.Let_syntax in
   let%bind verification_key =
     Compile_simple.Verification_key.of_tag
@@ -288,4 +458,4 @@ let create ?inner_action_batch ~signature_kind ~(body : Account_update.Body.t)
     |> Promise.to_deferred |> Deferred.ok
   in
   create_with_verification_key ~signature_kind ~body ~calls ~state_before
-    ?inner_action_batch ~proof ~verification_key
+    ?inner_action_batch ?asset_registry_batch ~proof ~verification_key

--- a/src/app/zeko/sequencer/lib/ethereum_settlement_export.ml
+++ b/src/app/zeko/sequencer/lib/ethereum_settlement_export.ml
@@ -111,6 +111,33 @@ let configured_ethereum_bridge_address () =
             "ethereum_holder_account_l1 is not an even 160-bit Ethereum address"
       )
 
+let ethereum_withdrawal_preimage_json
+    ({ recipient; amount; asset } : Archive.Ethereum_withdrawal.t) =
+  ethereum_address_of_compressed recipient
+  |> Option.map ~f:(fun recipient ->
+         match asset with
+         | None ->
+             ( "withdrawal"
+             , `Assoc
+                 [ ("recipient", `String recipient)
+                 ; ( "amount"
+                   , `Intlit
+                       ( Currency.Amount.to_uint64 amount
+                       |> Unsigned.UInt64.to_string ) )
+                 ] )
+         | Some { token; asset_id; params_fields } ->
+             ( "tokenWithdrawal"
+             , `Assoc
+                 [ ("token", `String token)
+                 ; ("assetId", `String asset_id)
+                 ; ("recipient", `String recipient)
+                 ; ( "amount"
+                   , `Intlit
+                       ( Currency.Amount.to_uint64 amount
+                       |> Unsigned.UInt64.to_string ) )
+                 ; ("paramsFields", fields_json (Array.of_list params_fields))
+                 ] ) )
+
 let inner_action_batch_json ~(archive : Archive.t)
     (records : Archive.Account_update_actions.t list) =
   let actions =
@@ -123,22 +150,13 @@ let inner_action_batch_json ~(archive : Archive.t)
           failwith "Ethereum settlement requires three-field inner actions" ;
         let withdrawal =
           Archive.find_ethereum_withdrawal archive ~aux:fields.(1)
-          |> Option.bind ~f:(fun { recipient; amount } ->
-                 ethereum_address_of_compressed recipient
-                 |> Option.map ~f:(fun recipient ->
-                        `Assoc
-                          [ ("recipient", `String recipient)
-                          ; ( "amount"
-                            , `Intlit
-                                ( Currency.Amount.to_uint64 amount
-                                |> Unsigned.UInt64.to_string ) )
-                          ] ) )
+          |> Option.bind ~f:ethereum_withdrawal_preimage_json
         in
         let fields = [ ("fields", fields_json fields) ] in
         `Assoc
           ( match withdrawal with
           | Some withdrawal ->
-              ("withdrawal", withdrawal) :: fields
+              withdrawal :: fields
           | None ->
               fields ) )
   in

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -9,6 +9,23 @@ open Currency
 module Schema = Graphql_wrapper.Make (Schema)
 module Zeko_sequencer = Zeko_sequencer.Sequencer
 
+let field_hex field =
+  Kimchi_backend.Pasta.Basic.Bigint256.to_hex_string
+    (Kimchi_backend.Pasta.Basic.Fp.to_bigint field)
+  |> String.lowercase
+  |> String.chop_prefix_if_exists ~prefix:"0x"
+  |> fun hex -> String.make (64 - String.length hex) '0' ^ hex
+
+let ethereum_asset_id_of_record
+    (record : Zeko_circuits.Asset_registry.Asset_record.t) =
+  "0x"
+  ^ String.suffix (field_hex record.asset_id_high) 32
+  ^ String.suffix (field_hex record.asset_id_low) 32
+
+let ethereum_token_address_of_record
+    (record : Zeko_circuits.Asset_registry.Asset_record.t) =
+  "0x" ^ String.suffix (field_hex record.ethereum_token_address) 40
+
 module Context = struct
   type t =
     { sequencer : Zeko_sequencer.t
@@ -1074,37 +1091,47 @@ module Types = struct
   end
 
   module Circuits_config = struct
-    module Ethereum_token = struct
+    module Ethereum_assets = struct
       type t =
-        { asset_id : string
-        ; ethereum_token_address : string
-        ; token_owner_l2 : Public_key.Compressed.t
-        ; token_id_l2 : Token_id.t
-        ; holder_account_l2 : Public_key.Compressed.t
-        ; verification_key_hash : Snark_params.Tick.Field.t
+        { registry_public_key : Public_key.Compressed.t
+        ; vault_public_key : Public_key.Compressed.t
+        ; registry_schema_version : int
+        ; approved_mft_standard_vk_id : Snark_params.Tick.Field.t
+        ; universal_bridge_vk_id : Snark_params.Tick.Field.t
+        ; bridge_verification_key_hash : Snark_params.Tick.Field.t
+        ; registry_verification_key_hash : Snark_params.Tick.Field.t
         }
 
       let t : (Context.t, t option) typ =
-        obj "ZekoEthereumTokenConfig" ~fields:(fun _ ->
-            [ field "assetId" ~typ:(non_null string)
+        obj "ZekoEthereumAssetsConfig" ~fields:(fun _ ->
+            [ field "registryPublicKey" ~typ:(non_null public_key)
                 ~args:Arg.[]
-                ~resolve:(fun _ t -> t.asset_id)
-            ; field "ethereumTokenAddress" ~typ:(non_null string)
+                ~resolve:(fun _ t -> t.registry_public_key)
+            ; field "vaultPublicKey" ~typ:(non_null public_key)
                 ~args:Arg.[]
-                ~resolve:(fun _ t -> t.ethereum_token_address)
-            ; field "tokenOwnerL2" ~typ:(non_null public_key)
+                ~resolve:(fun _ t -> t.vault_public_key)
+            ; field "registrySchemaVersion" ~typ:(non_null int)
                 ~args:Arg.[]
-                ~resolve:(fun _ t -> t.token_owner_l2)
-            ; field "tokenIdL2" ~typ:(non_null string)
-                ~args:Arg.[]
-                ~resolve:(fun _ t -> Token_id.to_string t.token_id_l2)
-            ; field "holderAccountL2" ~typ:(non_null public_key)
-                ~args:Arg.[]
-                ~resolve:(fun _ t -> t.holder_account_l2)
-            ; field "verificationKeyHash" ~typ:(non_null string)
+                ~resolve:(fun _ t -> t.registry_schema_version)
+            ; field "approvedMftStandardVkId" ~typ:(non_null string)
                 ~args:Arg.[]
                 ~resolve:(fun _ t ->
-                  Snark_params.Tick.Field.to_string t.verification_key_hash )
+                  Snark_params.Tick.Field.to_string
+                    t.approved_mft_standard_vk_id )
+            ; field "universalBridgeVkId" ~typ:(non_null string)
+                ~args:Arg.[]
+                ~resolve:(fun _ t ->
+                  Snark_params.Tick.Field.to_string t.universal_bridge_vk_id )
+            ; field "bridgeVerificationKeyHash" ~typ:(non_null string)
+                ~args:Arg.[]
+                ~resolve:(fun _ t ->
+                  Snark_params.Tick.Field.to_string
+                    t.bridge_verification_key_hash )
+            ; field "registryVerificationKeyHash" ~typ:(non_null string)
+                ~args:Arg.[]
+                ~resolve:(fun _ t ->
+                  Snark_params.Tick.Field.to_string
+                    t.registry_verification_key_hash )
             ] )
     end
 
@@ -1122,7 +1149,7 @@ module Types = struct
       ; bridge_fee_recipient_l1 : Public_key.Compressed.t
       ; bridge_fee_recipient_l2 : Public_key.Compressed.t
       ; bridge_proof_fee : Currency.Amount.t
-      ; ethereum_token : Ethereum_token.t option
+      ; ethereum_assets : Ethereum_assets.t option
       }
 
     let signature_kind_to_string = function
@@ -1175,9 +1202,9 @@ module Types = struct
           ; field "bridgeProofFee" ~typ:(non_null amount)
               ~args:Arg.[]
               ~resolve:(fun _ t -> t.bridge_proof_fee)
-          ; field "ethereumToken" ~typ:Ethereum_token.t
+          ; field "ethereumAssets" ~typ:Ethereum_assets.t
               ~args:Arg.[]
-              ~resolve:(fun _ t -> t.ethereum_token)
+              ~resolve:(fun _ t -> t.ethereum_assets)
           ] )
   end
 
@@ -1632,6 +1659,29 @@ module Types = struct
               ]
       end
 
+      module Ethereum_asset_membership = struct
+        type input =
+          Bridge_inst_ethereum_token.Registry.Membership_witness.t
+
+        let arg_typ =
+          scalar "EthereumAssetMembershipInput"
+            ~doc:
+              "Canonical JSON registry state, V1 asset record, and depth-8 \
+               Merkle path"
+            ~coerce:(function
+              | `String json ->
+                  Yojson.Safe.from_string json
+                  |> Bridge_inst_ethereum_token.Registry.Membership_witness
+                     .of_yojson
+              | _ ->
+                  Error "Expected a JSON-encoded Ethereum asset membership" )
+            ~to_json:(fun membership ->
+              `String
+                (Bridge_inst_ethereum_token.Registry.Membership_witness
+                 .to_yojson membership
+                |> Yojson.Safe.to_string ) )
+      end
+
       module Transferrer = struct
         type input = Account_update.Stable.Latest.t
 
@@ -2078,6 +2128,7 @@ module Types = struct
           ; check_accepted :
               Bridge.Check_accepted_ethereum_token.Init.t
               * Bridge.Check_accepted_ethereum_token.Elem.t list
+          ; asset : Ethereum_asset_membership.input
           ; prev_next_deposit : Unsigned.uint32
           ; prev_nonce : Unsigned.uint32
           ; helper_account_new : bool
@@ -2085,19 +2136,20 @@ module Types = struct
 
         let arg_typ ~proof_cache_db =
           obj "FinalizeEthereumTokenDepositInput"
-            ~coerce:(fun ase (check_accepted_init, check_accepted_elems)
+            ~coerce:(fun ase (check_accepted_init, check_accepted_elems) asset
                          prev_next_deposit prev_nonce helper_account_new ->
               let%map.Result check_accepted_elems =
                 Result.all check_accepted_elems
               in
               { ase
               ; check_accepted = (check_accepted_init, check_accepted_elems)
+              ; asset
               ; prev_next_deposit
               ; prev_nonce
               ; helper_account_new
               } )
             ~split:(fun f (x : input) ->
-              f x.ase x.check_accepted x.prev_next_deposit x.prev_nonce
+              f x.ase x.check_accepted x.asset x.prev_next_deposit x.prev_nonce
                 x.helper_account_new )
             ~fields:
               [ arg "ase" ~typ:(non_null Folder.Ase_with_length.arg_typ)
@@ -2106,6 +2158,7 @@ module Types = struct
                     ( non_null
                     @@ Folder.Check_accepted_ethereum_token.arg_typ
                          ~proof_cache_db )
+              ; arg "asset" ~typ:(non_null Ethereum_asset_membership.arg_typ)
               ; arg "prevNextDeposit" ~typ:(non_null UInt32.arg_typ)
               ; arg "prevNonce" ~typ:(non_null UInt32.arg_typ)
               ; arg "helperAccountNew" ~typ:(non_null bool)
@@ -2114,19 +2167,43 @@ module Types = struct
 
       module Ethereum_token_withdrawal_request = struct
         type input =
-          { withdrawal_params : Ethereum_token_withdrawal_params.input }
+          { withdrawal_params : Ethereum_token_withdrawal_params.input
+          ; asset : Ethereum_asset_membership.input
+          }
 
         let arg_typ ~proof_cache_db =
           obj "EthereumTokenWithdrawalRequestInput"
-            ~coerce:(fun withdrawal_params -> { withdrawal_params })
-            ~split:(fun f (x : input) -> f x.withdrawal_params)
+            ~coerce:(fun withdrawal_params asset ->
+              { withdrawal_params; asset } )
+            ~split:(fun f (x : input) -> f x.withdrawal_params x.asset)
             ~fields:
               [ arg "withdrawalParams"
                   ~typ:
                     ( non_null
                     @@ Ethereum_token_withdrawal_params.arg_typ ~proof_cache_db
                     )
+              ; arg "asset" ~typ:(non_null Ethereum_asset_membership.arg_typ)
               ]
+      end
+
+      module Register_ethereum_asset = struct
+        type input = Bridge_prover.Register_ethereum_asset.t
+
+        let arg_typ =
+          scalar "RegisterEthereumAssetInput"
+            ~doc:
+              "Canonical JSON old registry state, candidate, complete \
+               sequential membership traversal, and empty append path"
+            ~coerce:(function
+              | `String json ->
+                  Yojson.Safe.from_string json
+                  |> Bridge_prover.Register_ethereum_asset.of_yojson
+              | _ ->
+                  Error "Expected a JSON-encoded asset registration witness" )
+            ~to_json:(fun witness ->
+              `String
+                (Bridge_prover.Register_ethereum_asset.to_yojson witness
+                |> Yojson.Safe.to_string ) )
       end
 
       module Finalize_cancelled_deposit = struct
@@ -2726,8 +2803,8 @@ module Mutations = struct
                      .arg_typ ~proof_cache_db )
             ]
         ~resolve:(fun { ctx = Context.{ sequencer; _ }; _ } ()
-                      { withdrawal_params } ->
-          if not Zeko_circuits_config.Inputs.Ethereum_token.enabled then
+                      { withdrawal_params; asset } ->
+          if not Zeko_circuits_config.Inputs.Ethereum_assets.enabled then
             return (Error "Ethereum token bridge is not configured")
           else
             let params_fields =
@@ -2749,10 +2826,9 @@ module Mutations = struct
               ; asset =
                   Some
                     { token =
-                        Zeko_circuits_config.Inputs.Ethereum_token
-                        .ethereum_token_address
+                        ethereum_token_address_of_record asset.record
                     ; asset_id =
-                        Zeko_circuits_config.Inputs.Ethereum_token.asset_id
+                        ethereum_asset_id_of_record asset.record
                     ; params_fields
                     }
               } ;
@@ -2761,10 +2837,33 @@ module Mutations = struct
             return
               (let%map.Result key, proving =
                  Bridge_prover.Ethereum_token_withdrawal_request.f ~t ~logger
-                   { withdrawal_params }
+                   { withdrawal_params; asset }
                  |> Result.map_error ~f:Error.to_string_hum
                in
                don't_wait_for proving ; key ) )
+
+    let register_ethereum_asset =
+      io_field "registerEthereumAsset"
+        ~doc:
+          "Prove an append-only asset registration after exhaustively scanning \
+           every committed registry entry"
+        ~typ:(non_null Types.Payload.proof_key)
+        ~args:
+          Arg.
+            [ arg "input"
+                ~typ:
+                  ( non_null
+                  @@ Types.Input.Provers.Register_ethereum_asset.arg_typ )
+            ]
+        ~resolve:(fun { ctx = Context.{ sequencer; _ }; _ } () request ->
+          let logger = Zeko_sequencer.(sequencer.logger) in
+          let t = Zeko_sequencer.(sequencer.bridge_prover) in
+          return
+            (let%map.Result key, proving =
+               Bridge_prover.Register_ethereum_asset.f ~t ~logger request
+               |> Result.map_error ~f:Error.to_string_hum
+             in
+             don't_wait_for proving ; key ) )
 
     let finalize_deposit ~proof_cache_db =
       io_field "finalizeDeposit" ~doc:"Finalize a deposit"
@@ -2832,6 +2931,7 @@ module Mutations = struct
           let%bind.Deferred.Result { ase = ase_source, ase_elems
                                    ; check_accepted =
                                        check_accepted_init, check_accepted_elems
+                                   ; asset
                                    ; prev_next_deposit
                                    ; prev_nonce
                                    ; helper_account_new
@@ -2847,6 +2947,7 @@ module Mutations = struct
                  ; ase_elems
                  ; check_accepted_init
                  ; check_accepted_elems
+                 ; asset
                  ; prev_next_deposit
                  ; prev_nonce
                  ; helper_account_new
@@ -2981,6 +3082,7 @@ module Mutations = struct
       [ deposit_request ~proof_cache_db
       ; withdrawal_request ~proof_cache_db
       ; ethereum_token_withdrawal_request ~proof_cache_db
+      ; register_ethereum_asset
       ; finalize_deposit ~proof_cache_db
       ; finalize_ethereum_token_deposit ~proof_cache_db
       ; finalize_withdrawal ~proof_cache_db
@@ -3216,22 +3318,25 @@ module Queries = struct
         ; bridge_fee_recipient_l1 = Inputs.bridge_fee_recipient_l1
         ; bridge_fee_recipient_l2 = Inputs.bridge_fee_recipient_l2
         ; bridge_proof_fee = Inputs.bridge_proof_fee
-        ; ethereum_token =
-            ( if Inputs.Ethereum_token.enabled then
+        ; ethereum_assets =
+            ( if Inputs.Ethereum_assets.enabled then
               Some
-                { Types.Circuits_config.Ethereum_token.asset_id =
-                    Inputs.Ethereum_token.asset_id
-                ; ethereum_token_address =
-                    Inputs.Ethereum_token.ethereum_token_address
-                ; token_owner_l2 =
-                    Account_id.public_key Inputs.Ethereum_token.token_owner_l2
-                ; token_id_l2 =
-                    Account_id.derive_token_id
-                      ~owner:Inputs.Ethereum_token.token_owner_l2
-                ; holder_account_l2 = Inputs.Ethereum_token.holder_account_l2
-                ; verification_key_hash =
+                { Types.Circuits_config.Ethereum_assets.registry_public_key =
+                    Inputs.Ethereum_assets.registry_public_key
+                ; vault_public_key = Inputs.Ethereum_assets.vault_public_key
+                ; registry_schema_version =
+                    Zeko_circuits.Zeko_util.Checked32.to_int
+                      Inputs.Ethereum_assets.registry_schema_version
+                ; approved_mft_standard_vk_id =
+                    Inputs.Ethereum_assets.approved_mft_standard_vk_id
+                ; universal_bridge_vk_id =
+                    Inputs.Ethereum_assets.universal_bridge_vk_id
+                ; bridge_verification_key_hash =
                     sequencer.bridge_prover.verification_keys
                       .bridge_ethereum_token_l2
+                ; registry_verification_key_hash =
+                    sequencer.bridge_prover.verification_keys
+                      .ethereum_asset_registry
                 }
             else None )
         } )

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -2398,24 +2398,32 @@ module Types = struct
           ; token_id : Token_id.t option
           ; from_action_state : Field.t option
           ; end_action_state : Field.t option
+          ; from_block : int option
+          ; to_block : int option
           }
 
         let arg_typ =
           obj "ActionFilterOptionsInput"
-            ~coerce:(fun address token_id from_action_state end_action_state ->
+            ~coerce:(fun address token_id from_action_state end_action_state
+                         from_block to_block ->
               ( address
               , token_id
               , Option.map from_action_state ~f:Field.of_string
-              , Option.map end_action_state ~f:Field.of_string ) )
+              , Option.map end_action_state ~f:Field.of_string
+              , from_block
+              , to_block ) )
             ~split:(fun f (x : input) ->
               f x.address x.token_id
                 (Option.map x.from_action_state ~f:Field.to_string)
-                (Option.map x.end_action_state ~f:Field.to_string) )
+                (Option.map x.end_action_state ~f:Field.to_string)
+                x.from_block x.to_block )
             ~fields:
               [ arg "address" ~typ:(non_null PublicKey.arg_typ)
               ; arg "tokenId" ~typ:TokenId.arg_typ
               ; arg "fromActionState" ~typ:string
               ; arg "endActionState" ~typ:string
+              ; arg "from" ~typ:int
+              ; arg "to" ~typ:int
               ]
       end
 
@@ -3432,13 +3440,24 @@ module Queries = struct
                   (non_null Types.Input.Archive.ActionFilterOptionsInput.arg_typ)
             ]
         ~resolve:(fun { ctx = { sequencer; _ }; _ } ()
-                      (public_key, token_id, from_action_state, end_action_state)
-                      ->
+                      ( public_key
+                      , token_id
+                      , from_action_state
+                      , end_action_state
+                      , from_block
+                      , to_block ) ->
           let token_id = Option.value ~default:Token_id.default token_id in
-          return
-          @@ Archive.get_actions sequencer.archive
-               (Account_id.create public_key token_id)
-               ~from:from_action_state ~to_:end_action_state )
+          Archive.get_actions sequencer.archive
+            (Account_id.create public_key token_id)
+            ~from:from_action_state ~to_:end_action_state
+          |> Result.map ~f:
+               (List.filter ~f:(fun (action : Archive.Account_update_actions.t) ->
+                    Option.for_all action.block_info ~f:(fun block_info ->
+                        Option.for_all from_block ~f:(fun from_block ->
+                            block_info.height >= from_block )
+                        && Option.for_all to_block ~f:(fun to_block ->
+                               block_info.height < to_block ) ) ) )
+          |> return )
 
     let events =
       field "events"

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -1690,6 +1690,9 @@ module Types = struct
             ~coerce:(fun encoding_version registry_index record_commitment
                          asset_id_high asset_id_low token_owner sender_debit
                          amount recipient ->
+              let%map.Result () =
+                Zeko_circuits.Bridge_state.Ethereum_address.validate recipient
+              in
               Zeko_types.Bridge.Withdrawal_params_ethereum_token.of_serializable
                 ~proof_cache_db
                 { encoding_version =
@@ -2878,14 +2881,6 @@ module Mutations = struct
               Zeko_circuits.Bridge_state.Withdrawal_params_base.typ
               withdrawal_params
           in
-          Archive.store_ethereum_withdrawal
-            Zeko_sequencer.(sequencer.archive)
-            ~aux:withdrawal_aux
-            { Archive.Ethereum_withdrawal.recipient =
-                withdrawal_params.recipient
-            ; amount = withdrawal_params.amount
-            ; asset = None
-            } ;
           return
             (let%bind.Result key, d =
                Bridge_prover.Withdrawal_request.f
@@ -2894,6 +2889,14 @@ module Mutations = struct
                  { withdrawal_params; transferrer }
                |> Result.map_error ~f:Error.to_string_hum
              in
+             Archive.store_ethereum_withdrawal
+               Zeko_sequencer.(sequencer.archive)
+               ~aux:withdrawal_aux
+               { Archive.Ethereum_withdrawal.recipient =
+                   withdrawal_params.recipient
+               ; amount = withdrawal_params.amount
+               ; asset = None
+               } ;
              let d =
                Bridge_prover.execute_request t ~logger ~executor:l2_executor
                  (key, d)
@@ -2926,25 +2929,14 @@ module Mutations = struct
                 withdrawal_params
               |> Array.to_list
             in
-            Archive.store_ethereum_withdrawal
-              Zeko_sequencer.(sequencer.archive)
-              ~aux:
-                (Utils.value_to_hash
-                   ~init:
-                     Zeko_circuits.Bridge_state
-                     .Withdrawal_params_ethereum_token.hash_salt
-                   Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token
-                   .typ withdrawal_params )
-              { Archive.Ethereum_withdrawal.recipient =
-                  withdrawal_params.custom.base.recipient
-              ; amount = withdrawal_params.custom.base.amount
-              ; asset =
-                  Some
-                    { token = ethereum_token_address_of_record asset.record
-                    ; asset_id = ethereum_asset_id_of_record asset.record
-                    ; params_fields
-                    }
-              } ;
+            let withdrawal_aux =
+              Utils.value_to_hash
+                ~init:
+                  Zeko_circuits.Bridge_state
+                  .Withdrawal_params_ethereum_token.hash_salt
+                Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token.typ
+                withdrawal_params
+            in
             let logger = Zeko_sequencer.(sequencer.logger) in
             let t = Zeko_sequencer.(sequencer.bridge_prover) in
             return
@@ -2953,6 +2945,19 @@ module Mutations = struct
                    { withdrawal_params; asset }
                  |> Result.map_error ~f:Error.to_string_hum
                in
+               Archive.store_ethereum_withdrawal
+                 Zeko_sequencer.(sequencer.archive)
+                 ~aux:withdrawal_aux
+                 { Archive.Ethereum_withdrawal.recipient =
+                     withdrawal_params.custom.base.recipient
+                 ; amount = withdrawal_params.custom.base.amount
+                 ; asset =
+                     Some
+                       { token = ethereum_token_address_of_record asset.record
+                       ; asset_id = ethereum_asset_id_of_record asset.record
+                       ; params_fields
+                       }
+                 } ;
                don't_wait_for proving ; key ) )
 
     let register_ethereum_asset =

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -227,6 +227,33 @@ module Types = struct
               Time.now () |> Time.to_string_iso8601_basic ~zone:Time.Zone.utc )
         ] )
 
+  module MaxBlockHeight = struct
+    type t =
+      { canonical_max_block_height : int; pending_max_block_height : int }
+
+    let t : ('context, t option) typ =
+      obj "MaxBlockHeight" ~fields:(fun _ ->
+          [ field "canonicalMaxBlockHeight" ~typ:(non_null int)
+              ~args:Arg.[]
+              ~resolve:(fun _ value -> value.canonical_max_block_height)
+          ; field "pendingMaxBlockHeight" ~typ:(non_null int)
+              ~args:Arg.[]
+              ~resolve:(fun _ value -> value.pending_max_block_height)
+          ] )
+  end
+
+  module NetworkState = struct
+    type t = { max_block_height : MaxBlockHeight.t }
+
+    let t : ('context, t option) typ =
+      obj "NetworkState" ~fields:(fun _ ->
+          [ field "maxBlockHeight"
+              ~typ:(non_null MaxBlockHeight.t)
+              ~args:Arg.[]
+              ~resolve:(fun _ value -> value.max_block_height)
+          ] )
+  end
+
   module AccountObj = struct
     module AnnotatedBalance = struct
       type t =
@@ -2395,15 +2422,36 @@ module Types = struct
       module EventFilterOptionsInput = struct
         module Field = Snark_params.Tick.Field
 
-        type input = { address : Account.key; token_id : Token_id.t option }
+        type chain_status = Canonical | Pending | Orphaned
+
+        let chain_status =
+          enum "ArchiveChainStatus"
+            ~values:
+              [ enum_value "CANONICAL" ~value:Canonical
+              ; enum_value "PENDING" ~value:Pending
+              ; enum_value "ORPHANED" ~value:Orphaned
+              ]
+
+        type input =
+          { address : Account.key
+          ; token_id : Token_id.t option
+          ; from_block : int option
+          ; to_block : int option
+          ; status : chain_status option
+          }
 
         let arg_typ =
           obj "EventFilterOptionsInput"
-            ~coerce:(fun address token_id -> (address, token_id))
-            ~split:(fun f (x : input) -> f x.address x.token_id)
+            ~coerce:(fun address token_id from_block to_block status ->
+              (address, token_id, from_block, to_block, status) )
+            ~split:(fun f (x : input) ->
+              f x.address x.token_id x.from_block x.to_block x.status )
             ~fields:
               [ arg "address" ~typ:(non_null PublicKey.arg_typ)
               ; arg "tokenId" ~typ:TokenId.arg_typ
+              ; arg "from" ~typ:int
+              ; arg "to" ~typ:int
+              ; arg "status" ~typ:chain_status
               ]
       end
     end
@@ -3230,6 +3278,16 @@ module Queries = struct
       ~typ:(non_null Types.genesis_constants)
       ~resolve:(fun _ () -> ())
 
+  let network_state =
+    field "networkState" ~doc:"Embedded archive block-height compatibility"
+      ~args:Arg.[]
+      ~typ:(non_null Types.NetworkState.t)
+      ~resolve:(fun _ () ->
+        let max_block_height : Types.MaxBlockHeight.t =
+          { canonical_max_block_height = 0; pending_max_block_height = 0 }
+        in
+        { Types.NetworkState.max_block_height } )
+
   let proving_result =
     io_field "provingResult" ~doc:"Query proving result in a JSON format"
       ~typ:string
@@ -3391,10 +3449,21 @@ module Queries = struct
                 ~typ:
                   (non_null Types.Input.Archive.EventFilterOptionsInput.arg_typ)
             ]
-        ~resolve:(fun { ctx = { sequencer; _ }; _ } () (public_key, token_id) ->
+        ~resolve:(fun { ctx = { sequencer; _ }; _ } ()
+                      ( public_key
+                      , token_id
+                      , from_block
+                      , to_block
+                      , _status ) ->
           let token_id = Option.value ~default:Token_id.default token_id in
           Archive.get_events sequencer.archive
-            (Account_id.create public_key token_id) )
+            (Account_id.create public_key token_id)
+          |> List.filter ~f:(fun event ->
+                 Option.for_all event.block_info ~f:(fun block_info ->
+                     Option.for_all from_block ~f:(fun from_block ->
+                         block_info.height >= from_block )
+                     && Option.for_all to_block ~f:(fun to_block ->
+                            block_info.height < to_block ) ) ) )
 
     let commands = [ actions; events ]
   end
@@ -3407,6 +3476,7 @@ module Queries = struct
     ; accounts_for_pk
     ; token_accounts
     ; genesis_constants
+    ; network_state
     ; proving_result
     ; state_hashes
     ; token_owner

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -1630,6 +1630,13 @@ module Types = struct
         let arg_typ ~proof_cache_db =
           obj "WithdrawalParamsInput"
             ~coerce:(fun children amount recipient ->
+              let%map.Result () =
+                Zeko_circuits.Bridge_state.Ethereum_address.validate_for
+                  ( Zeko_circuits.Bridge_state.Withdrawal_recipient_domain
+                    .of_ethereum_holder_account
+                      Zeko_circuits_config.Inputs.ethereum_holder_account_l1 )
+                  recipient
+              in
               Zeko_types.Bridge.Finalize_withdrawal.Withdrawal_params_base
               .of_serializable ~proof_cache_db
                 { children =

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -2443,6 +2443,7 @@ module Mutations = struct
             { Archive.Ethereum_withdrawal.recipient =
                 withdrawal_params.recipient
             ; amount = withdrawal_params.amount
+            ; asset = None
             } ;
           return
             (let%bind.Result key, d =

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -1632,9 +1632,9 @@ module Types = struct
             ~coerce:(fun children amount recipient ->
               let%map.Result () =
                 Zeko_circuits.Bridge_state.Ethereum_address.validate_for
-                  ( Zeko_circuits.Bridge_state.Withdrawal_recipient_domain
-                    .of_ethereum_holder_account
-                      Zeko_circuits_config.Inputs.ethereum_holder_account_l1 )
+                  (Zeko_circuits.Bridge_state.Withdrawal_recipient_domain
+                   .of_ethereum_holder_account
+                     Zeko_circuits_config.Inputs.ethereum_holder_account_l1 )
                   recipient
               in
               Zeko_types.Bridge.Finalize_withdrawal.Withdrawal_params_base
@@ -2948,8 +2948,8 @@ module Mutations = struct
             let withdrawal_aux =
               Utils.value_to_hash
                 ~init:
-                  Zeko_circuits.Bridge_state
-                  .Withdrawal_params_ethereum_token.hash_salt
+                  Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token
+                  .hash_salt
                 Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token.typ
                 withdrawal_params
             in
@@ -2974,7 +2974,8 @@ module Mutations = struct
                        ; params_fields
                        }
                  } ;
-               don't_wait_for proving ; key ) )
+               don't_wait_for proving ;
+               key ) )
 
     let register_ethereum_asset =
       io_field "registerEthereumAsset"

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -2930,7 +2930,9 @@ module Mutations = struct
               Zeko_sequencer.(sequencer.archive)
               ~aux:
                 (Utils.value_to_hash
-                   ~init:Zeko_constants.ethereum_erc20_withdrawal_salt
+                   ~init:
+                     Zeko_circuits.Bridge_state
+                     .Withdrawal_params_ethereum_token.hash_salt
                    Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token
                    .typ withdrawal_params )
               { Archive.Ethereum_withdrawal.recipient =

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -1121,10 +1121,16 @@ module Types = struct
     module Ethereum_assets = struct
       type t =
         { registry_public_key : Public_key.Compressed.t
+        ; registration_authority : Public_key.Compressed.t
         ; vault_public_key : Public_key.Compressed.t
+        ; registry_root : Snark_params.Tick.Field.t
+        ; registry_count : int
         ; registry_schema_version : int
         ; approved_mft_standard_vk_id : Snark_params.Tick.Field.t
+        ; approved_mft_token_vk_hash : Snark_params.Tick.Field.t
+        ; approved_mft_admin_vk_hash : Snark_params.Tick.Field.t
         ; universal_bridge_vk_id : Snark_params.Tick.Field.t
+        ; universal_bridge_vk_hash : Snark_params.Tick.Field.t
         ; bridge_verification_key_hash : Snark_params.Tick.Field.t
         ; registry_verification_key_hash : Snark_params.Tick.Field.t
         }
@@ -1134,9 +1140,19 @@ module Types = struct
             [ field "registryPublicKey" ~typ:(non_null public_key)
                 ~args:Arg.[]
                 ~resolve:(fun _ t -> t.registry_public_key)
+            ; field "registrationAuthority" ~typ:(non_null public_key)
+                ~args:Arg.[]
+                ~resolve:(fun _ t -> t.registration_authority)
             ; field "vaultPublicKey" ~typ:(non_null public_key)
                 ~args:Arg.[]
                 ~resolve:(fun _ t -> t.vault_public_key)
+            ; field "registryRoot" ~typ:(non_null string)
+                ~args:Arg.[]
+                ~resolve:(fun _ t ->
+                  Snark_params.Tick.Field.to_string t.registry_root )
+            ; field "registryCount" ~typ:(non_null int)
+                ~args:Arg.[]
+                ~resolve:(fun _ t -> t.registry_count)
             ; field "registrySchemaVersion" ~typ:(non_null int)
                 ~args:Arg.[]
                 ~resolve:(fun _ t -> t.registry_schema_version)
@@ -1145,10 +1161,25 @@ module Types = struct
                 ~resolve:(fun _ t ->
                   Snark_params.Tick.Field.to_string
                     t.approved_mft_standard_vk_id )
+            ; field "approvedMftTokenVkHash" ~typ:(non_null string)
+                ~args:Arg.[]
+                ~resolve:(fun _ t ->
+                  Snark_params.Tick.Field.to_string t.approved_mft_token_vk_hash
+                  )
+            ; field "approvedMftAdminVkHash" ~typ:(non_null string)
+                ~args:Arg.[]
+                ~resolve:(fun _ t ->
+                  Snark_params.Tick.Field.to_string t.approved_mft_admin_vk_hash
+                  )
             ; field "universalBridgeVkId" ~typ:(non_null string)
                 ~args:Arg.[]
                 ~resolve:(fun _ t ->
                   Snark_params.Tick.Field.to_string t.universal_bridge_vk_id )
+            ; field "universalBridgeVkHash" ~typ:(non_null string)
+                ~args:Arg.[]
+                ~resolve:(fun _ t ->
+                  Snark_params.Tick.Field.to_string t.universal_bridge_vk_hash
+                  )
             ; field "bridgeVerificationKeyHash" ~typ:(non_null string)
                 ~args:Arg.[]
                 ~resolve:(fun _ t ->
@@ -1559,19 +1590,33 @@ module Types = struct
 
         let arg_typ ~proof_cache_db =
           obj "EthereumTokenDepositParamsInput"
-            ~coerce:(fun asset_id_high asset_id_low base : input ->
+            ~coerce:(fun encoding_version registry_index record_commitment
+                         asset_id_high asset_id_low base : input ->
               { Zeko_circuits.Bridge_state.Deposit_params_ethereum_token
-                .asset_id_high = Field.of_string asset_id_high
+                .encoding_version =
+                  Zeko_circuits.Zeko_util.Checked32.of_string
+                    (Unsigned.UInt32.to_string encoding_version)
+              ; registry_index =
+                  Zeko_circuits.Zeko_util.Checked32.of_string
+                    (Unsigned.UInt32.to_string registry_index)
+              ; record_commitment = Field.of_string record_commitment
+              ; asset_id_high = Field.of_string asset_id_high
               ; asset_id_low = Field.of_string asset_id_low
               ; base
               } )
             ~split:(fun f (x : input) ->
               f
+                (Zeko_circuits.Zeko_util.Checked32.to_uint32 x.encoding_version)
+                (Zeko_circuits.Zeko_util.Checked32.to_uint32 x.registry_index)
+                (Field.to_string x.record_commitment)
                 (Field.to_string x.asset_id_high)
                 (Field.to_string x.asset_id_low)
                 x.base )
             ~fields:
-              [ arg "assetIdHigh" ~typ:(non_null string)
+              [ arg "encodingVersion" ~typ:(non_null UInt32.arg_typ)
+              ; arg "registryIndex" ~typ:(non_null UInt32.arg_typ)
+              ; arg "recordCommitment" ~typ:(non_null string)
+              ; arg "assetIdHigh" ~typ:(non_null string)
               ; arg "assetIdLow" ~typ:(non_null string)
               ; arg "base"
                   ~typ:(non_null @@ Deposit_params.arg_typ ~proof_cache_db)
@@ -1642,11 +1687,19 @@ module Types = struct
 
         let arg_typ ~proof_cache_db =
           obj "EthereumTokenWithdrawalParamsInput"
-            ~coerce:(fun asset_id_high asset_id_low token_owner sender_debit
+            ~coerce:(fun encoding_version registry_index record_commitment
+                         asset_id_high asset_id_low token_owner sender_debit
                          amount recipient ->
               Zeko_types.Bridge.Withdrawal_params_ethereum_token.of_serializable
                 ~proof_cache_db
-                { asset_id_high = Field.of_string asset_id_high
+                { encoding_version =
+                    Zeko_circuits.Zeko_util.Checked32.of_string
+                      (Unsigned.UInt32.to_string encoding_version)
+                ; registry_index =
+                    Zeko_circuits.Zeko_util.Checked32.of_string
+                      (Unsigned.UInt32.to_string registry_index)
+                ; record_commitment = Field.of_string record_commitment
+                ; asset_id_high = Field.of_string asset_id_high
                 ; asset_id_low = Field.of_string asset_id_low
                 ; token_owner_body = single_account_update_body token_owner
                 ; nested_children =
@@ -1668,6 +1721,9 @@ module Types = struct
                 .to_serializable x
               in
               f
+                (Zeko_circuits.Zeko_util.Checked32.to_uint32 x.encoding_version)
+                (Zeko_circuits.Zeko_util.Checked32.to_uint32 x.registry_index)
+                (Field.to_string x.record_commitment)
                 (Field.to_string x.asset_id_high)
                 (Field.to_string x.asset_id_low)
                 (account_update_body_to_json x.token_owner_body)
@@ -1677,7 +1733,10 @@ module Types = struct
                 (Currency.Amount.to_uint64 x.amount)
                 x.recipient )
             ~fields:
-              [ arg "assetIdHigh" ~typ:(non_null string)
+              [ arg "encodingVersion" ~typ:(non_null UInt32.arg_typ)
+              ; arg "registryIndex" ~typ:(non_null UInt32.arg_typ)
+              ; arg "recordCommitment" ~typ:(non_null string)
+              ; arg "assetIdHigh" ~typ:(non_null string)
               ; arg "assetIdLow" ~typ:(non_null string)
               ; arg "tokenOwner" ~typ:(non_null string)
               ; arg "senderDebit" ~typ:(non_null string)
@@ -1687,8 +1746,7 @@ module Types = struct
       end
 
       module Ethereum_asset_membership = struct
-        type input =
-          Bridge_inst_ethereum_token.Registry.Membership_witness.t
+        type input = Bridge_inst_ethereum_token.Registry.Membership_witness.t
 
         let arg_typ =
           scalar "EthereumAssetMembershipInput"
@@ -1704,8 +1762,8 @@ module Types = struct
                   Error "Expected a JSON-encoded Ethereum asset membership" )
             ~to_json:(fun membership ->
               `String
-                (Bridge_inst_ethereum_token.Registry.Membership_witness
-                 .to_yojson membership
+                ( Bridge_inst_ethereum_token.Registry.Membership_witness
+                  .to_yojson membership
                 |> Yojson.Safe.to_string ) )
       end
 
@@ -2200,8 +2258,7 @@ module Types = struct
 
         let arg_typ ~proof_cache_db =
           obj "EthereumTokenWithdrawalRequestInput"
-            ~coerce:(fun withdrawal_params asset ->
-              { withdrawal_params; asset } )
+            ~coerce:(fun withdrawal_params asset -> { withdrawal_params; asset })
             ~split:(fun f (x : input) -> f x.withdrawal_params x.asset)
             ~fields:
               [ arg "withdrawalParams"
@@ -2229,7 +2286,7 @@ module Types = struct
                   Error "Expected a JSON-encoded asset registration witness" )
             ~to_json:(fun witness ->
               `String
-                (Bridge_prover.Register_ethereum_asset.to_yojson witness
+                ( Bridge_prover.Register_ethereum_asset.to_yojson witness
                 |> Yojson.Safe.to_string ) )
       end
 
@@ -2881,10 +2938,8 @@ module Mutations = struct
               ; amount = withdrawal_params.custom.base.amount
               ; asset =
                   Some
-                    { token =
-                        ethereum_token_address_of_record asset.record
-                    ; asset_id =
-                        ethereum_asset_id_of_record asset.record
+                    { token = ethereum_token_address_of_record asset.record
+                    ; asset_id = ethereum_asset_id_of_record asset.record
                     ; params_fields
                     }
               } ;
@@ -3385,25 +3440,58 @@ module Queries = struct
         ; bridge_fee_recipient_l2 = Inputs.bridge_fee_recipient_l2
         ; bridge_proof_fee = Inputs.bridge_proof_fee
         ; ethereum_assets =
-            ( if Inputs.Ethereum_assets.enabled then
+            ( if Inputs.Ethereum_assets.enabled then (
+              let registry_state =
+                Zeko_sequencer.get_account sequencer
+                  Inputs.Ethereum_assets.registry_public_key Token_id.default
+                |> Option.bind ~f:(fun account -> account.zkapp)
+                |> Option.map ~f:(fun zkapp ->
+                       Zeko_circuits.Asset_registry.Registry_state
+                       .value_of_app_state zkapp.app_state )
+                |> Option.value_exn
+                     ~message:
+                       "Configured Ethereum asset registry account is missing"
+              in
+              if
+                not
+                  (Snark_params.Tick.Field.equal
+                     Inputs.Ethereum_assets.universal_bridge_vk_hash
+                     sequencer.bridge_prover.verification_keys
+                       .bridge_ethereum_token_l2 )
+              then
+                failwith
+                  "Configured universal Ethereum bridge VK hash does not match \
+                   the compiled circuit" ;
               Some
                 { Types.Circuits_config.Ethereum_assets.registry_public_key =
                     Inputs.Ethereum_assets.registry_public_key
+                ; registration_authority =
+                    Inputs.Ethereum_assets.registration_authority
                 ; vault_public_key = Inputs.Ethereum_assets.vault_public_key
+                ; registry_root = registry_state.root
+                ; registry_count =
+                    Zeko_circuits.Zeko_util.Checked32.to_int
+                      registry_state.leaf_count
                 ; registry_schema_version =
                     Zeko_circuits.Zeko_util.Checked32.to_int
                       Inputs.Ethereum_assets.registry_schema_version
                 ; approved_mft_standard_vk_id =
                     Inputs.Ethereum_assets.approved_mft_standard_vk_id
+                ; approved_mft_token_vk_hash =
+                    Inputs.Ethereum_assets.approved_mft_token_vk_hash
+                ; approved_mft_admin_vk_hash =
+                    Inputs.Ethereum_assets.approved_mft_admin_vk_hash
                 ; universal_bridge_vk_id =
                     Inputs.Ethereum_assets.universal_bridge_vk_id
+                ; universal_bridge_vk_hash =
+                    Inputs.Ethereum_assets.universal_bridge_vk_hash
                 ; bridge_verification_key_hash =
                     sequencer.bridge_prover.verification_keys
                       .bridge_ethereum_token_l2
                 ; registry_verification_key_hash =
                     sequencer.bridge_prover.verification_keys
                       .ethereum_asset_registry
-                }
+                } )
             else None )
         } )
 
@@ -3450,13 +3538,15 @@ module Queries = struct
           Archive.get_actions sequencer.archive
             (Account_id.create public_key token_id)
             ~from:from_action_state ~to_:end_action_state
-          |> Result.map ~f:
-               (List.filter ~f:(fun (action : Archive.Account_update_actions.t) ->
-                    Option.for_all action.block_info ~f:(fun block_info ->
-                        Option.for_all from_block ~f:(fun from_block ->
-                            block_info.height >= from_block )
-                        && Option.for_all to_block ~f:(fun to_block ->
-                               block_info.height < to_block ) ) ) )
+          |> Result.map
+               ~f:
+                 (List.filter
+                    ~f:(fun (action : Archive.Account_update_actions.t) ->
+                      Option.for_all action.block_info ~f:(fun block_info ->
+                          Option.for_all from_block ~f:(fun from_block ->
+                              block_info.height >= from_block )
+                          && Option.for_all to_block ~f:(fun to_block ->
+                                 block_info.height < to_block ) ) ) )
           |> return )
 
     let events =
@@ -3469,11 +3559,7 @@ module Queries = struct
                   (non_null Types.Input.Archive.EventFilterOptionsInput.arg_typ)
             ]
         ~resolve:(fun { ctx = { sequencer; _ }; _ } ()
-                      ( public_key
-                      , token_id
-                      , from_block
-                      , to_block
-                      , _status ) ->
+                      (public_key, token_id, from_block, to_block, _status) ->
           let token_id = Option.value ~default:Token_id.default token_id in
           Archive.get_events sequencer.archive
             (Account_id.create public_key token_id)

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -1074,6 +1074,40 @@ module Types = struct
   end
 
   module Circuits_config = struct
+    module Ethereum_token = struct
+      type t =
+        { asset_id : string
+        ; ethereum_token_address : string
+        ; token_owner_l2 : Public_key.Compressed.t
+        ; token_id_l2 : Token_id.t
+        ; holder_account_l2 : Public_key.Compressed.t
+        ; verification_key_hash : Snark_params.Tick.Field.t
+        }
+
+      let t : (Context.t, t option) typ =
+        obj "ZekoEthereumTokenConfig" ~fields:(fun _ ->
+            [ field "assetId" ~typ:(non_null string)
+                ~args:Arg.[]
+                ~resolve:(fun _ t -> t.asset_id)
+            ; field "ethereumTokenAddress" ~typ:(non_null string)
+                ~args:Arg.[]
+                ~resolve:(fun _ t -> t.ethereum_token_address)
+            ; field "tokenOwnerL2" ~typ:(non_null public_key)
+                ~args:Arg.[]
+                ~resolve:(fun _ t -> t.token_owner_l2)
+            ; field "tokenIdL2" ~typ:(non_null string)
+                ~args:Arg.[]
+                ~resolve:(fun _ t -> Token_id.to_string t.token_id_l2)
+            ; field "holderAccountL2" ~typ:(non_null public_key)
+                ~args:Arg.[]
+                ~resolve:(fun _ t -> t.holder_account_l2)
+            ; field "verificationKeyHash" ~typ:(non_null string)
+                ~args:Arg.[]
+                ~resolve:(fun _ t ->
+                  Snark_params.Tick.Field.to_string t.verification_key_hash )
+            ] )
+    end
+
     type t =
       { zeko_l1 : Public_key.Compressed.t
       ; zeko_l2 : Public_key.Compressed.t
@@ -1088,6 +1122,7 @@ module Types = struct
       ; bridge_fee_recipient_l1 : Public_key.Compressed.t
       ; bridge_fee_recipient_l2 : Public_key.Compressed.t
       ; bridge_proof_fee : Currency.Amount.t
+      ; ethereum_token : Ethereum_token.t option
       }
 
     let signature_kind_to_string = function
@@ -1140,6 +1175,9 @@ module Types = struct
           ; field "bridgeProofFee" ~typ:(non_null amount)
               ~args:Arg.[]
               ~resolve:(fun _ t -> t.bridge_proof_fee)
+          ; field "ethereumToken" ~typ:Ethereum_token.t
+              ~args:Arg.[]
+              ~resolve:(fun _ t -> t.ethereum_token)
           ] )
   end
 
@@ -1462,6 +1500,30 @@ module Types = struct
               ]
       end
 
+      module Ethereum_token_deposit_params = struct
+        type input = Zeko_types.Bridge.Deposit_params_ethereum_token.t
+
+        let arg_typ ~proof_cache_db =
+          obj "EthereumTokenDepositParamsInput"
+            ~coerce:(fun asset_id_high asset_id_low base : input ->
+              { Zeko_circuits.Bridge_state.Deposit_params_ethereum_token
+                .asset_id_high = Field.of_string asset_id_high
+              ; asset_id_low = Field.of_string asset_id_low
+              ; base
+              } )
+            ~split:(fun f (x : input) ->
+              f
+                (Field.to_string x.asset_id_high)
+                (Field.to_string x.asset_id_low)
+                x.base )
+            ~fields:
+              [ arg "assetIdHigh" ~typ:(non_null string)
+              ; arg "assetIdLow" ~typ:(non_null string)
+              ; arg "base"
+                  ~typ:(non_null @@ Deposit_params.arg_typ ~proof_cache_db)
+              ]
+      end
+
       module Withdrawal_params = struct
         type input =
           Zeko_types.Bridge.Finalize_withdrawal.Withdrawal_params_base.t
@@ -1495,6 +1557,76 @@ module Types = struct
                 x.recipient )
             ~fields:
               [ arg "children" ~typ:(non_null string)
+              ; arg "amount" ~typ:(non_null UInt64.arg_typ)
+              ; arg "recipient" ~typ:(non_null PublicKey.arg_typ)
+              ]
+      end
+
+      module Ethereum_token_withdrawal_params = struct
+        type input = Zeko_types.Bridge.Withdrawal_params_ethereum_token.t
+
+        let single_account_update_body json =
+          match
+            Yojson.Safe.from_string json
+            |> Mina_base.Zkapp_command.account_updates_of_json
+            |> List.map ~f:Account_update.of_graphql_repr
+          with
+          | [ update ] ->
+              update.body
+          | _ ->
+              failwith
+                "tokenOwner must encode exactly one top-level account update"
+
+        let account_update_body_to_json body =
+          Mina_base.Zkapp_command.Call_forest.cons
+            ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+            (Account_update.with_no_aux ~body
+               ~authorization:Control.Poly.None_given )
+            []
+          |> Mina_base.Zkapp_command.account_updates_to_json
+          |> Yojson.Safe.to_string
+
+        let arg_typ ~proof_cache_db =
+          obj "EthereumTokenWithdrawalParamsInput"
+            ~coerce:(fun asset_id_high asset_id_low token_owner sender_debit
+                         amount recipient ->
+              Zeko_types.Bridge.Withdrawal_params_ethereum_token.of_serializable
+                ~proof_cache_db
+                { asset_id_high = Field.of_string asset_id_high
+                ; asset_id_low = Field.of_string asset_id_low
+                ; token_owner_body = single_account_update_body token_owner
+                ; nested_children =
+                    Yojson.Safe.from_string sender_debit
+                    |> Mina_base.Zkapp_command.account_updates_of_json
+                    |> Mina_base.Zkapp_command.Call_forest
+                       .of_account_updates_map ~f:Account_update.of_graphql_repr
+                         ~account_update_depth:(fun au -> au.body.call_depth)
+                    |> Mina_base.Zkapp_command.Call_forest
+                       .accumulate_hashes_predicated
+                         ~signature_kind:Zeko_circuits_config.t.chain_l2
+                ; children = []
+                ; amount = Currency.Amount.of_uint64 amount
+                ; recipient
+                } )
+            ~split:(fun f (x : input) ->
+              let x =
+                Zeko_types.Bridge.Withdrawal_params_ethereum_token
+                .to_serializable x
+              in
+              f
+                (Field.to_string x.asset_id_high)
+                (Field.to_string x.asset_id_low)
+                (account_update_body_to_json x.token_owner_body)
+                ( Yojson.Safe.to_string
+                @@ Mina_base.Zkapp_command.account_updates_to_json
+                     x.nested_children )
+                (Currency.Amount.to_uint64 x.amount)
+                x.recipient )
+            ~fields:
+              [ arg "assetIdHigh" ~typ:(non_null string)
+              ; arg "assetIdLow" ~typ:(non_null string)
+              ; arg "tokenOwner" ~typ:(non_null string)
+              ; arg "senderDebit" ~typ:(non_null string)
               ; arg "amount" ~typ:(non_null UInt64.arg_typ)
               ; arg "recipient" ~typ:(non_null PublicKey.arg_typ)
               ]
@@ -1693,6 +1825,68 @@ module Types = struct
                 ; arg "elems" ~typ:(non_null @@ list @@ non_null Elem.arg_typ)
                 ]
         end
+
+        module Check_accepted_ethereum_token = struct
+          module Init = struct
+            type input = Bridge.Check_accepted_ethereum_token.Init.t
+
+            let arg_typ ~proof_cache_db =
+              obj "CheckAcceptedEthereumTokenInitInput"
+                ~coerce:(fun params original_action_state deposit_index : input ->
+                  { params
+                  ; original_action_state =
+                      Zeko_circuits.Rollup_state.Outer_action_state
+                      .unsafe_value_of_field
+                      @@ Field.of_string original_action_state
+                  ; deposit_index
+                  } )
+                ~split:(fun f (x : input) ->
+                  f x.params
+                    ( Field.to_string
+                    @@ Zeko_circuits.Rollup_state.Outer_action_state.raw
+                         x.original_action_state )
+                    x.deposit_index )
+                ~fields:
+                  [ arg "params"
+                      ~typ:
+                        ( non_null
+                        @@ Ethereum_token_deposit_params.arg_typ ~proof_cache_db
+                        )
+                  ; arg "originalActionState" ~typ:(non_null string)
+                  ; arg "depositIndex" ~typ:(non_null UInt32.arg_typ)
+                  ]
+          end
+
+          module Elem = struct
+            type input = Bridge.Check_accepted_ethereum_token.Elem.t
+
+            let arg_typ =
+              obj "CheckAcceptedEthereumTokenElemInput"
+                ~coerce:(fun actions ->
+                  Result.try_with (fun () ->
+                      Utils.actions_to_outer_action
+                        (List.map actions ~f:Field.of_string |> Array.of_list) )
+                  |> Result.map_error ~f:Error.of_exn )
+                ~split:(fun f (x : input) ->
+                  f
+                    ( Utils.actions_of_outer_action x
+                    |> Array.map ~f:Field.to_string
+                    |> Array.to_list ) )
+                ~fields:
+                  [ arg "actions" ~typ:(non_null @@ list @@ non_null string) ]
+          end
+
+          type input = Init.input * Elem.input list
+
+          let arg_typ ~proof_cache_db =
+            obj "CheckAcceptedEthereumTokenInput"
+              ~coerce:(fun init elems -> (init, elems))
+              ~split:(fun f ((init, elems) : input) -> f init elems)
+              ~fields:
+                [ arg "init" ~typ:(non_null @@ Init.arg_typ ~proof_cache_db)
+                ; arg "elems" ~typ:(non_null @@ list @@ non_null Elem.arg_typ)
+                ]
+        end
       end
 
       module Outer_action_witness = struct
@@ -1875,6 +2069,63 @@ module Types = struct
               ; arg "helperAccountNew" ~typ:(non_null bool)
               ; arg "helperAccountSignature"
                   ~typ:(non_null SignatureInput.arg_typ)
+              ]
+      end
+
+      module Finalize_ethereum_token_deposit = struct
+        type input =
+          { ase : Ase.With_length.Stmt.t * Field.t list
+          ; check_accepted :
+              Bridge.Check_accepted_ethereum_token.Init.t
+              * Bridge.Check_accepted_ethereum_token.Elem.t list
+          ; prev_next_deposit : Unsigned.uint32
+          ; prev_nonce : Unsigned.uint32
+          ; helper_account_new : bool
+          }
+
+        let arg_typ ~proof_cache_db =
+          obj "FinalizeEthereumTokenDepositInput"
+            ~coerce:(fun ase (check_accepted_init, check_accepted_elems)
+                         prev_next_deposit prev_nonce helper_account_new ->
+              let%map.Result check_accepted_elems =
+                Result.all check_accepted_elems
+              in
+              { ase
+              ; check_accepted = (check_accepted_init, check_accepted_elems)
+              ; prev_next_deposit
+              ; prev_nonce
+              ; helper_account_new
+              } )
+            ~split:(fun f (x : input) ->
+              f x.ase x.check_accepted x.prev_next_deposit x.prev_nonce
+                x.helper_account_new )
+            ~fields:
+              [ arg "ase" ~typ:(non_null Folder.Ase_with_length.arg_typ)
+              ; arg "checkAccepted"
+                  ~typ:
+                    ( non_null
+                    @@ Folder.Check_accepted_ethereum_token.arg_typ
+                         ~proof_cache_db )
+              ; arg "prevNextDeposit" ~typ:(non_null UInt32.arg_typ)
+              ; arg "prevNonce" ~typ:(non_null UInt32.arg_typ)
+              ; arg "helperAccountNew" ~typ:(non_null bool)
+              ]
+      end
+
+      module Ethereum_token_withdrawal_request = struct
+        type input =
+          { withdrawal_params : Ethereum_token_withdrawal_params.input }
+
+        let arg_typ ~proof_cache_db =
+          obj "EthereumTokenWithdrawalRequestInput"
+            ~coerce:(fun withdrawal_params -> { withdrawal_params })
+            ~split:(fun f (x : input) -> f x.withdrawal_params)
+            ~fields:
+              [ arg "withdrawalParams"
+                  ~typ:
+                    ( non_null
+                    @@ Ethereum_token_withdrawal_params.arg_typ ~proof_cache_db
+                    )
               ]
       end
 
@@ -2460,6 +2711,61 @@ module Mutations = struct
              in
              don't_wait_for d ; Ok key ) )
 
+    let ethereum_token_withdrawal_request ~proof_cache_db =
+      io_field "proveEthereumTokenWithdrawalRequest"
+        ~doc:
+          "Prove an ERC20 withdrawal witness forest for subsequent standard \
+           FungibleToken approval"
+        ~typ:(non_null Types.Payload.proof_key)
+        ~args:
+          Arg.
+            [ arg "input"
+                ~typ:
+                  ( non_null
+                  @@ Types.Input.Provers.Ethereum_token_withdrawal_request
+                     .arg_typ ~proof_cache_db )
+            ]
+        ~resolve:(fun { ctx = Context.{ sequencer; _ }; _ } ()
+                      { withdrawal_params } ->
+          if not Zeko_circuits_config.Inputs.Ethereum_token.enabled then
+            return (Error "Ethereum token bridge is not configured")
+          else
+            let params_fields =
+              Utils.value_to_fields
+                Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token.typ
+                withdrawal_params
+              |> Array.to_list
+            in
+            Archive.store_ethereum_withdrawal
+              Zeko_sequencer.(sequencer.archive)
+              ~aux:
+                (Utils.value_to_hash
+                   ~init:Zeko_constants.ethereum_erc20_withdrawal_salt
+                   Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token
+                   .typ withdrawal_params )
+              { Archive.Ethereum_withdrawal.recipient =
+                  withdrawal_params.custom.base.recipient
+              ; amount = withdrawal_params.custom.base.amount
+              ; asset =
+                  Some
+                    { token =
+                        Zeko_circuits_config.Inputs.Ethereum_token
+                        .ethereum_token_address
+                    ; asset_id =
+                        Zeko_circuits_config.Inputs.Ethereum_token.asset_id
+                    ; params_fields
+                    }
+              } ;
+            let logger = Zeko_sequencer.(sequencer.logger) in
+            let t = Zeko_sequencer.(sequencer.bridge_prover) in
+            return
+              (let%map.Result key, proving =
+                 Bridge_prover.Ethereum_token_withdrawal_request.f ~t ~logger
+                   { withdrawal_params }
+                 |> Result.map_error ~f:Error.to_string_hum
+               in
+               don't_wait_for proving ; key ) )
+
     let finalize_deposit ~proof_cache_db =
       io_field "finalizeDeposit" ~doc:"Finalize a deposit"
         ~typ:(non_null Types.Payload.proof_key)
@@ -2507,6 +2813,47 @@ module Mutations = struct
                >>| ignore
              in
              don't_wait_for d ; Ok key ) )
+
+    let finalize_ethereum_token_deposit ~proof_cache_db =
+      io_field "finalizeEthereumTokenDeposit"
+        ~doc:
+          "Prove an ERC20 vault-to-recipient deposit forest for subsequent \
+           standard FungibleToken approval"
+        ~typ:(non_null Types.Payload.proof_key)
+        ~args:
+          Arg.
+            [ arg "input"
+                ~typ:
+                  ( non_null
+                  @@ Types.Input.Provers.Finalize_ethereum_token_deposit.arg_typ
+                       ~proof_cache_db )
+            ]
+        ~resolve:(fun { ctx = Context.{ sequencer; _ }; _ } () witness ->
+          let%bind.Deferred.Result { ase = ase_source, ase_elems
+                                   ; check_accepted =
+                                       check_accepted_init, check_accepted_elems
+                                   ; prev_next_deposit
+                                   ; prev_nonce
+                                   ; helper_account_new
+                                   } =
+            return (Result.map_error witness ~f:Error.to_string_hum)
+          in
+          let logger = Zeko_sequencer.(sequencer.logger) in
+          let t = Zeko_sequencer.(sequencer.bridge_prover) in
+          return
+            (let%map.Result key, proving =
+               Bridge_prover.Finalize_ethereum_token_deposit.f ~t ~logger
+                 { ase_source
+                 ; ase_elems
+                 ; check_accepted_init
+                 ; check_accepted_elems
+                 ; prev_next_deposit
+                 ; prev_nonce
+                 ; helper_account_new
+                 }
+               |> Result.map_error ~f:Error.to_string_hum
+             in
+             don't_wait_for proving ; key ) )
 
     let finalize_withdrawal ~proof_cache_db =
       io_field "finalizeWithdrawal" ~doc:"Finalize a withdrawal"
@@ -2633,7 +2980,9 @@ module Mutations = struct
     let commands ~proof_cache_db =
       [ deposit_request ~proof_cache_db
       ; withdrawal_request ~proof_cache_db
+      ; ethereum_token_withdrawal_request ~proof_cache_db
       ; finalize_deposit ~proof_cache_db
+      ; finalize_ethereum_token_deposit ~proof_cache_db
       ; finalize_withdrawal ~proof_cache_db
       ; cancel_deposit ~proof_cache_db
       ]
@@ -2867,6 +3216,24 @@ module Queries = struct
         ; bridge_fee_recipient_l1 = Inputs.bridge_fee_recipient_l1
         ; bridge_fee_recipient_l2 = Inputs.bridge_fee_recipient_l2
         ; bridge_proof_fee = Inputs.bridge_proof_fee
+        ; ethereum_token =
+            ( if Inputs.Ethereum_token.enabled then
+              Some
+                { Types.Circuits_config.Ethereum_token.asset_id =
+                    Inputs.Ethereum_token.asset_id
+                ; ethereum_token_address =
+                    Inputs.Ethereum_token.ethereum_token_address
+                ; token_owner_l2 =
+                    Account_id.public_key Inputs.Ethereum_token.token_owner_l2
+                ; token_id_l2 =
+                    Account_id.derive_token_id
+                      ~owner:Inputs.Ethereum_token.token_owner_l2
+                ; holder_account_l2 = Inputs.Ethereum_token.holder_account_l2
+                ; verification_key_hash =
+                    sequencer.bridge_prover.verification_keys
+                      .bridge_ethereum_token_l2
+                }
+            else None )
         } )
 
   let sequencer_pk =

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -2163,6 +2163,7 @@ module Types = struct
         let arg_typ ~proof_cache_db =
           obj "WithdrawalRequestInput"
             ~coerce:(fun withdrawal_params transferrer ->
+              let%map.Result withdrawal_params = withdrawal_params in
               { withdrawal_params; transferrer } )
             ~split:(fun f (x : input) -> f x.withdrawal_params x.transferrer)
             ~fields:
@@ -2268,7 +2269,9 @@ module Types = struct
 
         let arg_typ ~proof_cache_db =
           obj "EthereumTokenWithdrawalRequestInput"
-            ~coerce:(fun withdrawal_params asset -> { withdrawal_params; asset })
+            ~coerce:(fun withdrawal_params asset ->
+              let%map.Result withdrawal_params = withdrawal_params in
+              { withdrawal_params; asset } )
             ~split:(fun f (x : input) -> f x.withdrawal_params x.asset)
             ~fields:
               [ arg "withdrawalParams"
@@ -2399,6 +2402,7 @@ module Types = struct
                          before_withdrawal withdrawal_ase prev_next_withdrawal
                          withdrawal_params prev_nonce helper_account_new
                          helper_account_signature ->
+              let%bind.Result withdrawal_params = withdrawal_params in
               let%map.Result commit =
                 match%bind.Result commit with
                 | Commit commit ->
@@ -2880,7 +2884,10 @@ module Mutations = struct
                        ~proof_cache_db )
             ]
         ~resolve:(fun { ctx = Context.{ sequencer; l2_executor; _ }; _ } ()
-                      { withdrawal_params; transferrer } ->
+                      request ->
+          let%bind.Deferred.Result { withdrawal_params; transferrer } =
+            return (Result.map_error request ~f:Error.to_string_hum)
+          in
           let logger = Zeko_sequencer.(sequencer.logger) in
           let t = Zeko_sequencer.(sequencer.bridge_prover) in
           let withdrawal_aux =
@@ -2925,8 +2932,10 @@ module Mutations = struct
                   @@ Types.Input.Provers.Ethereum_token_withdrawal_request
                      .arg_typ ~proof_cache_db )
             ]
-        ~resolve:(fun { ctx = Context.{ sequencer; _ }; _ } ()
-                      { withdrawal_params; asset } ->
+        ~resolve:(fun { ctx = Context.{ sequencer; _ }; _ } () request ->
+          let%bind.Deferred.Result { withdrawal_params; asset } =
+            return (Result.map_error request ~f:Error.to_string_hum)
+          in
           if not Zeko_circuits_config.Inputs.Ethereum_assets.enabled then
             return (Error "Ethereum token bridge is not configured")
           else

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -337,13 +337,13 @@ module Sequencer = struct
       (state_of_account account).leaf_count
       |> C.Zeko_util.Checked32.to_int
 
-    let command_updates_count_for_account ~registry_id command =
+    let count_command_updates_for_account ~registry_id command =
       match command with
       | Signed_command _ ->
-          false
+          0
       | Zkapp_command command ->
           Zkapp_command.all_account_updates_list command
-          |> List.exists ~f:(fun update ->
+          |> List.count ~f:(fun update ->
                  Account_id.equal
                    (Account_update.account_id update)
                    registry_id
@@ -354,13 +354,25 @@ module Sequencer = struct
                  | _ ->
                      false )
 
-    let command_updates_count command =
-      Zeko_circuits_config.Inputs.Ethereum_assets.enabled
-      && command_updates_count_for_account ~registry_id:(account_id ()) command
+    let count_command_updates command =
+      if Zeko_circuits_config.Inputs.Ethereum_assets.enabled then
+        count_command_updates_for_account ~registry_id:(account_id ()) command
+      else 0
+
+    let validate_update_count registry_update_count =
+      if registry_update_count > 1 then
+        Or_error.errorf
+          "PoC settlement permits only one Ethereum asset registration update \
+           per command"
+      else if registry_update_count < 0 then
+        Or_error.error_string
+          "Ethereum asset registration update count cannot be negative"
+      else Ok ()
 
     let validate_counts ~committed_count ~current_count
-        ~updates_registry_count =
-      if not updates_registry_count then Ok ()
+        ~registry_update_count =
+      let%bind.Result () = validate_update_count registry_update_count in
+      if Int.equal registry_update_count 0 then Ok ()
       else if current_count < committed_count then
         Or_error.errorf
           "Ethereum asset registry count regressed from committed %d to %d"
@@ -372,7 +384,9 @@ module Sequencer = struct
       else Ok ()
 
     let validate t command =
-      if not (command_updates_count command) then Ok ()
+      let registry_update_count = count_command_updates command in
+      let%bind.Result () = validate_update_count registry_update_count in
+      if Int.equal registry_update_count 0 then Ok ()
       else
         let registry_id = account_id () in
         let current_account =
@@ -392,7 +406,7 @@ module Sequencer = struct
         in
         validate_counts ~committed_count:(count_of_account committed_account)
           ~current_count:(count_of_account current_account)
-          ~updates_registry_count:true
+          ~registry_update_count
   end
 
   let infer_nonce t public_key =

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -323,6 +323,78 @@ module Sequencer = struct
     let%bind.Option location = L.Db.location_of_account t.ledger account_id in
     L.Db.get t.ledger location
 
+  module Ethereum_asset_registry_admission = struct
+    let account_id () =
+      Account_id.create
+        Zeko_circuits_config.Inputs.Ethereum_assets.registry_public_key
+        Token_id.default
+
+    let state_of_account account =
+      (Option.value_exn account.Account.zkapp).app_state
+      |> C.Asset_registry.Registry_state.value_of_app_state
+
+    let count_of_account account =
+      (state_of_account account).leaf_count
+      |> C.Zeko_util.Checked32.to_int
+
+    let command_updates_count_for_account ~registry_id command =
+      match command with
+      | Signed_command _ ->
+          false
+      | Zkapp_command command ->
+          Zkapp_command.all_account_updates_list command
+          |> List.exists ~f:(fun update ->
+                 Account_id.equal
+                   (Account_update.account_id update)
+                   registry_id
+                 &&
+                 match Zkapp_state.V.to_list update.body.update.app_state with
+                 | _root :: leaf_count :: _ ->
+                     Zkapp_basic.Set_or_keep.is_set leaf_count
+                 | _ ->
+                     false )
+
+    let command_updates_count command =
+      Zeko_circuits_config.Inputs.Ethereum_assets.enabled
+      && command_updates_count_for_account ~registry_id:(account_id ()) command
+
+    let validate_counts ~committed_count ~current_count
+        ~updates_registry_count =
+      if not updates_registry_count then Ok ()
+      else if current_count < committed_count then
+        Or_error.errorf
+          "Ethereum asset registry count regressed from committed %d to %d"
+          committed_count current_count
+      else if current_count > committed_count then
+        Or_error.errorf
+          "PoC settlement permits only one pending Ethereum asset registration \
+           per commit"
+      else Ok ()
+
+    let validate t command =
+      if not (command_updates_count command) then Ok ()
+      else
+        let registry_id = account_id () in
+        let current_account =
+          get_account t
+            (Account_id.public_key registry_id)
+            (Account_id.token_id registry_id)
+          |> Option.value_exn
+               ~message:"Configured Ethereum asset registry is missing"
+        in
+        let committed_account =
+          let ledger =
+            State.Last_committed_ledger.get t.state
+            |> Option.value_exn ~message:"No previous committed ledger"
+          in
+          let index = Sparse_ledger.find_index_exn ledger registry_id in
+          Sparse_ledger.get_exn ledger index
+        in
+        validate_counts ~committed_count:(count_of_account committed_account)
+          ~current_count:(count_of_account current_account)
+          ~updates_registry_count:true
+  end
+
   let infer_nonce t public_key =
     match get_account t public_key Token_id.default with
     | Some account ->
@@ -431,6 +503,10 @@ module Sequencer = struct
               | _ ->
                   return (Ok command)
             else return (Ok command)
+          in
+
+          let%bind.Deferred.Result () =
+            return (Ethereum_asset_registry_admission.validate t command)
           in
 
           let%bind.Deferred.Result () =
@@ -828,13 +904,7 @@ module Sequencer = struct
                   []
                 else
                   let registry_id =
-                    Account_id.create
-                      Zeko_circuits_config.Inputs.Ethereum_assets
-                      .registry_public_key Token_id.default
-                  in
-                  let registry_state account =
-                    (Option.value_exn account.Account.zkapp).app_state
-                    |> C.Asset_registry.Registry_state.value_of_app_state
+                    Ethereum_asset_registry_admission.account_id ()
                   in
                   let old_registry =
                     let ledger =
@@ -845,7 +915,8 @@ module Sequencer = struct
                     let index =
                       Sparse_ledger.find_index_exn ledger registry_id
                     in
-                    Sparse_ledger.get_exn ledger index |> registry_state
+                    Sparse_ledger.get_exn ledger index
+                    |> Ethereum_asset_registry_admission.state_of_account
                   in
                   let new_registry =
                     let location =
@@ -855,7 +926,7 @@ module Sequencer = struct
                              "Configured Ethereum asset registry is missing"
                     in
                     L.get full_ledger location |> Option.value_exn
-                    |> registry_state
+                    |> Ethereum_asset_registry_admission.state_of_account
                   in
                   let old_count =
                     C.Zeko_util.Checked32.to_int old_registry.leaf_count

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -9,6 +9,16 @@ module C = Zeko_circuits
 module L = Ledger
 module Field = Snark_params.Tick.Field
 
+let committed_account_ids () =
+  Zeko_constants.inner_account_id
+  ::
+  if Zeko_circuits_config.Inputs.Ethereum_assets.enabled then
+    [ Account_id.create
+        Zeko_circuits_config.Inputs.Ethereum_assets.registry_public_key
+        Token_id.default
+    ]
+  else []
+
 module Sequencer = struct
   let constraint_constants = Zeko_constants.constraint_constants
 
@@ -811,7 +821,7 @@ module Sequencer = struct
               let target_ledger =
                 Sparse_ledger.of_ledger_subset_exn
                   L.(of_database t.ledger)
-                  [ Zeko_constants.inner_account_id ]
+                  (committed_account_ids ())
               in
               let () =
                 match t.config.checkpoints_dir with
@@ -1031,7 +1041,7 @@ module Sequencer = struct
     let sparse_ledger =
       Sparse_ledger.of_ledger_subset_exn
         L.(of_database t.ledger)
-        [ Zeko_constants.inner_account_id ]
+        (committed_account_ids ())
     in
     State.Last_committed_ledger.set t.state ~data:sparse_ledger ;
     return ()

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -334,20 +334,17 @@ module Sequencer = struct
       |> C.Asset_registry.Registry_state.value_of_app_state
 
     let count_of_account account =
-      (state_of_account account).leaf_count
-      |> C.Zeko_util.Checked32.to_int
+      (state_of_account account).leaf_count |> C.Zeko_util.Checked32.to_int
 
-    let count_command_updates_for_account ~registry_id
-        (command : User_command.t) =
+    let count_command_updates_for_account ~registry_id (command : User_command.t)
+        =
       match command with
       | Signed_command _ ->
           0
       | Zkapp_command command ->
           Zkapp_command.all_account_updates_list command
           |> List.count ~f:(fun update ->
-                 Account_id.equal
-                   (Account_update.account_id update)
-                   registry_id
+                 Account_id.equal (Account_update.account_id update) registry_id
                  &&
                  match Zkapp_state.V.to_list update.body.update.app_state with
                  | _root :: leaf_count :: _ ->
@@ -370,8 +367,7 @@ module Sequencer = struct
           "Ethereum asset registration update count cannot be negative"
       else Ok ()
 
-    let validate_counts ~committed_count ~current_count
-        ~registry_update_count =
+    let validate_counts ~committed_count ~current_count ~registry_update_count =
       let%bind.Result () = validate_update_count registry_update_count in
       if Int.equal registry_update_count 0 then Ok ()
       else if current_count < committed_count then
@@ -405,7 +401,8 @@ module Sequencer = struct
           let index = Sparse_ledger.find_index_exn ledger registry_id in
           Sparse_ledger.get_exn ledger index
         in
-        validate_counts ~committed_count:(count_of_account committed_account)
+        validate_counts
+          ~committed_count:(count_of_account committed_account)
           ~current_count:(count_of_account current_account)
           ~registry_update_count
   end

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -337,7 +337,8 @@ module Sequencer = struct
       (state_of_account account).leaf_count
       |> C.Zeko_util.Checked32.to_int
 
-    let count_command_updates_for_account ~registry_id command =
+    let count_command_updates_for_account ~registry_id
+        (command : User_command.t) =
       match command with
       | Signed_command _ ->
           0

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -9,15 +9,20 @@ module C = Zeko_circuits
 module L = Ledger
 module Field = Snark_params.Tick.Field
 
-let committed_account_ids () =
+let committed_account_ids ?(ethereum_asset_accounts = []) () =
   Zeko_constants.inner_account_id
   ::
-  if Zeko_circuits_config.Inputs.Ethereum_assets.enabled then
+  ( if Zeko_circuits_config.Inputs.Ethereum_assets.enabled then
     [ Account_id.create
         Zeko_circuits_config.Inputs.Ethereum_assets.registry_public_key
         Token_id.default
     ]
-  else []
+    @ ethereum_asset_accounts
+  else [] )
+
+let compressed_public_key_of_fields x is_odd =
+  let (Typ typ) = Signature_lib.Public_key.Compressed.typ in
+  typ.value_of_fields ([| x; is_odd |], typ.constraint_system_auxiliary ())
 
 module Sequencer = struct
   let constraint_constants = Zeko_constants.constraint_constants
@@ -276,7 +281,6 @@ module Sequencer = struct
       ; last_attempt_started_at = t.last_attempt_started_at
       ; next_attempt_at = t.next_attempt_at
       }
-
   end
 
   type t =
@@ -818,10 +822,94 @@ module Sequencer = struct
               [%log info] "Nothing to commit" ;
               return None )
             else
+              let full_ledger = L.of_database t.ledger in
+              let ethereum_asset_accounts =
+                if not Zeko_circuits_config.Inputs.Ethereum_assets.enabled then
+                  []
+                else
+                  let registry_id =
+                    Account_id.create
+                      Zeko_circuits_config.Inputs.Ethereum_assets
+                      .registry_public_key Token_id.default
+                  in
+                  let registry_state account =
+                    (Option.value_exn account.Account.zkapp).app_state
+                    |> C.Asset_registry.Registry_state.value_of_app_state
+                  in
+                  let old_registry =
+                    let ledger =
+                      State.Last_committed_ledger.get t.state
+                      |> Option.value_exn
+                           ~message:"No previous committed ledger"
+                    in
+                    let index =
+                      Sparse_ledger.find_index_exn ledger registry_id
+                    in
+                    Sparse_ledger.get_exn ledger index |> registry_state
+                  in
+                  let new_registry =
+                    let location =
+                      L.location_of_account full_ledger registry_id
+                      |> Option.value_exn
+                           ~message:
+                             "Configured Ethereum asset registry is missing"
+                    in
+                    L.get full_ledger location |> Option.value_exn
+                    |> registry_state
+                  in
+                  let old_count =
+                    C.Zeko_util.Checked32.to_int old_registry.leaf_count
+                  in
+                  let new_count =
+                    C.Zeko_util.Checked32.to_int new_registry.leaf_count
+                  in
+                  match new_count - old_count with
+                  | 0 ->
+                      []
+                  | 1 ->
+                      let candidate =
+                        Ethereum_settlement_export.registry_records_from_archive
+                          ~archive:t.archive
+                        |> Fn.flip List.nth_exn old_count
+                      in
+                      let owner_id =
+                        Account_id.create candidate.token_owner_l2
+                          Token_id.default
+                      in
+                      let owner =
+                        let location =
+                          L.location_of_account full_ledger owner_id
+                          |> Option.value_exn
+                               ~message:
+                                 "Registered Ethereum token owner is missing"
+                        in
+                        L.get full_ledger location |> Option.value_exn
+                      in
+                      let owner_state =
+                        (Option.value_exn owner.zkapp).app_state
+                        |> Zkapp_state.V.to_list
+                      in
+                      let admin_public_key =
+                        compressed_public_key_of_fields
+                          (List.nth_exn owner_state 1)
+                          (List.nth_exn owner_state 2)
+                      in
+                      [ owner_id
+                      ; Account_id.create admin_public_key Token_id.default
+                      ; Account_id.create candidate.vault_public_key
+                          candidate.token_id_l2
+                      ; Account_id.create candidate.token_owner_l2
+                          candidate.token_id_l2
+                      ]
+                  | delta ->
+                      failwithf
+                        "PoC settlement supports at most one Ethereum asset \
+                         registration per commit, observed count delta %d"
+                        delta ()
+              in
               let target_ledger =
-                Sparse_ledger.of_ledger_subset_exn
-                  L.(of_database t.ledger)
-                  (committed_account_ids ())
+                Sparse_ledger.of_ledger_subset_exn full_ledger
+                  (committed_account_ids ~ethereum_asset_accounts ())
               in
               let () =
                 match t.config.checkpoints_dir with

--- a/src/app/zeko/sequencer/prover/lib/client.ml
+++ b/src/app/zeko/sequencer/prover/lib/client.ml
@@ -266,6 +266,7 @@ let map_to_cached_source (type trans stmt) t
           (`Extend (trans, proof), List.drop elems extension_length) )
 
 let folder' (type stmt elem) t ~(source : stmt) ~(elems : elem list) ~max_excess
+    ?(prove_empty = false)
     (module Folder_iterations : Zeko_constants.FOLDER_ITERATIONS)
     ~(map_to_cached_source :
        source:stmt -> elems:elem list -> ('source * elem list) Deferred.t )
@@ -289,7 +290,7 @@ let folder' (type stmt elem) t ~(source : stmt) ~(elems : elem list) ~max_excess
         r )
   in
   match elems_to_prove with
-  | [] ->
+  | [] when not prove_empty ->
       return (Ok (None, source, excess))
   | elems_to_prove -> (
       let%bind input = map_to_cached_source ~source ~elems:elems_to_prove in
@@ -299,10 +300,10 @@ let folder' (type stmt elem) t ~(source : stmt) ~(elems : elem list) ~max_excess
       | Ok (proof, target) ->
           let%bind () =
             match proof with
-            | Some proof ->
+            | Some proof when not (List.is_empty elems_to_prove) ->
                 cache_ase_proof t ~source ~target ~proof
                   ~extension_length:(List.length elems_to_prove)
-            | None ->
+            | Some _ | None ->
                 return ()
           in
           return (Ok (proof, target, excess)) )
@@ -327,8 +328,8 @@ let ethereum_asset_registry_folder t =
     ~cache_ase_proof:(fun _ ~source:_ ~target:_ ~proof:_ ~extension_length:_ ->
       return () )
 
-let ase_cached_folder_with_length t =
-  folder' t
+let ase_cached_folder_with_length ?(prove_empty = false) t =
+  folder' t ~prove_empty
     (module Zeko_constants.Folder_iterations.Ase.With_length)
     ~map_to_cached_source:
       (map_to_cached_source t
@@ -337,8 +338,8 @@ let ase_cached_folder_with_length t =
          ~find_ase_by_source:Ase_cache_with_length_table.find_ase_by_source )
     ~cache_ase_proof:cache_ase_with_length
 
-let ase_cached_folder_without_length t =
-  folder' t
+let ase_cached_folder_without_length ?(prove_empty = false) t =
+  folder' t ~prove_empty
     (module Zeko_constants.Folder_iterations.Ase.Without_length)
     ~map_to_cached_source:
       (map_to_cached_source t
@@ -464,8 +465,10 @@ let outer_commit t ~txn_snark ~public_key ~inner_ase_source ~new_inner_actions
   (* Counting length of inner action state *)
   let%bind.Deferred.Result inner_ase =
     let%map.Deferred.Result proof, target, excess =
+      (* Pickles aggregation can reject conditional dummy proofs while wrapping.
+         Generate a zero-length leaf proof when there are no new actions. *)
       ase_cached_folder_with_length t ~source:inner_ase_source
-        ~elems:new_inner_actions
+        ~elems:new_inner_actions ~prove_empty:true
         ~max_excess:Zeko_constants.Max_excess_actions.Commit.inner
         (ase_with_length ~sendfn:send_with_priority)
     in
@@ -482,8 +485,10 @@ let outer_commit t ~txn_snark ~public_key ~inner_ase_source ~new_inner_actions
       Rollup_state.Outer_action_state.With_length.raw outer_action_state
     in
     let%map.Deferred.Result proof, target, excess =
+      (* See the inner ASE above: give the two-proof aggregator a concrete
+         predecessor for an empty transition too. *)
       ase_cached_folder_without_length t ~source:action_state
-        ~elems:unprocessed_actions
+        ~elems:unprocessed_actions ~prove_empty:true
         ~max_excess:Zeko_constants.Max_excess_actions.Commit.outer
         (ase_without_length ~sendfn:send_with_priority)
     in

--- a/src/app/zeko/sequencer/prover/lib/client.ml
+++ b/src/app/zeko/sequencer/prover/lib/client.ml
@@ -460,8 +460,9 @@ let verify_check_accepted_and_ase_cancelled_deposit t input =
 let outer_commit t ~txn_snark ~public_key ~inner_ase_source ~new_inner_actions
     ~unprocessed_actions ~(old_inner_acc : Account.t) ~old_inner_acc_path
     ~(new_inner_acc : Account.t) ~new_inner_acc_path ~da_multisig ~slot_range
-    ~emergency_mode ~ethereum_asset_registry_root
-    ~ethereum_asset_registry_count ~ethereum_asset_registry_schema =
+    ~emergency_mode ~old_ethereum_asset_registry_acc
+    ~old_ethereum_asset_registry_path ~new_ethereum_asset_registry_acc
+    ~new_ethereum_asset_registry_path ~ethereum_asset_registration =
   (* Counting length of inner action state *)
   let%bind.Deferred.Result inner_ase =
     let%map.Deferred.Result proof, target, excess =
@@ -510,9 +511,11 @@ let outer_commit t ~txn_snark ~public_key ~inner_ase_source ~new_inner_actions
        ; new_inner_acc_path
        ; da_multisig
        ; slot_range
-       ; ethereum_asset_registry_root
-       ; ethereum_asset_registry_count
-       ; ethereum_asset_registry_schema
+       ; old_ethereum_asset_registry_acc
+       ; old_ethereum_asset_registry_path
+       ; new_ethereum_asset_registry_acc
+       ; new_ethereum_asset_registry_path
+       ; ethereum_asset_registration
        } )
   >>| function
   | Prover.Output.Call_forest (parent_with_calls, proof) ->

--- a/src/app/zeko/sequencer/prover/lib/client.ml
+++ b/src/app/zeko/sequencer/prover/lib/client.ml
@@ -320,6 +320,13 @@ let check_accepted_folder t =
     ~cache_ase_proof:(fun _ ~source:_ ~target:_ ~proof:_ ~extension_length:_ ->
       return () )
 
+let ethereum_asset_registry_folder t =
+  folder' t
+    (module Zeko_constants.Folder_iterations.Ethereum_asset_registry_scan)
+    ~map_to_cached_source:(fun ~source ~elems -> return (source, elems))
+    ~cache_ase_proof:(fun _ ~source:_ ~target:_ ~proof:_ ~extension_length:_ ->
+      return () )
+
 let ase_cached_folder_with_length t =
   folder' t
     (module Zeko_constants.Folder_iterations.Ase.With_length)
@@ -390,6 +397,16 @@ let check_accepted_ethereum_token t input =
   | _ ->
       failwith "Unexpected response from prover"
 
+let ethereum_asset_registry_scan t input =
+  send t (Prover.Input.Folder (Ethereum_asset_registry_scan input))
+  >>| function
+  | Prover.Output.Folder (Ethereum_asset_registry_scan scan) ->
+      Ok scan
+  | Prover.Output.Error err ->
+      Error (Error.of_string err)
+  | _ ->
+      failwith "Unexpected response from prover"
+
 let inner_sync t ~public_key ~ase_source ~ase_elms =
   let%bind.Deferred.Result ase =
     let%map.Deferred.Result proof, target, excess =
@@ -442,7 +459,8 @@ let verify_check_accepted_and_ase_cancelled_deposit t input =
 let outer_commit t ~txn_snark ~public_key ~inner_ase_source ~new_inner_actions
     ~unprocessed_actions ~(old_inner_acc : Account.t) ~old_inner_acc_path
     ~(new_inner_acc : Account.t) ~new_inner_acc_path ~da_multisig ~slot_range
-    ~emergency_mode =
+    ~emergency_mode ~ethereum_asset_registry_root
+    ~ethereum_asset_registry_count ~ethereum_asset_registry_schema =
   (* Counting length of inner action state *)
   let%bind.Deferred.Result inner_ase =
     let%map.Deferred.Result proof, target, excess =
@@ -487,6 +505,9 @@ let outer_commit t ~txn_snark ~public_key ~inner_ase_source ~new_inner_actions
        ; new_inner_acc_path
        ; da_multisig
        ; slot_range
+       ; ethereum_asset_registry_root
+       ; ethereum_asset_registry_count
+       ; ethereum_asset_registry_schema
        } )
   >>| function
   | Prover.Output.Call_forest (parent_with_calls, proof) ->
@@ -578,7 +599,7 @@ let finalize_deposit t ~public_key ~may_use_token ~inner_authorization_kind
   | _ ->
       failwith "Unexpected response from prover"
 
-let finalize_ethereum_token_deposit t ~public_key ~may_use_token
+let finalize_ethereum_token_deposit t ~public_key ~asset ~may_use_token
     ~inner_authorization_kind ~(ase : Ase.With_length.Stmt.t * Field.t list)
     ~(check_accepted :
        Bridge.Check_accepted_ethereum_token.Init.t
@@ -629,6 +650,7 @@ let finalize_ethereum_token_deposit t ~public_key ~may_use_token
       Bridge
         (Finalize_ethereum_token_deposit
            { public_key
+           ; asset
            ; may_use_token
            ; inner_authorization_kind
            ; ase
@@ -755,6 +777,40 @@ let inner_receive t witness =
 
 let inner_receive_ethereum_token t witness =
   send t Prover.Input.(Bridge (Inner_receive_ethereum_token witness))
+  >>| function
+  | Prover.Output.Call_forest (parent_with_calls, proof) ->
+      Ok (parent_with_calls, proof)
+  | Prover.Output.Error err ->
+      Error (Error.of_string err)
+  | _ ->
+      failwith "Unexpected response from prover"
+
+let register_ethereum_asset t
+    ~(init : Bridge.Ethereum_asset_registry.Scan.Init.t)
+    ~(elems : Bridge.Ethereum_asset_registry.Scan.Elem.t list) ~append_path =
+  let source : Bridge.Ethereum_asset_registry.Scan.Stmt.t =
+    { old_root = init.old_state.root
+    ; leaf_count = init.old_state.leaf_count
+    ; candidate = init.candidate
+    ; next_expected_index = Zeko_util.Checked32.zero
+    ; traversed_count = Zeko_util.Checked32.zero
+    }
+  in
+  let%bind.Deferred.Result proof, proof_target, excess =
+    ethereum_asset_registry_folder t ~source ~elems ~max_excess:0
+      ethereum_asset_registry_scan
+  in
+  send t
+    Prover.Input.(
+      Bridge
+        (Register_ethereum_asset
+           { proof
+           ; proof_source = source
+           ; proof_target
+           ; init
+           ; excess
+           ; append_path
+           } ))
   >>| function
   | Prover.Output.Call_forest (parent_with_calls, proof) ->
       Ok (parent_with_calls, proof)

--- a/src/app/zeko/sequencer/prover/lib/client.ml
+++ b/src/app/zeko/sequencer/prover/lib/client.ml
@@ -380,6 +380,16 @@ let check_accepted_mina t input =
   | _ ->
       failwith "Unexpected response from prover"
 
+let check_accepted_ethereum_token t input =
+  send t (Prover.Input.Folder (Check_accepted_ethereum_token input))
+  >>| function
+  | Prover.Output.Folder (Check_accepted_ethereum_token check_accepted) ->
+      Ok check_accepted
+  | Prover.Output.Error err ->
+      Error (Error.of_string err)
+  | _ ->
+      failwith "Unexpected response from prover"
+
 let inner_sync t ~public_key ~ase_source ~ase_elms =
   let%bind.Deferred.Result ase =
     let%map.Deferred.Result proof, target, excess =
@@ -568,6 +578,73 @@ let finalize_deposit t ~public_key ~may_use_token ~inner_authorization_kind
   | _ ->
       failwith "Unexpected response from prover"
 
+let finalize_ethereum_token_deposit t ~public_key ~may_use_token
+    ~inner_authorization_kind ~(ase : Ase.With_length.Stmt.t * Field.t list)
+    ~(check_accepted :
+       Bridge.Check_accepted_ethereum_token.Init.t
+       * Field.t
+       * Bridge.Check_accepted_ethereum_token.Elem.t list ) ~prev_next_deposit
+    ~prev_nonce ~helper_account_new =
+  let%bind.Deferred.Result ase =
+    let ase_source, ase_elms = ase in
+    let%map.Deferred.Result proof, target, excess =
+      ase_cached_folder_with_length t ~source:ase_source ~elems:ase_elms
+        ~max_excess:Zeko_constants.Max_excess_actions.Finalize_deposit.outer
+        (ase_with_length ~sendfn:send)
+    in
+    Bridge.Finalize_ethereum_token_deposit.Ase_inst.
+      { proof; proof_target = target; init = ase_source; excess }
+  in
+  let%bind.Deferred.Result check_accepted =
+    let init, deposit_hash, elems = check_accepted in
+    let source : Bridge.Check_accepted_ethereum_token.Stmt.t =
+      { params = init.params
+      ; action_state =
+          Zkapp_account.Actions_impl.push_hash
+            (Rollup_state.Outer_action_state.raw init.original_action_state)
+            deposit_hash
+          |> Rollup_state.Outer_action_state.unsafe_value_of_field
+      ; deposit_index = init.deposit_index
+      ; n_steps = Zeko_util.Checked32.zero
+      ; is_rejected = false
+      ; is_accepted = false
+      }
+    in
+    let%map.Deferred.Result proof, target, excess =
+      check_accepted_folder t ~source ~elems
+        ~max_excess:
+          Zeko_constants.Max_excess_actions.Finalize_deposit.check_accepted
+        check_accepted_ethereum_token
+    in
+    ( { proof
+      ; proof_source = source
+      ; proof_target = target
+      ; init = Bridge.Check_accepted_ethereum_token.Init.to_serializable init
+      ; excess
+      }
+      : Bridge.Check_accepted_ethereum_token.serializable )
+  in
+  send t
+    Prover.Input.(
+      Bridge
+        (Finalize_ethereum_token_deposit
+           { public_key
+           ; may_use_token
+           ; inner_authorization_kind
+           ; ase
+           ; check_accepted
+           ; prev_next_deposit
+           ; prev_nonce
+           ; helper_account_new
+           } ))
+  >>| function
+  | Prover.Output.Call_forest (parent_with_calls, proof) ->
+      Ok (parent_with_calls, proof)
+  | Prover.Output.Error err ->
+      Error (Error.of_string err)
+  | _ ->
+      failwith "Unexpected response from prover"
+
 let finalize_cancelled_deposit t ~public_key ~may_use_token
     ~outer_authorization_kind ~commit ~before_commit
     ~(commit_ase : Ase.Without_length.Stmt.t * Field.t list)
@@ -668,6 +745,16 @@ let finalize_cancelled_deposit t ~public_key ~may_use_token
 
 let inner_receive t witness =
   send t Prover.Input.(Bridge (Inner_receive witness))
+  >>| function
+  | Prover.Output.Call_forest (parent_with_calls, proof) ->
+      Ok (parent_with_calls, proof)
+  | Prover.Output.Error err ->
+      Error (Error.of_string err)
+  | _ ->
+      failwith "Unexpected response from prover"
+
+let inner_receive_ethereum_token t witness =
+  send t Prover.Input.(Bridge (Inner_receive_ethereum_token witness))
   >>| function
   | Prover.Output.Call_forest (parent_with_calls, proof) ->
       Ok (parent_with_calls, proof)

--- a/src/app/zeko/sequencer/prover/lib/compile_circuits.ml
+++ b/src/app/zeko/sequencer/prover/lib/compile_circuits.ml
@@ -18,6 +18,9 @@ let compile_all ~logger () =
   let%bind () = compile_tag (Lazy.force Outer_rules_inst.tag) in
   let%bind () = compile_tag (Lazy.force Bridge_inst_mina.Check_accepted.tag) in
   let%bind () =
+    compile_tag (Lazy.force Bridge_inst_ethereum_token.Check_accepted.tag)
+  in
+  let%bind () =
     compile_tag
       (Lazy.force
          Bridge_inst_mina.Rule_bridge_finalize_cancelled_deposit
@@ -38,6 +41,9 @@ let compile_all ~logger () =
     compile_tag (Lazy.force Bridge_inst_mina.System_L1_disabled.tag)
   in
   let%bind () = compile_tag (Lazy.force Bridge_inst_mina.System_L2.tag) in
+  let%bind () =
+    compile_tag (Lazy.force Bridge_inst_ethereum_token.System_L2.tag)
+  in
   let%bind () =
     compile_tag (Lazy.force Bridge_inst_mina.System_L1_token_owner.tag)
   in

--- a/src/app/zeko/sequencer/prover/lib/compile_circuits.ml
+++ b/src/app/zeko/sequencer/prover/lib/compile_circuits.ml
@@ -45,6 +45,10 @@ let compile_all ~logger () =
     compile_tag (Lazy.force Bridge_inst_ethereum_token.System_L2.tag)
   in
   let%bind () =
+    compile_tag
+      (Lazy.force Bridge_inst_ethereum_token.Registry.registry_tag)
+  in
+  let%bind () =
     compile_tag (Lazy.force Bridge_inst_mina.System_L1_token_owner.tag)
   in
   [%log info] "Compiled circuits in %s"

--- a/src/app/zeko/sequencer/prover/lib/compile_circuits.ml
+++ b/src/app/zeko/sequencer/prover/lib/compile_circuits.ml
@@ -45,8 +45,7 @@ let compile_all ~logger () =
     compile_tag (Lazy.force Bridge_inst_ethereum_token.System_L2.tag)
   in
   let%bind () =
-    compile_tag
-      (Lazy.force Bridge_inst_ethereum_token.Registry.registry_tag)
+    compile_tag (Lazy.force Bridge_inst_ethereum_token.Registry.registry_tag)
   in
   let%bind () =
     compile_tag (Lazy.force Bridge_inst_mina.System_L1_token_owner.tag)

--- a/src/app/zeko/sequencer/prover/lib/prover.ml
+++ b/src/app/zeko/sequencer/prover/lib/prover.ml
@@ -87,10 +87,10 @@ struct
          | `Full of System.Stmt.t ] ) ~elems : out_t Promise.t =
     match elems with
     | [] -> (
-        (* No need for folding, everything goes to excess *)
         match source with
         | `Full source ->
-            Promise.return (None, source)
+            let%map.Promise trans, proof = System.leaf_option ([], source) in
+            (Some proof, trans.target)
         | `Extend (trans, proof) ->
             Promise.return (Some proof, trans.target) )
     | elems_to_prove ->

--- a/src/app/zeko/sequencer/prover/lib/prover.ml
+++ b/src/app/zeko/sequencer/prover/lib/prover.ml
@@ -141,6 +141,8 @@ module Folder_without_length = Make_folder (Ase.Without_length)
 module Folder_check_accepted_mina = Make_folder (Bridge.Check_accepted_mina)
 module Folder_check_accepted_ethereum_token =
   Make_folder (Bridge.Check_accepted_ethereum_token)
+module Folder_ethereum_asset_registry_scan =
+  Make_folder (Bridge.Ethereum_asset_registry.Scan)
 
 (* Unfortunately yojson doesn't support GADTs so it can't be one type, or maybe I'm just bad *)
 module Input = struct
@@ -168,6 +170,9 @@ module Input = struct
       | Check_accepted_ethereum_token of
           ( Bridge.Check_accepted_ethereum_token.Stmt.t
           * Bridge.Check_accepted_ethereum_token.Elem.t list )
+      | Ethereum_asset_registry_scan of
+          ( Bridge.Ethereum_asset_registry.Scan.Stmt.t
+          * Bridge.Ethereum_asset_registry.Scan.Elem.t list )
     [@@deriving yojson]
   end
 
@@ -183,6 +188,8 @@ module Input = struct
       | Inner_receive of Bridge.Inner_receive.serializable
       | Inner_receive_ethereum_token of
           Bridge.Inner_receive_ethereum_token.serializable
+      | Register_ethereum_asset of
+          Bridge.Ethereum_asset_registry.serializable
       | Finalize_withdrawal of Bridge.Finalize_withdrawal.serializable
       | Outer_token_owner of Bridge.Outer_token_owner.serializable
     [@@deriving yojson]
@@ -221,6 +228,7 @@ module Verification_key_hashes = struct
     ; bridge_mina_token_owner : F.t
     ; bridge_mina_l2 : F.t
     ; bridge_ethereum_token_l2 : F.t
+    ; ethereum_asset_registry : F.t
     }
   [@@deriving yojson]
 end
@@ -233,6 +241,8 @@ module Output = struct
       | Check_accepted_mina of Folder_check_accepted_mina.out_t
       | Check_accepted_ethereum_token of
           Folder_check_accepted_ethereum_token.out_t
+      | Ethereum_asset_registry_scan of
+          Folder_ethereum_asset_registry_scan.out_t
     [@@deriving yojson]
   end
 
@@ -357,6 +367,15 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
           |> Promise.to_deferred )
       in
       Output.(Folder (Check_accepted_ethereum_token snark))
+  | Folder (Ethereum_asset_registry_scan (source, elems)) ->
+      let%map snark =
+        time ?fake_proving_time ~logger
+          "Folder.Ethereum_asset_registry_scan.fold"
+          ( Folder_ethereum_asset_registry_scan.fold ~source:(`Full source)
+              ~elems
+          |> Promise.to_deferred )
+      in
+      Output.(Folder (Ethereum_asset_registry_scan snark))
   | Verify_both_ases_commit (outer, inner) ->
       let Compile_simple.[ prove ] =
         Lazy.force Rule_commit.Verify_both_ases.provers
@@ -498,7 +517,7 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
                  ~f:Account_update.read_all_proofs_from_disk )
         , proof )
   | Bridge (Finalize_ethereum_token_deposit input) ->
-      if not Zeko_circuits_config.Inputs.Ethereum_token.enabled then
+      if not Zeko_circuits_config.Inputs.Ethereum_assets.enabled then
         return (Output.Error "Ethereum token bridge is not configured")
       else
         let Compile_simple.[ prove; _; _ ] =
@@ -578,7 +597,7 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
                  ~f:Account_update.read_all_proofs_from_disk )
         , proof )
   | Bridge (Inner_receive_ethereum_token input) ->
-      if not Zeko_circuits_config.Inputs.Ethereum_token.enabled then
+      if not Zeko_circuits_config.Inputs.Ethereum_assets.enabled then
         return (Output.Error "Ethereum token bridge is not configured")
       else
         let Compile_simple.[ _; prove; _ ] =
@@ -595,6 +614,31 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
             ( prove
                 (Bridge.Inner_receive_ethereum_token.of_serializable ~vk_hash
                    input )
+            |> Promise.to_deferred )
+        in
+        Output.Call_forest
+          ( Tuple3.map_trd parent_with_calls
+              ~f:
+                (Zkapp_command.Call_forest.map
+                   ~f:Account_update.read_all_proofs_from_disk )
+          , proof )
+  | Bridge (Register_ethereum_asset input) ->
+      if not Zeko_circuits_config.Inputs.Ethereum_assets.enabled then
+        return (Output.Error "Ethereum asset registry is not configured")
+      else
+        let prove = Lazy.force Bridge_inst_ethereum_token.Registry.register in
+        let%bind registry_vk_hash =
+          Compile_simple.Verification_key.of_tag
+            (Lazy.force
+               Bridge_inst_ethereum_token.Registry.registry_tag )
+          |> Promise.to_deferred >>| Compile_simple.Verification_key.hash
+        in
+        let%map (_stmt, parent_with_calls), proof =
+          time ?fake_proving_time ~logger
+            "Ethereum_asset_registry.register"
+            ( prove
+                (Bridge.Ethereum_asset_registry.of_serializable
+                   ~registry_vk_hash input )
             |> Promise.to_deferred )
         in
         Output.Call_forest
@@ -689,6 +733,11 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
         Compile_simple.Verification_key.of_tag
           (Lazy.force Bridge_inst_ethereum_token.System_L2.tag)
         |> Promise.to_deferred >>| Compile_simple.Verification_key.hash
+      and ethereum_asset_registry =
+        Compile_simple.Verification_key.of_tag
+          (Lazy.force
+             Bridge_inst_ethereum_token.Registry.registry_tag )
+        |> Promise.to_deferred >>| Compile_simple.Verification_key.hash
       in
       return
         (Output.Verification_keys
@@ -698,6 +747,7 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
            ; bridge_mina_token_owner
            ; bridge_mina_l2
            ; bridge_ethereum_token_l2
+           ; ethereum_asset_registry
            } )
 
 let run ?fake_proving_time ~logger ~mq_host () =

--- a/src/app/zeko/sequencer/prover/lib/prover.ml
+++ b/src/app/zeko/sequencer/prover/lib/prover.ml
@@ -139,6 +139,8 @@ end
 module Folder_with_length = Make_folder (Ase.With_length)
 module Folder_without_length = Make_folder (Ase.Without_length)
 module Folder_check_accepted_mina = Make_folder (Bridge.Check_accepted_mina)
+module Folder_check_accepted_ethereum_token =
+  Make_folder (Bridge.Check_accepted_ethereum_token)
 
 (* Unfortunately yojson doesn't support GADTs so it can't be one type, or maybe I'm just bad *)
 module Input = struct
@@ -163,6 +165,9 @@ module Input = struct
       | Check_accepted_mina of
           ( Bridge.Check_accepted_mina.Stmt.t
           * Bridge.Check_accepted_mina.Elem.t list )
+      | Check_accepted_ethereum_token of
+          ( Bridge.Check_accepted_ethereum_token.Stmt.t
+          * Bridge.Check_accepted_ethereum_token.Elem.t list )
     [@@deriving yojson]
   end
 
@@ -171,9 +176,13 @@ module Input = struct
       | Outer_action_witness of Bridge.Outer_action_witness.serializable
       | Inner_action_witness of Bridge.Inner_action_witness.serializable
       | Finalize_deposit of Bridge.Finalize_deposit.serializable
+      | Finalize_ethereum_token_deposit of
+          Bridge.Finalize_ethereum_token_deposit.serializable
       | Finalize_cancelled_deposit of
           Bridge.Finalize_cancelled_deposit.serializable
       | Inner_receive of Bridge.Inner_receive.serializable
+      | Inner_receive_ethereum_token of
+          Bridge.Inner_receive_ethereum_token.serializable
       | Finalize_withdrawal of Bridge.Finalize_withdrawal.serializable
       | Outer_token_owner of Bridge.Outer_token_owner.serializable
     [@@deriving yojson]
@@ -211,6 +220,7 @@ module Verification_key_hashes = struct
     ; bridge_mina_l1 : F.t
     ; bridge_mina_token_owner : F.t
     ; bridge_mina_l2 : F.t
+    ; bridge_ethereum_token_l2 : F.t
     }
   [@@deriving yojson]
 end
@@ -221,6 +231,8 @@ module Output = struct
       | Ase_with_length of Folder_with_length.out_t
       | Ase_without_length of Folder_without_length.out_t
       | Check_accepted_mina of Folder_check_accepted_mina.out_t
+      | Check_accepted_ethereum_token of
+          Folder_check_accepted_ethereum_token.out_t
     [@@deriving yojson]
   end
 
@@ -336,6 +348,15 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
           |> Promise.to_deferred )
       in
       Output.(Folder (Check_accepted_mina snark))
+  | Folder (Check_accepted_ethereum_token (source, elems)) ->
+      let%map snark =
+        time ?fake_proving_time ~logger
+          "Folder.Check_accepted_ethereum_token.fold"
+          ( Folder_check_accepted_ethereum_token.fold ~source:(`Full source)
+              ~elems
+          |> Promise.to_deferred )
+      in
+      Output.(Folder (Check_accepted_ethereum_token snark))
   | Verify_both_ases_commit (outer, inner) ->
       let Compile_simple.[ prove ] =
         Lazy.force Rule_commit.Verify_both_ases.provers
@@ -476,6 +497,32 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
               (Zkapp_command.Call_forest.map
                  ~f:Account_update.read_all_proofs_from_disk )
         , proof )
+  | Bridge (Finalize_ethereum_token_deposit input) ->
+      if not Zeko_circuits_config.Inputs.Ethereum_token.enabled then
+        return (Output.Error "Ethereum token bridge is not configured")
+      else
+        let Compile_simple.[ prove; _; _ ] =
+          Lazy.force Bridge_inst_ethereum_token.System_L2.provers
+        in
+        let%bind vk_hash =
+          Compile_simple.Verification_key.of_tag
+            (Lazy.force Bridge_inst_ethereum_token.System_L2.tag)
+          |> Promise.to_deferred >>| Compile_simple.Verification_key.hash
+        in
+        let%map (_stmt, parent_with_calls), proof =
+          time ?fake_proving_time ~logger
+            "Bridge_ethereum_token.System_L2.finalize_deposit"
+            ( prove
+                (Bridge.Finalize_ethereum_token_deposit.of_serializable
+                   ~proof_cache_db ~vk_hash input )
+            |> Promise.to_deferred )
+        in
+        Output.Call_forest
+          ( Tuple3.map_trd parent_with_calls
+              ~f:
+                (Zkapp_command.Call_forest.map
+                   ~f:Account_update.read_all_proofs_from_disk )
+          , proof )
   | Bridge (Finalize_cancelled_deposit input) ->
       let Compile_simple.[ prove; _; _; _ ] =
         Lazy.force Bridge_inst_mina.System_L1_enabled.provers
@@ -530,6 +577,32 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
               (Zkapp_command.Call_forest.map
                  ~f:Account_update.read_all_proofs_from_disk )
         , proof )
+  | Bridge (Inner_receive_ethereum_token input) ->
+      if not Zeko_circuits_config.Inputs.Ethereum_token.enabled then
+        return (Output.Error "Ethereum token bridge is not configured")
+      else
+        let Compile_simple.[ _; prove; _ ] =
+          Lazy.force Bridge_inst_ethereum_token.System_L2.provers
+        in
+        let%bind vk_hash =
+          Compile_simple.Verification_key.of_tag
+            (Lazy.force Bridge_inst_ethereum_token.System_L2.tag)
+          |> Promise.to_deferred >>| Compile_simple.Verification_key.hash
+        in
+        let%map (_stmt, parent_with_calls), proof =
+          time ?fake_proving_time ~logger
+            "Bridge_ethereum_token.System_L2.inner_receive"
+            ( prove
+                (Bridge.Inner_receive_ethereum_token.of_serializable ~vk_hash
+                   input )
+            |> Promise.to_deferred )
+        in
+        Output.Call_forest
+          ( Tuple3.map_trd parent_with_calls
+              ~f:
+                (Zkapp_command.Call_forest.map
+                   ~f:Account_update.read_all_proofs_from_disk )
+          , proof )
   | Bridge (Finalize_withdrawal input) ->
       let Compile_simple.[ _; prove; _; _ ] =
         Lazy.force Bridge_inst_mina.System_L1_enabled.provers
@@ -612,6 +685,10 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
         Compile_simple.Verification_key.of_tag
           (Lazy.force Bridge_inst_mina.System_L2.tag)
         |> Promise.to_deferred >>| Compile_simple.Verification_key.hash
+      and bridge_ethereum_token_l2 =
+        Compile_simple.Verification_key.of_tag
+          (Lazy.force Bridge_inst_ethereum_token.System_L2.tag)
+        |> Promise.to_deferred >>| Compile_simple.Verification_key.hash
       in
       return
         (Output.Verification_keys
@@ -620,6 +697,7 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
            ; bridge_mina_l1
            ; bridge_mina_token_owner
            ; bridge_mina_l2
+           ; bridge_ethereum_token_l2
            } )
 
 let run ?fake_proving_time ~logger ~mq_host () =

--- a/src/app/zeko/sequencer/prover/lib/prover.ml
+++ b/src/app/zeko/sequencer/prover/lib/prover.ml
@@ -188,8 +188,7 @@ module Input = struct
       | Inner_receive of Bridge.Inner_receive.serializable
       | Inner_receive_ethereum_token of
           Bridge.Inner_receive_ethereum_token.serializable
-      | Register_ethereum_asset of
-          Bridge.Ethereum_asset_registry.serializable
+      | Register_ethereum_asset of Bridge.Ethereum_asset_registry.serializable
       | Finalize_withdrawal of Bridge.Finalize_withdrawal.serializable
       | Outer_token_owner of Bridge.Outer_token_owner.serializable
     [@@deriving yojson]
@@ -629,13 +628,11 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
         let prove = Lazy.force Bridge_inst_ethereum_token.Registry.register in
         let%bind registry_vk_hash =
           Compile_simple.Verification_key.of_tag
-            (Lazy.force
-               Bridge_inst_ethereum_token.Registry.registry_tag )
+            (Lazy.force Bridge_inst_ethereum_token.Registry.registry_tag)
           |> Promise.to_deferred >>| Compile_simple.Verification_key.hash
         in
         let%map (_stmt, parent_with_calls), proof =
-          time ?fake_proving_time ~logger
-            "Ethereum_asset_registry.register"
+          time ?fake_proving_time ~logger "Ethereum_asset_registry.register"
             ( prove
                 (Bridge.Ethereum_asset_registry.of_serializable
                    ~registry_vk_hash input )
@@ -735,8 +732,7 @@ let prove ?fake_proving_time ~logger ~proof_cache_db :
         |> Promise.to_deferred >>| Compile_simple.Verification_key.hash
       and ethereum_asset_registry =
         Compile_simple.Verification_key.of_tag
-          (Lazy.force
-             Bridge_inst_ethereum_token.Registry.registry_tag )
+          (Lazy.force Bridge_inst_ethereum_token.Registry.registry_tag)
         |> Promise.to_deferred >>| Compile_simple.Verification_key.hash
       in
       return

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -223,10 +223,8 @@ let () =
           let compiled_registry_vk_hash =
             run (fun () ->
                 Compile_simple.Verification_key.of_tag
-                  (Lazy.force
-                     Bridge_inst_ethereum_token.Registry.registry_tag )
-                |> Promise.to_deferred
-                >>| Compile_simple.Verification_key.hash )
+                  (Lazy.force Bridge_inst_ethereum_token.Registry.registry_tag)
+                |> Promise.to_deferred >>| Compile_simple.Verification_key.hash )
           in
           printf "Ethereum asset registry VK hash in genesis: %s\n%!"
             (Field.to_string local_registry_vk_hash) ;
@@ -240,8 +238,8 @@ let () =
                     (Field.equal local_registry_vk_hash
                        compiled_registry_vk_hash ) )
                || not
-                    (Field.equal local_registry_vk_hash
-                       prover_registry_vk_hash ) )
+                    (Field.equal local_registry_vk_hash prover_registry_vk_hash)
+               )
           then
             failwithf
               "Ethereum asset registry VK mismatch: genesis %s, local compile \
@@ -375,6 +373,10 @@ let () =
                    ->
                   { asset_id_high = record.asset_id_high
                   ; asset_id_low = record.asset_id_low
+                  ; encoding_version = C.Zeko_util.Checked32.of_int 2
+                  ; registry_index = record.registry_index
+                  ; record_commitment =
+                      C.Asset_registry.Asset_record.commitment record
                   ; base = deposit_params
                   } )
         in
@@ -958,8 +960,7 @@ let () =
           let validate_helper_account ~expected_next_deposit helper_owner =
             let next_deposit = helper_next_deposit helper_owner in
             if not (UInt32.equal next_deposit expected_next_deposit) then
-              failwithf
-                "Live SDK finalized deposit index %s, expected %s"
+              failwithf "Live SDK finalized deposit index %s, expected %s"
                 (UInt32.to_string next_deposit)
                 (UInt32.to_string expected_next_deposit)
                 ()
@@ -1061,12 +1062,11 @@ let () =
               in
               if
                 not
-                  (List.equal UInt32.equal next_deposits
-                     expected_next_deposits )
+                  (List.equal UInt32.equal next_deposits expected_next_deposits)
               then
                 failwithf
                   "Live SDK finalized unexpected ERC20 deposit indices: %s"
-                  (List.map next_deposits ~f:UInt32.to_string
+                  ( List.map next_deposits ~f:UInt32.to_string
                   |> String.concat ~sep:"," )
                   () ;
               print_endline

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -74,6 +74,17 @@ let bridge_live_sdk =
     ~default:false
     ~f:(String.Caseless.equal "true")
 
+type bridge_asset = Native | Ethereum_token
+
+let bridge_asset =
+  match Stdlib.Sys.getenv_opt "BRIDGE_ASSET" with
+  | None | Some "native" ->
+      Native
+  | Some "erc20" ->
+      Ethereum_token
+  | Some asset ->
+      failwithf "Unsupported BRIDGE_ASSET: %s" asset ()
+
 let bridge_commit_validity_period =
   Option.value_map
     (Stdlib.Sys.getenv_opt "ZEKO_ETHEREUM_COMMIT_VALIDITY_PERIOD")
@@ -131,6 +142,7 @@ let () =
               ; da_keys
               ; l1_executor
               ; l2_executor
+              ; accounts
               ; _
               } ->
         let rec create_even_keypair () =
@@ -192,6 +204,43 @@ let () =
             (Field.to_string compiled_bridge_vk_hash)
             (Field.to_string prover_bridge_vk_hash)
             () ;
+        let ethereum_token_bridge_verification_key =
+          match bridge_asset with
+          | Native ->
+              None
+          | Ethereum_token ->
+              if not Zeko_circuits_config.Inputs.Ethereum_token.enabled then
+                failwith
+                  "BRIDGE_ASSET=erc20 requires an ethereum_token circuits config" ;
+              let verification_key =
+                run (fun () ->
+                    Compile_simple.Verification_key.of_tag
+                      (Lazy.force Bridge_inst_ethereum_token.System_L2.tag)
+                    |> Promise.to_deferred )
+              in
+              let expected_hash =
+                !sequencer.bridge_prover.verification_keys
+                  .bridge_ethereum_token_l2
+              in
+              let actual_hash =
+                Compile_simple.Verification_key.hash verification_key
+              in
+              if not (Field.equal expected_hash actual_hash) then
+                failwithf
+                  "Ethereum token bridge VK mismatch: local %s, prover %s"
+                  (Field.to_string actual_hash) (Field.to_string expected_hash)
+                  () ;
+              let pickles_verification_key =
+                Compile_simple.Verification_key.to_pickles verification_key
+                |> Option.value_exn
+                     ~message:
+                       "Real ERC20 live integration requires a Pickles verification key"
+              in
+              Some
+                ( Pickles.Side_loaded.Verification_key.to_base64
+                    pickles_verification_key
+                , actual_hash )
+        in
         let ethereum_holder =
           Option.value_exn
             ~message:
@@ -212,6 +261,45 @@ let () =
           ; amount = Currency.Amount.of_mina_int_exn 10
           ; timeout = Global_slot_since_genesis.max_value
           }
+        in
+        let ethereum_token_deposit_params :
+            C.Bridge_state.Deposit_params_ethereum_token.t option =
+          match bridge_asset with
+          | Native ->
+              None
+          | Ethereum_token ->
+              Some
+                { asset_id_high =
+                    Zeko_circuits_config.Inputs.Ethereum_token
+                    .ethereum_asset_id_high
+                ; asset_id_low =
+                    Zeko_circuits_config.Inputs.Ethereum_token
+                    .ethereum_asset_id_low
+                ; base = deposit_params
+                }
+        in
+        ( match bridge_asset with
+        | Native ->
+            ()
+        | Ethereum_token ->
+            let configured_amount =
+              UInt64.of_string (Sys.getenv_exn "ERC20_DEPOSIT_AMOUNT")
+            in
+            let scenario_amount = Currency.Amount.to_uint64 deposit_params.amount in
+            if not (UInt64.equal configured_amount scenario_amount) then
+              failwithf
+                "ERC20_DEPOSIT_AMOUNT %s does not match scenario amount %s"
+                (UInt64.to_string configured_amount)
+                (UInt64.to_string scenario_amount) () ) ;
+        let deposit_aux () =
+          match ethereum_token_deposit_params with
+          | None ->
+              Utils.value_to_hash ~init:Zeko_constants.ethereum_deposit_salt
+                C.Bridge_state.Deposit_params_base.typ deposit_params
+          | Some params ->
+              Utils.value_to_hash
+                ~init:Zeko_constants.ethereum_erc20_deposit_salt
+                C.Bridge_state.Deposit_params_ethereum_token.typ params
         in
         let withdrawal_params : C.Bridge_state.Withdrawal_params_base.t =
           { children = []
@@ -251,13 +339,59 @@ let () =
                 |> Option.value_exn
                      ~message:"withdrawal recipient is not an Ethereum address"
               in
-              let aux =
-                Utils.value_to_hash ~init:Zeko_constants.ethereum_deposit_salt
-                  C.Bridge_state.Deposit_params_base.typ deposit_params
+              let aux = deposit_aux () in
+              let asset_fields =
+                match bridge_asset with
+                | Native ->
+                    [ ("bridgeAsset", `String "native") ]
+                | Ethereum_token ->
+                    let token_owner =
+                      Account_id.public_key
+                        Zeko_circuits_config.Inputs.Ethereum_token.token_owner_l2
+                    in
+                    if token_owner.is_odd then
+                      failwith
+                        "The local ERC20 token owner must have an even public key" ;
+                    let token_id =
+                      Account_id.derive_token_id
+                        ~owner:
+                          Zeko_circuits_config.Inputs.Ethereum_token
+                          .token_owner_l2
+                    in
+                    [ ("bridgeAsset", `String "erc20")
+                    ; ( "ethereumTokenAddress"
+                      , `String
+                          Zeko_circuits_config.Inputs.Ethereum_token
+                            .ethereum_token_address )
+                    ; ( "ethereumTokenAssetId"
+                      , `String
+                          Zeko_circuits_config.Inputs.Ethereum_token.asset_id )
+                    ; ( "ethereumTokenOwnerL2"
+                      , `String
+                          (Public_key.Compressed.to_base58_check token_owner) )
+                    ; ( "ethereumTokenOwnerPacked"
+                      , `String
+                          (Ethereum_settlement_export.field_to_hex token_owner.x)
+                      )
+                    ; ( "ethereumTokenIdL2"
+                      , `String
+                          (Ethereum_settlement_export.field_to_hex
+                             (Token_id.to_field_unsafe token_id) ) )
+                    ; ( "ethereumTokenIdL2Base58"
+                      , `String (Token_id.to_string token_id) )
+                    ; ( "ethereumTokenVaultL2"
+                      , `String
+                          (Public_key.Compressed.to_base58_check
+                             Zeko_circuits_config.Inputs.Ethereum_token
+                               .holder_account_l2 ) )
+                    ; ("ethereumTokenDecimals", `Int 9)
+                    ; ( "ethereumTokenDepositCap"
+                      , `String (Sys.getenv_exn "ERC20_DEPOSIT_CAP") )
+                    ]
               in
               let json =
                 `Assoc
-                  [ ("schemaVersion", `Int 1)
+                  ( [ ("schemaVersion", `Int 2)
                   ; ("commitValidityPeriod", `Int bridge_commit_validity_period)
                   ; ( "zekoRecipient"
                     , `String
@@ -300,6 +434,7 @@ let () =
                     , `String (Public_key.Compressed.to_base58_check signer_pk)
                     )
                   ]
+                  @ asset_fields )
               in
               Out_channel.write_all
                 (Filename.concat directory "bridge-scenario.json")
@@ -309,10 +444,7 @@ let () =
           let witness : Bridge.Outer_action_witness.serializable =
             { public_key = Zeko_circuits_config.Inputs.zeko_l1
             ; witness =
-                { aux =
-                    Utils.value_to_hash
-                      ~init:Zeko_constants.ethereum_deposit_salt
-                      C.Bridge_state.Deposit_params_base.typ deposit_params
+                { aux = deposit_aux ()
                 ; children = []
                 ; slot_range = C.Zeko_util.Slot_range.infinite
                 }
@@ -350,6 +482,30 @@ let () =
           in
           Executor.send_zkapp_command ~logger l1_executor command
           >>| Or_error.ok_exn
+        in
+        let fund_ethereum_token_operator () =
+          match bridge_asset with
+          | Native ->
+              Deferred.unit
+          | Ethereum_token ->
+              let source = List.hd_exn accounts in
+              let nonce =
+                Sequencer.infer_nonce !sequencer
+                  (Public_key.compress source.public_key)
+              in
+              let payment : Transaction_spec.t =
+                { fee = Currency.Fee.of_mina_string_exn "0.1"
+                ; sender = (source, nonce)
+                ; receiver = Public_key.compress recipient.public_key
+                ; amount = Currency.Amount.of_mina_int_exn 100
+                ; actions = None
+                }
+              in
+              apply_user_command !sequencer
+                (Signed_command
+                   (command_send
+                      ~chain:Zeko_circuits_config.Inputs.chain_l2 payment ) )
+              >>| Or_error.ok_exn
         in
         let commit_and_check label =
           printf "(* %s *)\n%!" label ;
@@ -583,9 +739,19 @@ let () =
           let complete_path = Filename.concat directory "operations-complete" in
           run (fun () ->
               start_graphql_server ~port !sequencer ~l1_executor ~l2_executor ) ;
+          let token_verification_key_fields =
+            match ethereum_token_bridge_verification_key with
+            | None ->
+                []
+            | Some (data, hash) ->
+                [ ("ethereumTokenBridgeVerificationKey", `String data)
+                ; ( "ethereumTokenBridgeVerificationKeyHash"
+                  , `String (Field.to_string hash) )
+                ]
+          in
           let manifest =
             `Assoc
-              [ ("schemaVersion", `Int 1)
+              ( [ ("schemaVersion", `Int 2)
               ; ( "sequencerGraphqlUrl"
                 , `String (sprintf "http://127.0.0.1:%d/graphql" port) )
               ; ("l1GraphqlUrl", `String (Uri.to_string gql_uri))
@@ -596,23 +762,34 @@ let () =
               ; ( "recipientPublicKey"
                 , `String
                     (Public_key.Compressed.to_base58_check
-                       (Public_key.compress recipient.public_key) ) )
+                    (Public_key.compress recipient.public_key) ) )
               ; ("completionMarker", `String complete_path)
               ]
+              @ token_verification_key_fields )
           in
           Out_channel.write_all ready_path
             ~data:(Yojson.Safe.pretty_to_string manifest ^ "\n") ;
           printf "Live bridge SDK harness ready: %s\n%!" ready_path ;
           run (fun () ->
               wait_for_file ~timeout:(Time.Span.of_min 45.) complete_path ) ;
+          let helper_owner =
+            match bridge_asset with
+            | Native ->
+                Account_id.of_public_key
+                  (Public_key.decompress_exn
+                     Zeko_circuits_config.Inputs.holder_account_l2 )
+            | Ethereum_token ->
+                Account_id.create
+                  Zeko_circuits_config.Inputs.Ethereum_token.holder_account_l2
+                  (Account_id.derive_token_id
+                     ~owner:
+                       Zeko_circuits_config.Inputs.Ethereum_token
+                         .token_owner_l2 )
+          in
           let helper_account =
             Sequencer.get_account !sequencer
               (Public_key.compress recipient.public_key)
-              (Account_id.derive_token_id
-                 ~owner:
-                   (Account_id.of_public_key
-                      (Public_key.decompress_exn
-                         Zeko_circuits_config.Inputs.holder_account_l2 ) ) )
+              (Account_id.derive_token_id ~owner:helper_owner)
             |> Option.value_exn
                  ~message:
                    "Live SDK deposit finalization did not create the helper \
@@ -632,26 +809,74 @@ let () =
             failwithf "Live SDK finalized an unexpected next deposit index: %s"
               (UInt32.to_string next_deposit)
               () ;
-          let withdrawal_aux =
-            Utils.value_to_hash ~init:Zeko_constants.withdrawal_salt
-              C.Bridge_state.Withdrawal_params_base.typ withdrawal_params
-          in
-          match
-            Archive.find_ethereum_withdrawal !sequencer.archive
-              ~aux:withdrawal_aux
-          with
-          | Some withdrawal
-            when Public_key.Compressed.equal withdrawal.recipient
-                   withdrawal_params.recipient
-                 && Currency.Amount.equal withdrawal.amount
-                      withdrawal_params.amount ->
+          ( match bridge_asset with
+          | Native ->
+              let withdrawal_aux =
+                Utils.value_to_hash ~init:Zeko_constants.withdrawal_salt
+                  C.Bridge_state.Withdrawal_params_base.typ withdrawal_params
+              in
+              ( match
+                  Archive.find_ethereum_withdrawal !sequencer.archive
+                    ~aux:withdrawal_aux
+                with
+              | Some withdrawal
+                when Public_key.Compressed.equal withdrawal.recipient
+                       withdrawal_params.recipient
+                     && Currency.Amount.equal withdrawal.amount
+                          withdrawal_params.amount ->
+                  print_endline
+                    "Live SDK finalized the deposit and submitted the native \
+                     withdrawal"
+              | _ ->
+                  failwith
+                    "Live SDK withdrawal request was not recorded in the OCaml \
+                     archive" )
+          | Ethereum_token ->
+              let token_id =
+                Account_id.derive_token_id
+                  ~owner:
+                    Zeko_circuits_config.Inputs.Ethereum_token.token_owner_l2
+              in
+              let vault =
+                Sequencer.get_account !sequencer
+                  Zeko_circuits_config.Inputs.Ethereum_token.holder_account_l2
+                  token_id
+                |> Option.value_exn
+                     ~message:"Live SDK did not install the ERC20 bridge vault"
+              in
+              let recipient_account =
+                Sequencer.get_account !sequencer
+                  (Public_key.compress recipient.public_key)
+                  token_id
+                |> Option.value_exn
+                     ~message:"Live SDK did not credit the ERC20 recipient"
+              in
+              let cap = UInt64.of_string (Sys.getenv_exn "ERC20_DEPOSIT_CAP") in
+              let deposit_amount = Currency.Amount.to_uint64 deposit_params.amount in
+              let withdrawal_amount =
+                Currency.Amount.to_uint64 withdrawal_params.amount
+              in
+              let expected_vault =
+                UInt64.add (UInt64.sub cap deposit_amount) withdrawal_amount
+              in
+              let expected_recipient =
+                UInt64.sub deposit_amount withdrawal_amount
+              in
+              let vault_balance = Currency.Balance.to_uint64 vault.balance in
+              let recipient_balance =
+                Currency.Balance.to_uint64 recipient_account.balance
+              in
+              if
+                (not (UInt64.equal vault_balance expected_vault))
+                || not (UInt64.equal recipient_balance expected_recipient)
+              then
+                failwithf
+                  "Unexpected live ERC20 balances: vault=%s recipient=%s"
+                  (UInt64.to_string vault_balance)
+                  (UInt64.to_string recipient_balance) () ;
               print_endline
-                "Live SDK finalized the deposit and submitted the native \
-                 withdrawal"
-          | _ ->
-              failwith
-                "Live SDK withdrawal request was not recorded in the OCaml \
-                 archive"
+                "Live SDK deployed the standard token, finalized the ERC20 \
+                 deposit, and submitted the ERC20 withdrawal" )
         in
         let outer_action_state_before =
           run (fun () ->
@@ -668,6 +893,7 @@ let () =
               Gql_client.For_tests.create_new_block ~logger gql_uri
             in
             () ) ;
+        run fund_ethereum_token_operator ;
         let outer_action_state_after =
           run (fun () ->
               Gql_client.fetch_action_state gql_uri
@@ -681,12 +907,18 @@ let () =
         print_endline
           "(* Synchronize the accepting commit into the inner account *)" ;
         run synchronize_accepting_commit ;
-        if bridge_live_sdk then run_live_sdk ()
-        else (
-          print_endline "(* Finalize deposit on L2 *)" ;
-          run (fun () -> finalize_deposit () >>| ignore) ;
-          print_endline "(* Submit native withdrawal on L2 *)" ;
-          run (fun () -> submit_withdrawal () >>| ignore) ) ;
+        ( if bridge_live_sdk then run_live_sdk ()
+          else
+            match bridge_asset with
+            | Native ->
+                print_endline "(* Finalize deposit on L2 *)" ;
+                run (fun () -> finalize_deposit () >>| ignore) ;
+                print_endline "(* Submit native withdrawal on L2 *)" ;
+                run (fun () -> submit_withdrawal () >>| ignore)
+            | Ethereum_token ->
+                failwith
+                  "BRIDGE_ASSET=erc20 requires \
+                   ZEKO_ETHEREUM_BRIDGE_LIVE_SDK=true" ) ;
         run (fun () -> commit_and_check "Commit inner withdrawal action") ;
         let[@warning "-26"] sequencer = free_sequencer sequencer in
         run (fun () ->

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -933,7 +933,7 @@ let () =
           Out_channel.write_all operations_ready_path ~data:"ready\n" ;
           run (fun () ->
               wait_for_file ~timeout:(Time.Span.of_min 45.) complete_path ) ;
-          let validate_helper_account ~expected_next_deposit helper_owner =
+          let helper_next_deposit helper_owner =
             let helper_account =
               Sequencer.get_account !sequencer
                 (Public_key.compress recipient.public_key)
@@ -953,6 +953,10 @@ let () =
               in
               UInt32.of_string (Field.to_string next_deposit)
             in
+            next_deposit
+          in
+          let validate_helper_account ~expected_next_deposit helper_owner =
+            let next_deposit = helper_next_deposit helper_owner in
             if not (UInt32.equal next_deposit expected_next_deposit) then
               failwithf
                 "Live SDK finalized deposit index %s, expected %s"
@@ -987,16 +991,14 @@ let () =
                     "Live SDK withdrawal request was not recorded in the OCaml \
                      archive" )
           | Ethereum_token ->
-              List.iteri ethereum_asset_records ~f:(fun index record ->
+              List.mapi ethereum_asset_records ~f:(fun index record ->
                   let token_id = record.token_id_l2 in
                   let helper_owner =
                     Account_id.create
                       Zeko_circuits_config.Inputs.Ethereum_assets
                       .vault_public_key token_id
                   in
-                  validate_helper_account
-                    ~expected_next_deposit:(UInt32.of_int (index + 1))
-                    helper_owner ;
+                  let next_deposit = helper_next_deposit helper_owner in
                   let vault =
                     Sequencer.get_account !sequencer
                       Zeko_circuits_config.Inputs.Ethereum_assets
@@ -1045,7 +1047,26 @@ let () =
                       index
                       (UInt64.to_string vault_balance)
                       (UInt64.to_string recipient_balance)
-                      () ) ;
+                      () ;
+                  next_deposit )
+              |> fun next_deposits ->
+              let next_deposits =
+                List.sort next_deposits ~compare:UInt32.compare
+              in
+              let expected_next_deposits =
+                List.init (List.length ethereum_asset_records) ~f:(fun index ->
+                    UInt32.of_int (index + 1) )
+              in
+              if
+                not
+                  (List.equal UInt32.equal next_deposits
+                     expected_next_deposits )
+              then
+                failwithf
+                  "Live SDK finalized unexpected ERC20 deposit indices: %s"
+                  (List.map next_deposits ~f:UInt32.to_string
+                  |> String.concat ~sep:"," )
+                  () ;
               print_endline
                 "Live SDK deployed two standard tokens, finalized both ERC20 \
                  deposits, and submitted both ERC20 withdrawals"

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -205,6 +205,51 @@ let () =
             (Field.to_string compiled_bridge_vk_hash)
             (Field.to_string prover_bridge_vk_hash)
             () ;
+        if Zeko_circuits_config.Inputs.Ethereum_assets.enabled then (
+          let local_registry_vk_hash =
+            Sequencer.get_account !sequencer
+              Zeko_circuits_config.Inputs.Ethereum_assets.registry_public_key
+              Token_id.default
+            |> Option.bind ~f:Account.zkapp
+            |> Option.bind ~f:(fun zkapp -> zkapp.verification_key)
+            |> Option.map ~f:With_hash.hash
+            |> Option.value_exn
+                 ~message:
+                   "Ethereum asset registry is missing its verification key"
+          in
+          let prover_registry_vk_hash =
+            !sequencer.bridge_prover.verification_keys.ethereum_asset_registry
+          in
+          let compiled_registry_vk_hash =
+            run (fun () ->
+                Compile_simple.Verification_key.of_tag
+                  (Lazy.force
+                     Bridge_inst_ethereum_token.Registry.registry_tag )
+                |> Promise.to_deferred
+                >>| Compile_simple.Verification_key.hash )
+          in
+          printf "Ethereum asset registry VK hash in genesis: %s\n%!"
+            (Field.to_string local_registry_vk_hash) ;
+          printf "Ethereum asset registry VK hash compiled locally: %s\n%!"
+            (Field.to_string compiled_registry_vk_hash) ;
+          printf "Ethereum asset registry VK hash from prover: %s\n%!"
+            (Field.to_string prover_registry_vk_hash) ;
+          if
+            Option.is_some Is_compile_simple_real.is_compile_simple_real
+            && ( (not
+                    (Field.equal local_registry_vk_hash
+                       compiled_registry_vk_hash ) )
+               || not
+                    (Field.equal local_registry_vk_hash
+                       prover_registry_vk_hash ) )
+          then
+            failwithf
+              "Ethereum asset registry VK mismatch: genesis %s, local compile \
+               %s, real prover %s"
+              (Field.to_string local_registry_vk_hash)
+              (Field.to_string compiled_registry_vk_hash)
+              (Field.to_string prover_registry_vk_hash)
+              () ) ;
         let ethereum_token_bridge_verification_key =
           match bridge_asset with
           | Native ->

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -410,7 +410,8 @@ let () =
           | params ->
               List.map params ~f:(fun params ->
                   Utils.value_to_hash
-                    ~init:Zeko_constants.ethereum_erc20_deposit_salt
+                    ~init:
+                      C.Bridge_state.Deposit_params_ethereum_token.ethereum_salt
                     C.Bridge_state.Deposit_params_ethereum_token.typ params )
         in
         let withdrawal_params : C.Bridge_state.Withdrawal_params_base.t =

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -994,11 +994,12 @@ let () =
               account_creation_fee
             @@ Zkapp_command.Call_forest.cons
                  ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
-                 Deploy_account_update.account_update
+                 (Lazy.force Deploy_account_update.account_update)
             @@ Zkapp_command.Call_forest.cons_tree
-                 Initialize_account_update.account_update
+                 (Lazy.force Initialize_account_update.account_update)
             @@ Zkapp_command.Call_forest.cons_tree
-                 Update_state_account_update.account_update []
+                 (Lazy.force Update_state_account_update.account_update)
+                 []
           in
           User_command.Zkapp_command
             (Utils.sign_zkapp_command

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -210,9 +210,9 @@ let () =
           | Native ->
               None
           | Ethereum_token ->
-              if not Zeko_circuits_config.Inputs.Ethereum_token.enabled then
+              if not Zeko_circuits_config.Inputs.Ethereum_assets.enabled then
                 failwith
-                  "BRIDGE_ASSET=erc20 requires an ethereum_token circuits config" ;
+                  "BRIDGE_ASSET=erc20 requires an ethereum_assets circuits config" ;
               let verification_key =
                 run (fun () ->
                     Compile_simple.Verification_key.of_tag
@@ -255,6 +255,58 @@ let () =
                (Stdlib.Sys.getenv_opt "ZEKO_ETHEREUM_WITHDRAWAL_RECIPIENT")
                ~default:"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266" )
         in
+        let ethereum_asset_records :
+            Zeko_circuits.Asset_registry.Asset_record.t list =
+          match bridge_asset with
+          | Native ->
+              []
+          | Ethereum_token ->
+              List.init 2 ~f:(fun registry_index ->
+                  let prefix = sprintf "ERC20_TOKEN_%d_" registry_index in
+                  let env suffix = Sys.getenv_exn (prefix ^ suffix) in
+                  let asset_id_high, asset_id_low =
+                    Zeko_circuits_config.asset_id_limbs_exn (env "ASSET_ID")
+                  in
+                  let ethereum_token_address =
+                    Zeko_circuits_config.ethereum_address_to_public_key
+                      (env "ADDRESS")
+                  in
+                  let token_owner_l2 =
+                    Public_key.Compressed.of_base58_check_exn (env "OWNER_L2")
+                  in
+                  if ethereum_token_address.is_odd || token_owner_l2.is_odd then
+                    failwith
+                      "Live Ethereum asset addresses and owners must be even"
+                  else
+                    let owner =
+                      Account_id.create token_owner_l2 Token_id.default
+                    in
+                    ( { schema_version =
+                        Zeko_circuits_config.Inputs.Ethereum_assets
+                          .registry_schema_version
+                    ; registry_index =
+                        Zeko_circuits.Zeko_util.Checked32.of_int registry_index
+                    ; asset_id_high
+                    ; asset_id_low
+                    ; ethereum_token_address = ethereum_token_address.x
+                    ; token_owner_l2
+                    ; token_id_l2 = Account_id.derive_token_id ~owner
+                    ; decimals = Zeko_circuits.Zeko_util.Checked32.of_int 9
+                    ; inventory_cap =
+                        Currency.Amount.of_uint64
+                          (Unsigned.UInt64.of_string (env "DEPOSIT_CAP"))
+                    ; mft_standard_vk_id =
+                        Zeko_circuits_config.Inputs.Ethereum_assets
+                          .approved_mft_standard_vk_id
+                    ; vault_public_key =
+                        Zeko_circuits_config.Inputs.Ethereum_assets
+                          .vault_public_key
+                    ; universal_bridge_vk_id =
+                        Zeko_circuits_config.Inputs.Ethereum_assets
+                          .universal_bridge_vk_id
+                      }
+                      : Zeko_circuits.Asset_registry.Asset_record.t ) )
+        in
         let deposit_params : C.Bridge_state.Deposit_params_base.t =
           { children = []
           ; holder_account_l1 = ethereum_holder
@@ -264,43 +316,48 @@ let () =
           }
         in
         let ethereum_token_deposit_params :
-            C.Bridge_state.Deposit_params_ethereum_token.t option =
+            C.Bridge_state.Deposit_params_ethereum_token.t list =
           match bridge_asset with
           | Native ->
-              None
+              []
           | Ethereum_token ->
-              Some
-                { asset_id_high =
-                    Zeko_circuits_config.Inputs.Ethereum_token
-                    .ethereum_asset_id_high
-                ; asset_id_low =
-                    Zeko_circuits_config.Inputs.Ethereum_token
-                    .ethereum_asset_id_low
-                ; base = deposit_params
-                }
+              List.map ethereum_asset_records ~f:(fun record ->
+                  ( { asset_id_high = record.asset_id_high
+                  ; asset_id_low = record.asset_id_low
+                  ; base = deposit_params
+                    }
+                    : C.Bridge_state.Deposit_params_ethereum_token.t ) )
         in
         ( match bridge_asset with
         | Native ->
             ()
         | Ethereum_token ->
-            let configured_amount =
-              UInt64.of_string (Sys.getenv_exn "ERC20_DEPOSIT_AMOUNT")
+            let scenario_amount =
+              Currency.Amount.to_uint64 deposit_params.amount
             in
-            let scenario_amount = Currency.Amount.to_uint64 deposit_params.amount in
-            if not (UInt64.equal configured_amount scenario_amount) then
-              failwithf
-                "ERC20_DEPOSIT_AMOUNT %s does not match scenario amount %s"
-                (UInt64.to_string configured_amount)
-                (UInt64.to_string scenario_amount) () ) ;
-        let deposit_aux () =
+            List.iteri ethereum_asset_records ~f:(fun index _record ->
+                let configured_amount =
+                  UInt64.of_string
+                    (Sys.getenv_exn
+                       (sprintf "ERC20_TOKEN_%d_DEPOSIT_AMOUNT" index) )
+                in
+                if not (UInt64.equal configured_amount scenario_amount) then
+                  failwithf
+                    "ERC20_TOKEN_%d_DEPOSIT_AMOUNT %s does not match scenario \
+                     amount %s"
+                    index (UInt64.to_string configured_amount)
+                    (UInt64.to_string scenario_amount) () ) ) ;
+        let deposit_auxes () =
           match ethereum_token_deposit_params with
-          | None ->
-              Utils.value_to_hash ~init:Zeko_constants.ethereum_deposit_salt
-                C.Bridge_state.Deposit_params_base.typ deposit_params
-          | Some params ->
-              Utils.value_to_hash
-                ~init:Zeko_constants.ethereum_erc20_deposit_salt
-                C.Bridge_state.Deposit_params_ethereum_token.typ params
+          | [] ->
+              [ Utils.value_to_hash ~init:Zeko_constants.ethereum_deposit_salt
+                  C.Bridge_state.Deposit_params_base.typ deposit_params
+              ]
+          | params ->
+              List.map params ~f:(fun params ->
+                  Utils.value_to_hash
+                    ~init:Zeko_constants.ethereum_erc20_deposit_salt
+                    C.Bridge_state.Deposit_params_ethereum_token.typ params )
         in
         let withdrawal_params : C.Bridge_state.Withdrawal_params_base.t =
           { children = []
@@ -327,8 +384,8 @@ let () =
                 (Filename.concat directory "bridge-genesis-ledger.json")
                 ~data:(json ^ "\n")
         in
-        let write_scenario_manifest ~outer_action_state_before
-            ~outer_action_state_after =
+        let write_scenario_manifest ~outer_action_state_before_registration
+            ~outer_action_state_before ~outer_action_state_after =
           match bridge_scenario_directory () with
           | None ->
               ()
@@ -340,59 +397,60 @@ let () =
                 |> Option.value_exn
                      ~message:"withdrawal recipient is not an Ethereum address"
               in
-              let aux = deposit_aux () in
+              let auxes = deposit_auxes () in
+              let aux = List.hd_exn auxes in
               let asset_fields =
                 match bridge_asset with
                 | Native ->
                     [ ("bridgeAsset", `String "native") ]
                 | Ethereum_token ->
-                    let token_owner =
-                      Account_id.public_key
-                        Zeko_circuits_config.Inputs.Ethereum_token.token_owner_l2
-                    in
-                    if token_owner.is_odd then
-                      failwith
-                        "The local ERC20 token owner must have an even public key" ;
-                    let token_id =
-                      Account_id.derive_token_id
-                        ~owner:
-                          Zeko_circuits_config.Inputs.Ethereum_token
-                          .token_owner_l2
+                    let assets =
+                      List.zip_exn ethereum_asset_records auxes
+                      |> List.map ~f:(fun (record, deposit_aux) ->
+                             `Assoc
+                               [ ( "record"
+                                 , Ethereum_settlement_export
+                                   .canonical_asset_record_json record )
+                               ; ( "tokenOwnerPublicKey"
+                                 , `String
+                                     (Public_key.Compressed.to_base58_check
+                                        record.token_owner_l2 ) )
+                               ; ( "tokenIdBase58"
+                                 , `String
+                                     (Token_id.to_string record.token_id_l2) )
+                               ; ( "depositAux"
+                                 , `String
+                                     (Ethereum_settlement_export.field_to_hex
+                                        deposit_aux ) )
+                               ] )
                     in
                     [ ("bridgeAsset", `String "erc20")
-                    ; ( "ethereumTokenAddress"
-                      , `String
-                          Zeko_circuits_config.Inputs.Ethereum_token
-                            .ethereum_token_address )
-                    ; ( "ethereumTokenAssetId"
-                      , `String
-                          Zeko_circuits_config.Inputs.Ethereum_token.asset_id )
-                    ; ( "ethereumTokenOwnerL2"
-                      , `String
-                          (Public_key.Compressed.to_base58_check token_owner) )
-                    ; ( "ethereumTokenOwnerPacked"
-                      , `String
-                          (Ethereum_settlement_export.field_to_hex token_owner.x)
-                      )
-                    ; ( "ethereumTokenIdL2"
-                      , `String
-                          (Ethereum_settlement_export.field_to_hex
-                             (Token_id.to_field_unsafe token_id) ) )
-                    ; ( "ethereumTokenIdL2Base58"
-                      , `String (Token_id.to_string token_id) )
-                    ; ( "ethereumTokenVaultL2"
+                    ; ("ethereumAssets", `List assets)
+                    ; ( "ethereumAssetRegistryL2"
                       , `String
                           (Public_key.Compressed.to_base58_check
-                             Zeko_circuits_config.Inputs.Ethereum_token
-                               .holder_account_l2 ) )
-                    ; ("ethereumTokenDecimals", `Int 9)
-                    ; ( "ethereumTokenDepositCap"
-                      , `String (Sys.getenv_exn "ERC20_DEPOSIT_CAP") )
+                             Zeko_circuits_config.Inputs.Ethereum_assets
+                               .registry_public_key ) )
+                    ; ( "ethereumSharedVaultL2"
+                      , `String
+                          (Public_key.Compressed.to_base58_check
+                             Zeko_circuits_config.Inputs.Ethereum_assets
+                               .vault_public_key ) )
+                    ; ( "ethereumMftStandardVkId"
+                      , `String
+                          (Field.to_string
+                             Zeko_circuits_config.Inputs.Ethereum_assets
+                               .approved_mft_standard_vk_id ) )
+                    ; ( "ethereumUniversalBridgeVkId"
+                      , `String
+                          (Field.to_string
+                             Zeko_circuits_config.Inputs.Ethereum_assets
+                               .universal_bridge_vk_id ) )
                     ]
               in
               let json =
                 `Assoc
-                  ( [ ("schemaVersion", `Int 2)
+                  ( [ ("schemaVersion", `Int 3)
                   ; ("commitValidityPeriod", `Int bridge_commit_validity_period)
                   ; ( "zekoRecipient"
                     , `String
@@ -412,10 +470,17 @@ let () =
                         |> Unsigned.UInt32.to_string ) )
                   ; ( "depositAux"
                     , `String (Ethereum_settlement_export.field_to_hex aux) )
+                  ; ( "depositAuxes"
+                    , Ethereum_settlement_export.fields_json
+                        (Array.of_list auxes) )
                   ; ( "outerActionStateBeforeDeposit"
                     , `String
                         (Ethereum_settlement_export.field_to_hex
                            outer_action_state_before ) )
+                  ; ( "outerActionStateBeforeRegistration"
+                    , `String
+                        (Ethereum_settlement_export.field_to_hex
+                           outer_action_state_before_registration ) )
                   ; ( "outerActionStateAfterDeposit"
                     , `String
                         (Ethereum_settlement_export.field_to_hex
@@ -441,11 +506,11 @@ let () =
                 (Filename.concat directory "bridge-scenario.json")
                 ~data:(Yojson.Safe.pretty_to_string json ^ "\n")
         in
-        let submit_ethereum_deposit () =
+        let submit_ethereum_deposit aux =
           let witness : Bridge.Outer_action_witness.serializable =
             { public_key = Zeko_circuits_config.Inputs.zeko_l1
             ; witness =
-                { aux = deposit_aux ()
+                { aux
                 ; children = []
                 ; slot_range = C.Zeko_util.Slot_range.infinite
                 }
@@ -733,15 +798,25 @@ let () =
               |> Or_error.ok_exn ))
           >>| Or_error.ok_exn
         in
-        let run_live_sdk () =
+        let live_sdk_paths () =
           let directory = Sys.getenv_exn "ZEKO_ETHEREUM_BRIDGE_LIVE_DIR" in
+          ( Filename.concat directory "ready.json"
+          , Filename.concat directory "registrations-complete"
+          , Filename.concat directory "operations-ready"
+          , Filename.concat directory "operations-complete" )
+        in
+        let start_live_sdk () =
           let port =
             Option.value_map
               (Stdlib.Sys.getenv_opt "ZEKO_ETHEREUM_BRIDGE_LIVE_PORT")
               ~default:8082 ~f:Int.of_string
           in
-          let ready_path = Filename.concat directory "ready.json" in
-          let complete_path = Filename.concat directory "operations-complete" in
+          let ( ready_path
+              , registration_complete_path
+              , operations_ready_path
+              , complete_path ) =
+            live_sdk_paths ()
+          in
           run (fun () ->
               start_graphql_server ~port !sequencer ~l1_executor ~l2_executor ) ;
           let token_verification_key_fields =
@@ -756,7 +831,7 @@ let () =
           in
           let manifest =
             `Assoc
-              ( [ ("schemaVersion", `Int 2)
+              ( [ ("schemaVersion", `Int 3)
               ; ( "sequencerGraphqlUrl"
                 , `String (sprintf "http://127.0.0.1:%d/graphql" port) )
               ; ("l1GraphqlUrl", `String (Uri.to_string gql_uri))
@@ -769,6 +844,9 @@ let () =
                     (Public_key.Compressed.to_base58_check
                     (Public_key.compress recipient.public_key) ) )
               ; ("completionMarker", `String complete_path)
+              ; ( "registrationCompletionMarker"
+                , `String registration_complete_path )
+              ; ("operationsReadyMarker", `String operations_ready_path)
               ]
               @ token_verification_key_fields )
           in
@@ -776,46 +854,45 @@ let () =
             ~data:(Yojson.Safe.pretty_to_string manifest ^ "\n") ;
           printf "Live bridge SDK harness ready: %s\n%!" ready_path ;
           run (fun () ->
+              wait_for_file ~timeout:(Time.Span.of_min 45.)
+                registration_complete_path )
+        in
+        let run_live_sdk () =
+          let _, _, operations_ready_path, complete_path = live_sdk_paths () in
+          Out_channel.write_all operations_ready_path ~data:"ready\n" ;
+          run (fun () ->
               wait_for_file ~timeout:(Time.Span.of_min 45.) complete_path ) ;
-          let helper_owner =
-            match bridge_asset with
-            | Native ->
-                Account_id.of_public_key
-                  (Public_key.decompress_exn
-                     Zeko_circuits_config.Inputs.holder_account_l2 )
-            | Ethereum_token ->
-                Account_id.create
-                  Zeko_circuits_config.Inputs.Ethereum_token.holder_account_l2
-                  (Account_id.derive_token_id
-                     ~owner:
-                       Zeko_circuits_config.Inputs.Ethereum_token
-                         .token_owner_l2 )
-          in
-          let helper_account =
-            Sequencer.get_account !sequencer
-              (Public_key.compress recipient.public_key)
-              (Account_id.derive_token_id ~owner:helper_owner)
-            |> Option.value_exn
-                 ~message:
-                   "Live SDK deposit finalization did not create the helper \
-                    account"
-          in
-          let next_deposit =
-            Account.zkapp helper_account
-            |> Option.value_exn
-                 ~message:"Live SDK helper account is not a zkApp"
-            |> fun zkapp ->
-            let (next_deposit :: _ : F.t Zkapp_state.V.t) =
-              Zkapp_account.Poly.app_state zkapp
+          let validate_helper_account helper_owner =
+            let helper_account =
+              Sequencer.get_account !sequencer
+                (Public_key.compress recipient.public_key)
+                (Account_id.derive_token_id ~owner:helper_owner)
+              |> Option.value_exn
+                   ~message:
+                     "Live SDK deposit finalization did not create the helper \
+                      account"
             in
-            UInt32.of_string (Field.to_string next_deposit)
+            let next_deposit =
+              Account.zkapp helper_account
+              |> Option.value_exn
+                   ~message:"Live SDK helper account is not a zkApp"
+              |> fun zkapp ->
+              let (next_deposit :: _ : F.t Zkapp_state.V.t) =
+                Zkapp_account.Poly.app_state zkapp
+              in
+              UInt32.of_string (Field.to_string next_deposit)
+            in
+            if not (UInt32.equal next_deposit UInt32.one) then
+              failwithf
+                "Live SDK finalized an unexpected next deposit index: %s"
+                (UInt32.to_string next_deposit) ()
           in
-          if not (UInt32.equal next_deposit UInt32.one) then
-            failwithf "Live SDK finalized an unexpected next deposit index: %s"
-              (UInt32.to_string next_deposit)
-              () ;
           ( match bridge_asset with
           | Native ->
+              validate_helper_account
+                (Account_id.of_public_key
+                   (Public_key.decompress_exn
+                      Zeko_circuits_config.Inputs.holder_account_l2 ) ) ;
               let withdrawal_aux =
                 Utils.value_to_hash ~init:Zeko_constants.withdrawal_salt
                   C.Bridge_state.Withdrawal_params_base.typ withdrawal_params
@@ -837,53 +914,69 @@ let () =
                     "Live SDK withdrawal request was not recorded in the OCaml \
                      archive" )
           | Ethereum_token ->
-              let token_id =
-                Account_id.derive_token_id
-                  ~owner:
-                    Zeko_circuits_config.Inputs.Ethereum_token.token_owner_l2
-              in
-              let vault =
-                Sequencer.get_account !sequencer
-                  Zeko_circuits_config.Inputs.Ethereum_token.holder_account_l2
-                  token_id
-                |> Option.value_exn
-                     ~message:"Live SDK did not install the ERC20 bridge vault"
-              in
-              let recipient_account =
-                Sequencer.get_account !sequencer
-                  (Public_key.compress recipient.public_key)
-                  token_id
-                |> Option.value_exn
-                     ~message:"Live SDK did not credit the ERC20 recipient"
-              in
-              let cap = UInt64.of_string (Sys.getenv_exn "ERC20_DEPOSIT_CAP") in
-              let deposit_amount = Currency.Amount.to_uint64 deposit_params.amount in
-              let withdrawal_amount =
-                Currency.Amount.to_uint64 withdrawal_params.amount
-              in
-              let expected_vault =
-                UInt64.add (UInt64.sub cap deposit_amount) withdrawal_amount
-              in
-              let expected_recipient =
-                UInt64.sub deposit_amount withdrawal_amount
-              in
-              let vault_balance = Currency.Balance.to_uint64 vault.balance in
-              let recipient_balance =
-                Currency.Balance.to_uint64 recipient_account.balance
-              in
-              if
-                (not (UInt64.equal vault_balance expected_vault))
-                || not (UInt64.equal recipient_balance expected_recipient)
-              then
-                failwithf
-                  "Unexpected live ERC20 balances: vault=%s recipient=%s"
-                  (UInt64.to_string vault_balance)
-                  (UInt64.to_string recipient_balance) () ;
+              List.iteri ethereum_asset_records ~f:(fun index record ->
+                  let token_id = record.token_id_l2 in
+                  let helper_owner =
+                    Account_id.create
+                      Zeko_circuits_config.Inputs.Ethereum_assets
+                        .vault_public_key
+                      token_id
+                  in
+                  validate_helper_account helper_owner ;
+                  let vault =
+                    Sequencer.get_account !sequencer
+                      Zeko_circuits_config.Inputs.Ethereum_assets
+                        .vault_public_key
+                      token_id
+                    |> Option.value_exn
+                         ~message:
+                           "Live SDK did not install an ERC20 bridge vault"
+                  in
+                  let recipient_account =
+                    Sequencer.get_account !sequencer
+                      (Public_key.compress recipient.public_key)
+                      token_id
+                    |> Option.value_exn
+                         ~message:"Live SDK did not credit an ERC20 recipient"
+                  in
+                  let cap =
+                    UInt64.of_string
+                      (Sys.getenv_exn
+                         (sprintf "ERC20_TOKEN_%d_DEPOSIT_CAP" index) )
+                  in
+                  let deposit_amount =
+                    Currency.Amount.to_uint64 deposit_params.amount
+                  in
+                  let withdrawal_amount =
+                    Currency.Amount.to_uint64 withdrawal_params.amount
+                  in
+                  let expected_vault =
+                    UInt64.add (UInt64.sub cap deposit_amount)
+                      withdrawal_amount
+                  in
+                  let expected_recipient =
+                    UInt64.sub deposit_amount withdrawal_amount
+                  in
+                  let vault_balance =
+                    Currency.Balance.to_uint64 vault.balance
+                  in
+                  let recipient_balance =
+                    Currency.Balance.to_uint64 recipient_account.balance
+                  in
+                  if
+                    (not (UInt64.equal vault_balance expected_vault))
+                    || not (UInt64.equal recipient_balance expected_recipient)
+                  then
+                    failwithf
+                      "Unexpected live ERC20[%d] balances: vault=%s \
+                       recipient=%s"
+                      index (UInt64.to_string vault_balance)
+                      (UInt64.to_string recipient_balance) () ) ;
               print_endline
-                "Live SDK deployed the standard token, finalized the ERC20 \
-                 deposit, and submitted the ERC20 withdrawal" )
+                "Live SDK deployed two standard tokens, finalized both ERC20 \
+                 deposits, and submitted both ERC20 withdrawals" )
         in
-        let outer_action_state_before =
+        let outer_action_state_before_registration =
           run (fun () ->
               Gql_client.fetch_action_state gql_uri
                 (Public_key.compress outer_kp.public_key)
@@ -891,9 +984,27 @@ let () =
               >>| Or_error.ok_exn )
         in
         write_genesis_ledger () ;
-        print_endline "(* Append synthetic Ethereum deposit action *)" ;
+        if bridge_live_sdk then start_live_sdk () ;
+        ( match bridge_asset with
+        | Ethereum_token ->
+            run (fun () ->
+                commit_and_check
+                  "Commit two proof-backed Ethereum asset registrations" )
+        | Native ->
+            () ) ;
+        let outer_action_state_before =
+          run (fun () ->
+              Gql_client.fetch_action_state gql_uri
+                (Public_key.compress outer_kp.public_key)
+                ~logger
+              >>| Or_error.ok_exn )
+        in
+        print_endline "(* Append synthetic Ethereum deposit actions *)" ;
         run (fun () ->
-            let%bind _hash = submit_ethereum_deposit () in
+            let%bind () =
+              Deferred.List.iter (deposit_auxes ())
+                ~f:(fun aux -> submit_ethereum_deposit aux >>| ignore)
+            in
             let%map _created =
               Gql_client.For_tests.create_new_block ~logger gql_uri
             in
@@ -906,7 +1017,8 @@ let () =
                 ~logger
               >>| Or_error.ok_exn )
         in
-        write_scenario_manifest ~outer_action_state_before
+        write_scenario_manifest ~outer_action_state_before_registration
+          ~outer_action_state_before
           ~outer_action_state_after ;
         run (fun () -> commit_and_check "Commit synchronized deposit") ;
         print_endline

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -1055,7 +1055,9 @@ let () =
               in
               let expected_next_deposits =
                 List.init (List.length ethereum_asset_records) ~f:(fun index ->
-                    UInt32.of_int (index + 1) )
+                    (* The registry checkpoint precedes the two ERC20 deposits
+                       in the shared outer action stream. *)
+                    UInt32.of_int (index + 2) )
               in
               if
                 not

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -212,7 +212,8 @@ let () =
           | Ethereum_token ->
               if not Zeko_circuits_config.Inputs.Ethereum_assets.enabled then
                 failwith
-                  "BRIDGE_ASSET=erc20 requires an ethereum_assets circuits config" ;
+                  "BRIDGE_ASSET=erc20 requires an ethereum_assets circuits \
+                   config" ;
               let verification_key =
                 run (fun () ->
                     Compile_simple.Verification_key.of_tag
@@ -229,13 +230,15 @@ let () =
               if not (Field.equal expected_hash actual_hash) then
                 failwithf
                   "Ethereum token bridge VK mismatch: local %s, prover %s"
-                  (Field.to_string actual_hash) (Field.to_string expected_hash)
+                  (Field.to_string actual_hash)
+                  (Field.to_string expected_hash)
                   () ;
               let pickles_verification_key =
                 Compile_simple.Verification_key.to_pickles verification_key
                 |> Option.value_exn
                      ~message:
-                       "Real ERC20 live integration requires a Pickles verification key"
+                       "Real ERC20 live integration requires a Pickles \
+                        verification key"
               in
               Some
                 ( Pickles.Side_loaded.Verification_key.to_base64
@@ -282,27 +285,28 @@ let () =
                       Account_id.create token_owner_l2 Token_id.default
                     in
                     ( { schema_version =
-                        Zeko_circuits_config.Inputs.Ethereum_assets
+                          Zeko_circuits_config.Inputs.Ethereum_assets
                           .registry_schema_version
-                    ; registry_index =
-                        Zeko_circuits.Zeko_util.Checked32.of_int registry_index
-                    ; asset_id_high
-                    ; asset_id_low
-                    ; ethereum_token_address = ethereum_token_address.x
-                    ; token_owner_l2
-                    ; token_id_l2 = Account_id.derive_token_id ~owner
-                    ; decimals = Zeko_circuits.Zeko_util.Checked32.of_int 9
-                    ; inventory_cap =
-                        Currency.Amount.of_uint64
-                          (Unsigned.UInt64.of_string (env "DEPOSIT_CAP"))
-                    ; mft_standard_vk_id =
-                        Zeko_circuits_config.Inputs.Ethereum_assets
+                      ; registry_index =
+                          Zeko_circuits.Zeko_util.Checked32.of_int
+                            registry_index
+                      ; asset_id_high
+                      ; asset_id_low
+                      ; ethereum_token_address = ethereum_token_address.x
+                      ; token_owner_l2
+                      ; token_id_l2 = Account_id.derive_token_id ~owner
+                      ; decimals = Zeko_circuits.Zeko_util.Checked32.of_int 9
+                      ; inventory_cap =
+                          Currency.Amount.of_uint64
+                            (Unsigned.UInt64.of_string (env "DEPOSIT_CAP"))
+                      ; mft_standard_vk_id =
+                          Zeko_circuits_config.Inputs.Ethereum_assets
                           .approved_mft_standard_vk_id
-                    ; vault_public_key =
-                        Zeko_circuits_config.Inputs.Ethereum_assets
+                      ; vault_public_key =
+                          Zeko_circuits_config.Inputs.Ethereum_assets
                           .vault_public_key
-                    ; universal_bridge_vk_id =
-                        Zeko_circuits_config.Inputs.Ethereum_assets
+                      ; universal_bridge_vk_id =
+                          Zeko_circuits_config.Inputs.Ethereum_assets
                           .universal_bridge_vk_id
                       }
                       : Zeko_circuits.Asset_registry.Asset_record.t ) )
@@ -321,12 +325,13 @@ let () =
           | Native ->
               []
           | Ethereum_token ->
-              List.map ethereum_asset_records ~f:(fun record ->
-                  ( { asset_id_high = record.asset_id_high
+              List.map ethereum_asset_records
+                ~f:(fun record : C.Bridge_state.Deposit_params_ethereum_token.t
+                   ->
+                  { asset_id_high = record.asset_id_high
                   ; asset_id_low = record.asset_id_low
                   ; base = deposit_params
-                    }
-                    : C.Bridge_state.Deposit_params_ethereum_token.t ) )
+                  } )
         in
         ( match bridge_asset with
         | Native ->
@@ -345,8 +350,10 @@ let () =
                   failwithf
                     "ERC20_TOKEN_%d_DEPOSIT_AMOUNT %s does not match scenario \
                      amount %s"
-                    index (UInt64.to_string configured_amount)
-                    (UInt64.to_string scenario_amount) () ) ) ;
+                    index
+                    (UInt64.to_string configured_amount)
+                    (UInt64.to_string scenario_amount)
+                    () ) ) ;
         let deposit_auxes () =
           match ethereum_token_deposit_params with
           | [] ->
@@ -430,76 +437,78 @@ let () =
                       , `String
                           (Public_key.Compressed.to_base58_check
                              Zeko_circuits_config.Inputs.Ethereum_assets
-                               .registry_public_key ) )
+                             .registry_public_key ) )
                     ; ( "ethereumSharedVaultL2"
                       , `String
                           (Public_key.Compressed.to_base58_check
                              Zeko_circuits_config.Inputs.Ethereum_assets
-                               .vault_public_key ) )
+                             .vault_public_key ) )
                     ; ( "ethereumMftStandardVkId"
                       , `String
                           (Field.to_string
                              Zeko_circuits_config.Inputs.Ethereum_assets
-                               .approved_mft_standard_vk_id ) )
+                             .approved_mft_standard_vk_id ) )
                     ; ( "ethereumUniversalBridgeVkId"
                       , `String
                           (Field.to_string
                              Zeko_circuits_config.Inputs.Ethereum_assets
-                               .universal_bridge_vk_id ) )
+                             .universal_bridge_vk_id ) )
                     ]
               in
               let json =
                 `Assoc
                   ( [ ("schemaVersion", `Int 3)
-                  ; ("commitValidityPeriod", `Int bridge_commit_validity_period)
-                  ; ( "zekoRecipient"
-                    , `String
-                        (Ethereum_settlement_export.field_to_hex recipient.x) )
-                  ; ( "zekoRecipientPublicKey"
-                    , `String (Public_key.Compressed.to_base58_check recipient)
-                    )
-                  ; ("zekoRecipientIsOdd", `Bool recipient.is_odd)
-                  ; ( "depositAmountZeko"
-                    , `String
-                        ( Currency.Amount.to_uint64 deposit_params.amount
-                        |> Unsigned.UInt64.to_string ) )
-                  ; ( "depositTimeout"
-                    , `String
-                        ( Global_slot_since_genesis.to_uint32
-                            deposit_params.timeout
-                        |> Unsigned.UInt32.to_string ) )
-                  ; ( "depositAux"
-                    , `String (Ethereum_settlement_export.field_to_hex aux) )
-                  ; ( "depositAuxes"
-                    , Ethereum_settlement_export.fields_json
-                        (Array.of_list auxes) )
-                  ; ( "outerActionStateBeforeDeposit"
-                    , `String
-                        (Ethereum_settlement_export.field_to_hex
-                           outer_action_state_before ) )
-                  ; ( "outerActionStateBeforeRegistration"
-                    , `String
-                        (Ethereum_settlement_export.field_to_hex
-                           outer_action_state_before_registration ) )
-                  ; ( "outerActionStateAfterDeposit"
-                    , `String
-                        (Ethereum_settlement_export.field_to_hex
-                           outer_action_state_after ) )
-                  ; ("withdrawalRecipient", `String withdrawal_recipient)
-                  ; ( "withdrawalAmountZeko"
-                    , `String
-                        ( Currency.Amount.to_uint64 withdrawal_params.amount
-                        |> Unsigned.UInt64.to_string ) )
-                  ; ( "daPublicKeys"
-                    , `List
-                        (List.map da_keys ~f:(fun public_key ->
-                             `String
-                               (Public_key.Compressed.to_base58_check public_key) )
-                        ) )
-                  ; ( "sequencerPublicKey"
-                    , `String (Public_key.Compressed.to_base58_check signer_pk)
-                    )
-                  ]
+                    ; ( "commitValidityPeriod"
+                      , `Int bridge_commit_validity_period )
+                    ; ( "zekoRecipient"
+                      , `String
+                          (Ethereum_settlement_export.field_to_hex recipient.x)
+                      )
+                    ; ( "zekoRecipientPublicKey"
+                      , `String
+                          (Public_key.Compressed.to_base58_check recipient) )
+                    ; ("zekoRecipientIsOdd", `Bool recipient.is_odd)
+                    ; ( "depositAmountZeko"
+                      , `String
+                          ( Currency.Amount.to_uint64 deposit_params.amount
+                          |> Unsigned.UInt64.to_string ) )
+                    ; ( "depositTimeout"
+                      , `String
+                          ( Global_slot_since_genesis.to_uint32
+                              deposit_params.timeout
+                          |> Unsigned.UInt32.to_string ) )
+                    ; ( "depositAux"
+                      , `String (Ethereum_settlement_export.field_to_hex aux) )
+                    ; ( "depositAuxes"
+                      , Ethereum_settlement_export.fields_json
+                          (Array.of_list auxes) )
+                    ; ( "outerActionStateBeforeDeposit"
+                      , `String
+                          (Ethereum_settlement_export.field_to_hex
+                             outer_action_state_before ) )
+                    ; ( "outerActionStateBeforeRegistration"
+                      , `String
+                          (Ethereum_settlement_export.field_to_hex
+                             outer_action_state_before_registration ) )
+                    ; ( "outerActionStateAfterDeposit"
+                      , `String
+                          (Ethereum_settlement_export.field_to_hex
+                             outer_action_state_after ) )
+                    ; ("withdrawalRecipient", `String withdrawal_recipient)
+                    ; ( "withdrawalAmountZeko"
+                      , `String
+                          ( Currency.Amount.to_uint64 withdrawal_params.amount
+                          |> Unsigned.UInt64.to_string ) )
+                    ; ( "daPublicKeys"
+                      , `List
+                          (List.map da_keys ~f:(fun public_key ->
+                               `String
+                                 (Public_key.Compressed.to_base58_check
+                                    public_key ) ) ) )
+                    ; ( "sequencerPublicKey"
+                      , `String
+                          (Public_key.Compressed.to_base58_check signer_pk) )
+                    ]
                   @ asset_fields )
               in
               Out_channel.write_all
@@ -562,20 +571,37 @@ let () =
               let payment : Transaction_spec.t =
                 { fee = Currency.Fee.of_mina_string_exn "0.1"
                 ; sender = (source, nonce)
-                ; receiver = Public_key.compress recipient.public_key
-                (* Generated test accounts hold exactly 100 MINA. Keep enough
-                   headroom for this transfer's fee and the source account's
-                   later use while giving the browser operator ample funds for
-                   token deployment and account creation. *)
+                ; receiver =
+                    Public_key.compress recipient.public_key
+                    (* Generated test accounts hold exactly 100 MINA. Keep enough
+                       headroom for this transfer's fee and the source account's
+                       later use while giving the browser operator ample funds for
+                       token deployment and account creation. *)
                 ; amount = Currency.Amount.of_mina_int_exn 50
                 ; actions = None
                 }
               in
               apply_user_command !sequencer
                 (Signed_command
-                   (command_send
-                      ~chain:Zeko_circuits_config.Inputs.chain_l2 payment ) )
+                   (command_send ~chain:Zeko_circuits_config.Inputs.chain_l2
+                      payment ) )
               >>| Or_error.ok_exn
+        in
+        let require_live_sdk_fee_payer () =
+          match bridge_asset with
+          | Native ->
+              ()
+          | Ethereum_token ->
+              let (_ : Account.t) =
+                Sequencer.get_account !sequencer
+                  (Public_key.compress recipient.public_key)
+                  Token_id.default
+                |> Option.value_exn
+                     ~message:
+                       "Live SDK fee payer must be funded on L2 before the \
+                        readiness manifest is published"
+              in
+              ()
         in
         let commit_and_check label =
           printf "(* %s *)\n%!" label ;
@@ -832,22 +858,22 @@ let () =
           let manifest =
             `Assoc
               ( [ ("schemaVersion", `Int 3)
-              ; ( "sequencerGraphqlUrl"
-                , `String (sprintf "http://127.0.0.1:%d/graphql" port) )
-              ; ("l1GraphqlUrl", `String (Uri.to_string gql_uri))
-              ; ( "outerPublicKey"
-                , `String
-                    (Public_key.Compressed.to_base58_check
-                       (Public_key.compress outer_kp.public_key) ) )
-              ; ( "recipientPublicKey"
-                , `String
-                    (Public_key.Compressed.to_base58_check
-                    (Public_key.compress recipient.public_key) ) )
-              ; ("completionMarker", `String complete_path)
-              ; ( "registrationCompletionMarker"
-                , `String registration_complete_path )
-              ; ("operationsReadyMarker", `String operations_ready_path)
-              ]
+                ; ( "sequencerGraphqlUrl"
+                  , `String (sprintf "http://127.0.0.1:%d/graphql" port) )
+                ; ("l1GraphqlUrl", `String (Uri.to_string gql_uri))
+                ; ( "outerPublicKey"
+                  , `String
+                      (Public_key.Compressed.to_base58_check
+                         (Public_key.compress outer_kp.public_key) ) )
+                ; ( "recipientPublicKey"
+                  , `String
+                      (Public_key.Compressed.to_base58_check
+                         (Public_key.compress recipient.public_key) ) )
+                ; ("completionMarker", `String complete_path)
+                ; ( "registrationCompletionMarker"
+                  , `String registration_complete_path )
+                ; ("operationsReadyMarker", `String operations_ready_path)
+                ]
               @ token_verification_key_fields )
           in
           Out_channel.write_all ready_path
@@ -885,10 +911,11 @@ let () =
             if not (UInt32.equal next_deposit UInt32.one) then
               failwithf
                 "Live SDK finalized an unexpected next deposit index: %s"
-                (UInt32.to_string next_deposit) ()
+                (UInt32.to_string next_deposit)
+                ()
           in
-          ( match bridge_asset with
-          | Native ->
+          match bridge_asset with
+          | Native -> (
               validate_helper_account
                 (Account_id.of_public_key
                    (Public_key.decompress_exn
@@ -897,10 +924,10 @@ let () =
                 Utils.value_to_hash ~init:Zeko_constants.withdrawal_salt
                   C.Bridge_state.Withdrawal_params_base.typ withdrawal_params
               in
-              ( match
-                  Archive.find_ethereum_withdrawal !sequencer.archive
-                    ~aux:withdrawal_aux
-                with
+              match
+                Archive.find_ethereum_withdrawal !sequencer.archive
+                  ~aux:withdrawal_aux
+              with
               | Some withdrawal
                 when Public_key.Compressed.equal withdrawal.recipient
                        withdrawal_params.recipient
@@ -919,15 +946,13 @@ let () =
                   let helper_owner =
                     Account_id.create
                       Zeko_circuits_config.Inputs.Ethereum_assets
-                        .vault_public_key
-                      token_id
+                      .vault_public_key token_id
                   in
                   validate_helper_account helper_owner ;
                   let vault =
                     Sequencer.get_account !sequencer
                       Zeko_circuits_config.Inputs.Ethereum_assets
-                        .vault_public_key
-                      token_id
+                      .vault_public_key token_id
                     |> Option.value_exn
                          ~message:
                            "Live SDK did not install an ERC20 bridge vault"
@@ -951,8 +976,7 @@ let () =
                     Currency.Amount.to_uint64 withdrawal_params.amount
                   in
                   let expected_vault =
-                    UInt64.add (UInt64.sub cap deposit_amount)
-                      withdrawal_amount
+                    UInt64.add (UInt64.sub cap deposit_amount) withdrawal_amount
                   in
                   let expected_recipient =
                     UInt64.sub deposit_amount withdrawal_amount
@@ -970,11 +994,13 @@ let () =
                     failwithf
                       "Unexpected live ERC20[%d] balances: vault=%s \
                        recipient=%s"
-                      index (UInt64.to_string vault_balance)
-                      (UInt64.to_string recipient_balance) () ) ;
+                      index
+                      (UInt64.to_string vault_balance)
+                      (UInt64.to_string recipient_balance)
+                      () ) ;
               print_endline
                 "Live SDK deployed two standard tokens, finalized both ERC20 \
-                 deposits, and submitted both ERC20 withdrawals" )
+                 deposits, and submitted both ERC20 withdrawals"
         in
         let outer_action_state_before_registration =
           run (fun () ->
@@ -984,6 +1010,8 @@ let () =
               >>| Or_error.ok_exn )
         in
         write_genesis_ledger () ;
+        run fund_ethereum_token_operator ;
+        require_live_sdk_fee_payer () ;
         if bridge_live_sdk then start_live_sdk () ;
         ( match bridge_asset with
         | Ethereum_token ->
@@ -1002,14 +1030,13 @@ let () =
         print_endline "(* Append synthetic Ethereum deposit actions *)" ;
         run (fun () ->
             let%bind () =
-              Deferred.List.iter (deposit_auxes ())
-                ~f:(fun aux -> submit_ethereum_deposit aux >>| ignore)
+              Deferred.List.iter (deposit_auxes ()) ~f:(fun aux ->
+                  submit_ethereum_deposit aux >>| ignore )
             in
             let%map _created =
               Gql_client.For_tests.create_new_block ~logger gql_uri
             in
             () ) ;
-        run fund_ethereum_token_operator ;
         let outer_action_state_after =
           run (fun () ->
               Gql_client.fetch_action_state gql_uri
@@ -1018,24 +1045,23 @@ let () =
               >>| Or_error.ok_exn )
         in
         write_scenario_manifest ~outer_action_state_before_registration
-          ~outer_action_state_before
-          ~outer_action_state_after ;
+          ~outer_action_state_before ~outer_action_state_after ;
         run (fun () -> commit_and_check "Commit synchronized deposit") ;
         print_endline
           "(* Synchronize the accepting commit into the inner account *)" ;
         run synchronize_accepting_commit ;
         ( if bridge_live_sdk then run_live_sdk ()
-          else
-            match bridge_asset with
-            | Native ->
-                print_endline "(* Finalize deposit on L2 *)" ;
-                run (fun () -> finalize_deposit () >>| ignore) ;
-                print_endline "(* Submit native withdrawal on L2 *)" ;
-                run (fun () -> submit_withdrawal () >>| ignore)
-            | Ethereum_token ->
-                failwith
-                  "BRIDGE_ASSET=erc20 requires \
-                   ZEKO_ETHEREUM_BRIDGE_LIVE_SDK=true" ) ;
+        else
+          match bridge_asset with
+          | Native ->
+              print_endline "(* Finalize deposit on L2 *)" ;
+              run (fun () -> finalize_deposit () >>| ignore) ;
+              print_endline "(* Submit native withdrawal on L2 *)" ;
+              run (fun () -> submit_withdrawal () >>| ignore)
+          | Ethereum_token ->
+              failwith
+                "BRIDGE_ASSET=erc20 requires ZEKO_ETHEREUM_BRIDGE_LIVE_SDK=true"
+        ) ;
         run (fun () -> commit_and_check "Commit inner withdrawal action") ;
         let[@warning "-26"] sequencer = free_sequencer sequencer in
         run (fun () ->

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -497,7 +497,11 @@ let () =
                 { fee = Currency.Fee.of_mina_string_exn "0.1"
                 ; sender = (source, nonce)
                 ; receiver = Public_key.compress recipient.public_key
-                ; amount = Currency.Amount.of_mina_int_exn 100
+                (* Generated test accounts hold exactly 100 MINA. Keep enough
+                   headroom for this transfer's fee and the source account's
+                   later use while giving the browser operator ample funds for
+                   token deployment and account creation. *)
+                ; amount = Currency.Amount.of_mina_int_exn 50
                 ; actions = None
                 }
               in

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -520,6 +520,7 @@ let () =
             { Archive.Ethereum_withdrawal.recipient =
                 withdrawal_params.recipient
             ; amount = withdrawal_params.amount
+            ; asset = None
             } ;
           let nonce =
             Sequencer.infer_nonce !sequencer

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -933,7 +933,7 @@ let () =
           Out_channel.write_all operations_ready_path ~data:"ready\n" ;
           run (fun () ->
               wait_for_file ~timeout:(Time.Span.of_min 45.) complete_path ) ;
-          let validate_helper_account helper_owner =
+          let validate_helper_account ~expected_next_deposit helper_owner =
             let helper_account =
               Sequencer.get_account !sequencer
                 (Public_key.compress recipient.public_key)
@@ -953,15 +953,16 @@ let () =
               in
               UInt32.of_string (Field.to_string next_deposit)
             in
-            if not (UInt32.equal next_deposit UInt32.one) then
+            if not (UInt32.equal next_deposit expected_next_deposit) then
               failwithf
-                "Live SDK finalized an unexpected next deposit index: %s"
+                "Live SDK finalized deposit index %s, expected %s"
                 (UInt32.to_string next_deposit)
+                (UInt32.to_string expected_next_deposit)
                 ()
           in
           match bridge_asset with
           | Native -> (
-              validate_helper_account
+              validate_helper_account ~expected_next_deposit:UInt32.one
                 (Account_id.of_public_key
                    (Public_key.decompress_exn
                       Zeko_circuits_config.Inputs.holder_account_l2 ) ) ;
@@ -993,7 +994,9 @@ let () =
                       Zeko_circuits_config.Inputs.Ethereum_assets
                       .vault_public_key token_id
                   in
-                  validate_helper_account helper_owner ;
+                  validate_helper_account
+                    ~expected_next_deposit:(UInt32.of_int (index + 1))
+                    helper_owner ;
                   let vault =
                     Sequencer.get_account !sequencer
                       Zeko_circuits_config.Inputs.Ethereum_assets

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -132,6 +132,7 @@ let () =
       (Sequencer_spec.gen ~logger ~number_of_transactions:0 ~postgres_uri
          ~gql_uri ~da_config:da_config_with3 ~da_keys ~da_quorum ~mq_host
          ~slot_acceptance:(Time.Span.of_min 10.)
+         ~include_bridge_fee_recipient:true
          ~commit_validity_period:
            (Global_slot_span.of_int bridge_commit_validity_period)
          () )

--- a/src/app/zeko/sequencer/tests/test_spec.ml
+++ b/src/app/zeko/sequencer/tests/test_spec.ml
@@ -437,7 +437,9 @@ module Sequencer_spec = struct
           (Keypair.create (), Int64.of_float (1000. *. 1e8)) )
     in
 
-    let `Inner inner_account, `Holder holder_account =
+    let ( `Inner inner_account
+        , `Holder holder_account
+        , `Ethereum_asset_registry registry_account ) =
       run Deploy.Z.Inner.initial_accounts
     in
     (* Pre-fund the sequencer's signer on L2 so the bridge prover's
@@ -463,13 +465,17 @@ module Sequencer_spec = struct
         [ (aid, Account.create aid Currency.Balance.zero) ]
       else []
     in
+    let registry_accounts =
+      Option.to_list registry_account
+      |> List.map ~f:(fun account -> (Account.identifier account, account))
+    in
     let genesis_accounts =
       ( Account_id.create inner_account.public_key inner_account.token_id
       , inner_account )
       :: ( Account_id.create holder_account.public_key holder_account.token_id
          , holder_account )
       :: signer_l2_account
-      :: ( bridge_fee_recipient_l2_accounts
+      :: ( registry_accounts @ bridge_fee_recipient_l2_accounts
          @ ( Array.concat [ init_ledger; funded_accounts ]
            |> Array.map ~f:(fun (keypair, balance) ->
                   let pk =

--- a/src/app/zeko/sequencer/tests/test_spec.ml
+++ b/src/app/zeko/sequencer/tests/test_spec.ml
@@ -450,12 +450,22 @@ module Sequencer_spec = struct
           (Currency.Balance.of_uint64
              (Unsigned.UInt64.of_int64 (Int64.of_float (1000. *. 1e8))) ) )
     in
+    (* Match the production genesis assembled by [Deploy.generate]. The bridge
+       circuits always emit their fee-recipient leaf, including when an ERC20
+       withdrawal's MINA-denominated proof fee is zero, so this protocol-owned
+       account must already exist. *)
+    let bridge_fee_recipient_l2_account =
+      let public_key = Zeko_circuits_config.Inputs.bridge_fee_recipient_l2 in
+      let aid = Account_id.create public_key Token_id.default in
+      (aid, Account.create aid Currency.Balance.zero)
+    in
     let genesis_accounts =
       ( Account_id.create inner_account.public_key inner_account.token_id
       , inner_account )
       :: ( Account_id.create holder_account.public_key holder_account.token_id
          , holder_account )
       :: signer_l2_account
+      :: bridge_fee_recipient_l2_account
       :: ( Array.concat [ init_ledger; funded_accounts ]
          |> Array.map ~f:(fun (keypair, balance) ->
                 let pk = Signature_lib.Public_key.compress keypair.public_key in

--- a/src/app/zeko/sequencer/tests/test_spec.ml
+++ b/src/app/zeko/sequencer/tests/test_spec.ml
@@ -583,6 +583,38 @@ module Sequencer_spec = struct
             ~commit_fee:(Currency.Fee.of_mina_int_exn 1)
             ~bridge_txn_fee:(Currency.Fee.of_mina_string_exn "0.1") )
     in
+    let deployed_outer_vk_hash =
+      run (fun () ->
+          let%map account =
+            Gql_client.fetch_account ~logger gql_uri
+              (Account_id.create
+                 (Public_key.compress outer_kp.public_key)
+                 Token_id.default )
+            >>| Or_error.ok_exn
+          in
+          let account =
+            Option.value_exn account
+              ~message:"deployed outer account is missing"
+          in
+          let zkapp =
+            Account.zkapp account
+            |> Option.value_exn ~message:"deployed outer account is not a zkApp"
+          in
+          Option.value_exn zkapp.verification_key
+            ~message:"deployed outer account is missing its verification key"
+          |> With_hash.hash )
+    in
+    let prover_outer_vk_hash =
+      sequencer.bridge_prover.verification_keys.outer_rules
+    in
+    if
+      Option.is_some Is_compile_simple_real.is_compile_simple_real
+      && not (Field.equal deployed_outer_vk_hash prover_outer_vk_hash)
+    then
+      failwithf "outer VK mismatch: deployed %s, real prover %s"
+        (Field.to_string deployed_outer_vk_hash)
+        (Field.to_string prover_outer_vk_hash)
+        () ;
     let l1_executor =
       Executor.create ~kind:(`L1 gql_uri)
         ~signature_kind:Zeko_circuits_config.Inputs.chain_l1 ~signer ()

--- a/src/app/zeko/sequencer/tests/test_spec.ml
+++ b/src/app/zeko/sequencer/tests/test_spec.ml
@@ -391,8 +391,8 @@ module Sequencer_spec = struct
 
   let gen ?(delay_deposit = 0) ?(number_of_transactions = 5) ?db_dir
       ?checkpoints_dir ?(commit_validity_period = Global_slot_span.of_int 10)
-      ~logger ~postgres_uri ~gql_uri ~da_config ~da_keys ~da_quorum ~mq_host
-      ~slot_acceptance () =
+      ?(include_bridge_fee_recipient = false) ~logger ~postgres_uri ~gql_uri
+      ~da_config ~da_keys ~da_quorum ~mq_host ~slot_acceptance () =
     let _reset =
       run @@ fun () -> Gql_client.For_tests.reset_state ~logger gql_uri
     in
@@ -450,14 +450,18 @@ module Sequencer_spec = struct
           (Currency.Balance.of_uint64
              (Unsigned.UInt64.of_int64 (Int64.of_float (1000. *. 1e8))) ) )
     in
-    (* Match the production genesis assembled by [Deploy.generate]. The bridge
-       circuits always emit their fee-recipient leaf, including when an ERC20
-       withdrawal's MINA-denominated proof fee is zero, so this protocol-owned
-       account must already exist. *)
-    let bridge_fee_recipient_l2_account =
-      let public_key = Zeko_circuits_config.Inputs.bridge_fee_recipient_l2 in
-      let aid = Account_id.create public_key Token_id.default in
-      (aid, Account.create aid Currency.Balance.zero)
+    (* The bridge export harness mirrors the production genesis assembled by
+       [Deploy.generate]. Bridge circuits always emit their fee-recipient leaf,
+       including when an ERC20 withdrawal's MINA-denominated proof fee is zero,
+       so this protocol-owned account must already exist there. Keep the
+       generic randomized test genesis unchanged because its checked
+       [Initialize_state] fixture is bound to that historical account set. *)
+    let bridge_fee_recipient_l2_accounts =
+      if include_bridge_fee_recipient then
+        let public_key = Zeko_circuits_config.Inputs.bridge_fee_recipient_l2 in
+        let aid = Account_id.create public_key Token_id.default in
+        [ (aid, Account.create aid Currency.Balance.zero) ]
+      else []
     in
     let genesis_accounts =
       ( Account_id.create inner_account.public_key inner_account.token_id
@@ -465,17 +469,20 @@ module Sequencer_spec = struct
       :: ( Account_id.create holder_account.public_key holder_account.token_id
          , holder_account )
       :: signer_l2_account
-      :: bridge_fee_recipient_l2_account
-      :: ( Array.concat [ init_ledger; funded_accounts ]
-         |> Array.map ~f:(fun (keypair, balance) ->
-                let pk = Signature_lib.Public_key.compress keypair.public_key in
-                let account_id = Account_id.create pk Token_id.default in
-                let balance = Unsigned.UInt64.of_int64 balance in
-                let account =
-                  Account.create account_id (Currency.Balance.of_uint64 balance)
-                in
-                (account_id, account) )
-         |> Array.to_list )
+      :: ( bridge_fee_recipient_l2_accounts
+         @ ( Array.concat [ init_ledger; funded_accounts ]
+           |> Array.map ~f:(fun (keypair, balance) ->
+                  let pk =
+                    Signature_lib.Public_key.compress keypair.public_key
+                  in
+                  let account_id = Account_id.create pk Token_id.default in
+                  let balance = Unsigned.UInt64.of_int64 balance in
+                  let account =
+                    Account.create account_id
+                      (Currency.Balance.of_uint64 balance)
+                  in
+                  (account_id, account) )
+           |> Array.to_list ) )
     in
 
     print_endline "(* Init ephemeral ledger *)" ;

--- a/src/app/zeko/sequencer/tests/testing_ledger/gql.ml
+++ b/src/app/zeko/sequencer/tests/testing_ledger/gql.ml
@@ -2043,13 +2043,15 @@ module Queries = struct
           Archive.get_actions t.archive
             (Account_id.create public_key token_id)
             ~from:from_action_state ~to_:end_action_state
-          |> Result.map ~f:
-               (List.filter ~f:(fun (action : Archive.Account_update_actions.t) ->
-                    Option.for_all action.block_info ~f:(fun block_info ->
-                        Option.for_all from_block ~f:(fun from_block ->
-                            block_info.height >= from_block )
-                        && Option.for_all to_block ~f:(fun to_block ->
-                               block_info.height < to_block ) ) ) )
+          |> Result.map
+               ~f:
+                 (List.filter
+                    ~f:(fun (action : Archive.Account_update_actions.t) ->
+                      Option.for_all action.block_info ~f:(fun block_info ->
+                          Option.for_all from_block ~f:(fun from_block ->
+                              block_info.height >= from_block )
+                          && Option.for_all to_block ~f:(fun to_block ->
+                                 block_info.height < to_block ) ) ) )
           |> return )
 
     let events =

--- a/src/app/zeko/sequencer/tests/testing_ledger/gql.ml
+++ b/src/app/zeko/sequencer/tests/testing_ledger/gql.ml
@@ -1337,15 +1337,36 @@ module Types = struct
       module EventFilterOptionsInput = struct
         module Field = Snark_params.Tick.Field
 
-        type input = { address : Account.key; token_id : Token_id.t option }
+        type chain_status = Canonical | Pending | Orphaned
+
+        let chain_status =
+          enum "ArchiveChainStatus"
+            ~values:
+              [ enum_value "CANONICAL" ~value:Canonical
+              ; enum_value "PENDING" ~value:Pending
+              ; enum_value "ORPHANED" ~value:Orphaned
+              ]
+
+        type input =
+          { address : Account.key
+          ; token_id : Token_id.t option
+          ; from_block : int option
+          ; to_block : int option
+          ; status : chain_status option
+          }
 
         let arg_typ =
           obj "EventFilterOptionsInput"
-            ~coerce:(fun address token_id -> (address, token_id))
-            ~split:(fun f (x : input) -> f x.address x.token_id)
+            ~coerce:(fun address token_id from_block to_block status ->
+              (address, token_id, from_block, to_block, status) )
+            ~split:(fun f (x : input) ->
+              f x.address x.token_id x.from_block x.to_block x.status )
             ~fields:
               [ arg "address" ~typ:(non_null PublicKey.arg_typ)
               ; arg "tokenId" ~typ:TokenId.arg_typ
+              ; arg "from" ~typ:int
+              ; arg "to" ~typ:int
+              ; arg "status" ~typ:chain_status
               ]
       end
     end
@@ -2016,13 +2037,20 @@ module Queries = struct
                       , token_id
                       , from_action_state
                       , end_action_state
-                      , _from_block
-                      , _to_block ) ->
+                      , from_block
+                      , to_block ) ->
           let token_id = Option.value ~default:Token_id.default token_id in
-          return
-          @@ Archive.get_actions t.archive
-               (Account_id.create public_key token_id)
-               ~from:from_action_state ~to_:end_action_state )
+          Archive.get_actions t.archive
+            (Account_id.create public_key token_id)
+            ~from:from_action_state ~to_:end_action_state
+          |> Result.map ~f:
+               (List.filter ~f:(fun (action : Archive.Account_update_actions.t) ->
+                    Option.for_all action.block_info ~f:(fun block_info ->
+                        Option.for_all from_block ~f:(fun from_block ->
+                            block_info.height >= from_block )
+                        && Option.for_all to_block ~f:(fun to_block ->
+                               block_info.height < to_block ) ) ) )
+          |> return )
 
     let events =
       field "events"
@@ -2033,10 +2061,16 @@ module Queries = struct
                 ~typ:
                   (non_null Types.Input.Archive.EventFilterOptionsInput.arg_typ)
             ]
-        ~resolve:(fun { ctx = t; _ } () (public_key, token_id) ->
+        ~resolve:(fun { ctx = t; _ } ()
+                      (public_key, token_id, from_block, to_block, _status) ->
           let token_id = Option.value ~default:Token_id.default token_id in
           Archive.get_events t.archive (Account_id.create public_key token_id)
-          )
+          |> List.filter ~f:(fun event ->
+                 Option.for_all event.block_info ~f:(fun block_info ->
+                     Option.for_all from_block ~f:(fun from_block ->
+                         block_info.height >= from_block )
+                     && Option.for_all to_block ~f:(fun to_block ->
+                            block_info.height < to_block ) ) ) )
 
     let commands = [ actions; events ]
   end

--- a/src/app/zeko/tests/asset_registry_vectors.ml
+++ b/src/app/zeko/tests/asset_registry_vectors.ml
@@ -1,0 +1,515 @@
+open Core
+open Mina_base
+open Snark_params.Tick
+open Zeko_circuits
+open Zeko_util
+module PC = Signature_lib.Public_key.Compressed
+module AR = Asset_registry
+
+let point_of_string value =
+  Inner_curve.(to_affine_exn @@ point_near_x @@ Field.of_string value)
+  |> Signature_lib.Public_key.compress
+
+let registry_public_key = point_of_string "91001"
+
+let vault_public_key = point_of_string "91002"
+
+let approved_mft_standard_vk_id = Field.of_int 91003
+
+module Registry =
+  AR.Make
+    (struct
+      let registry_public_key = registry_public_key
+
+      let schema_version =
+        Checked32.of_int Zeko_constants.Ethereum_asset_registry.schema_version
+
+      let approved_mft_standard_vk_id = approved_mft_standard_vk_id
+
+      let universal_bridge_vk_id = Field.of_int 91004
+
+      let vault_public_key = vault_public_key
+
+      let chain_l2 = Mina_signature_kind.Testnet
+    end)
+    ()
+
+let register = Lazy.force Registry.register
+
+let amount value =
+  Unsigned.UInt64.of_int value |> Currency.Amount.of_uint64
+
+let record index =
+  let token_owner_l2 = point_of_string (Int.to_string (92000 + index)) in
+  let owner = Account_id.create token_owner_l2 AR.Token_id.default in
+  ({ schema_version =
+       Checked32.of_int Zeko_constants.Ethereum_asset_registry.schema_version
+   ; registry_index = Checked32.of_int index
+   ; asset_id_high = Field.of_int (1000 + index)
+   ; asset_id_low = Field.of_int (2000 + index)
+   ; ethereum_token_address = Field.of_int (3000 + index)
+   ; token_owner_l2
+   ; token_id_l2 = Account_id.derive_token_id ~owner
+   ; decimals = Checked32.of_int (6 + (index mod 4))
+   ; inventory_cap = amount (1_000_000 + index)
+   ; mft_standard_vk_id = approved_mft_standard_vk_id
+   ; vault_public_key
+   ; universal_bridge_vk_id = Field.of_int 91004
+   } :
+    AR.Asset_record.t )
+
+let state tree =
+  ({ root = AR.Merkle_list.root tree
+   ; leaf_count = Checked32.of_int (AR.Merkle_list.count tree)
+   ; schema_version =
+       Checked32.of_int Zeko_constants.Ethereum_asset_registry.schema_version
+   } :
+    AR.Registry_state.t )
+
+let expect_failure label f =
+  if not (Exn.does_raise f) then failwithf "%s unexpectedly succeeded" label ()
+
+let run_membership witness =
+  run_and_check_exn
+    (let* witness =
+       exists Registry.Membership_witness.typ ~compute:(fun _ -> witness)
+     in
+     let*| verified = Registry.verify witness in
+     As_prover.read
+       Typ.(AR.Token_id.typ * Account_update.Body.typ ())
+       ( Registry.Verified_asset.token_id verified
+       , Registry.Verified_asset.authenticated_registry_call verified ))
+
+let check_membership () =
+  let tree0 = AR.Merkle_list.empty () in
+  let first = record 0 in
+  let tree1 = AR.Merkle_list.append_exn tree0 first in
+  let witness : Registry.Membership_witness.t =
+    { state = state tree1; record = first; path = AR.Merkle_list.path tree1 ~index:0 }
+  in
+  let token_id, registry_call = run_membership witness in
+  if not (AR.Token_id.equal token_id first.token_id_l2) then
+    failwith "verified membership returned the wrong token ID" ;
+  if not (PC.equal registry_call.public_key registry_public_key) then
+    failwith "registry state was not authenticated against the configured zkApp" ;
+  let checked_state =
+    Zkapp_state.V.to_list registry_call.preconditions.account.state
+    |> List.filter_map ~f:Zkapp_basic.Or_ignore.to_option
+  in
+  if
+    not
+      ([%equal: Field.t list]
+         checked_state
+         [ (state tree1).root
+         ; Checked32.to_field (state tree1).leaf_count
+         ; Checked32.to_field (state tree1).schema_version
+         ] )
+  then failwith "registry account precondition did not bind root/count/version" ;
+  let bad_path =
+    match witness.path with
+    | sibling :: rest ->
+        Field.(sibling + one) :: rest
+    | [] ->
+        assert false
+  in
+  expect_failure "wrong Merkle path" (fun () ->
+      ignore
+        (run_membership
+           { witness with path = bad_path }
+          : AR.Token_id.t * Account_update.Body.t ) ) ;
+  expect_failure "modified immutable record" (fun () ->
+      ignore
+        (run_membership
+           { witness with
+             record =
+               { first with inventory_cap = amount 2_000_000 }
+           }
+          : AR.Token_id.t * Account_update.Body.t ) ) ;
+  expect_failure "record beyond committed count" (fun () ->
+      ignore
+        (run_membership
+           { witness with
+             state = { witness.state with leaf_count = Checked32.zero }
+           }
+          : AR.Token_id.t * Account_update.Body.t ) ) ;
+  expect_failure "unsupported schema version" (fun () ->
+      ignore
+        (run_membership
+           { witness with
+             state =
+               { witness.state with schema_version = Checked32.of_int 2 }
+           }
+          : AR.Token_id.t * Account_update.Body.t ) ) ;
+  expect_failure "unsupported decimals" (fun () ->
+      ignore
+        (run_membership
+           { witness with
+             record = { first with decimals = Checked32.of_int 10 }
+           }
+          : AR.Token_id.t * Account_update.Body.t ) )
+
+let check_append_only_paths () =
+  let tree0 = AR.Merkle_list.empty () in
+  if not (Field.equal (AR.Merkle_list.root tree0) AR.Merkle_list.empty_root) then
+    failwith "empty registry root is unstable" ;
+  let first = record 0 in
+  let tree1 = AR.Merkle_list.append_exn tree0 first in
+  let first_path_at_one = AR.Merkle_list.path tree1 ~index:0 in
+  if
+    not
+      (AR.Merkle_list.verify ~root:(AR.Merkle_list.root tree1) first
+         first_path_at_one )
+  then failwith "first record is not a member after append" ;
+  let second = record 1 in
+  let tree2 = AR.Merkle_list.append_exn tree1 second in
+  if
+    AR.Merkle_list.verify ~root:(AR.Merkle_list.root tree2) first
+      first_path_at_one
+  then failwith "stale membership path unexpectedly verified after append" ;
+  let refreshed = AR.Merkle_list.path tree2 ~index:0 in
+  if
+    not
+      (AR.Merkle_list.verify ~root:(AR.Merkle_list.root tree2) first refreshed)
+  then failwith "historical record did not survive append with a refreshed path" ;
+  if
+    not
+      (AR.Merkle_list.verify ~root:(AR.Merkle_list.root tree2) second
+         (AR.Merkle_list.path tree2 ~index:1) )
+  then failwith "second record is not a member after append"
+
+let run_scan_step elem stmt =
+  run_and_check_exn
+    (let* elem =
+       exists Registry.Scan.Definition.Elem.typ ~compute:(fun _ -> elem)
+     in
+     let* stmt =
+       exists Registry.Scan.Definition.Stmt.typ ~compute:(fun _ -> stmt)
+     in
+     let*| target = Registry.Scan.Definition.step elem stmt in
+     As_prover.read Registry.Scan.Definition.Stmt.typ target)
+
+let scan_stmt tree candidate =
+  ({ old_root = AR.Merkle_list.root tree
+   ; leaf_count = Checked32.of_int (AR.Merkle_list.count tree)
+   ; candidate
+   ; next_expected_index = Checked32.zero
+   ; traversed_count = Checked32.zero
+   } :
+    Registry.Scan.Definition.Stmt.t )
+
+let scan_elem tree (existing : AR.Asset_record.t) =
+  ({ active = true
+   ; record = existing
+   ; path =
+       AR.Merkle_list.path tree
+         ~index:(Checked32.to_int existing.registry_index)
+   } :
+    Registry.Scan.Definition.Elem.t )
+
+let check_exhaustive_scan_step () =
+  let first = record 0 in
+  let tree = AR.Merkle_list.append_exn (AR.Merkle_list.empty ()) first in
+  let candidate = record 1 in
+  let stmt = scan_stmt tree candidate in
+  let target = run_scan_step (scan_elem tree first) stmt in
+  if
+    not
+      (Checked32.equal target.next_expected_index Checked32.one
+      && Checked32.equal target.traversed_count Checked32.one )
+  then failwith "scan did not advance index and count exactly once" ;
+  let repeated_index =
+    { stmt with
+      next_expected_index = Checked32.one
+    ; traversed_count = Checked32.one
+    }
+  in
+  expect_failure "repeated or reordered scan leaf" (fun () ->
+      ignore
+        (run_scan_step (scan_elem tree first) repeated_index
+          : Registry.Scan.Definition.Stmt.t ) ) ;
+  expect_failure "wrong scan root" (fun () ->
+      ignore
+        (run_scan_step (scan_elem tree first)
+           { stmt with old_root = Field.(stmt.old_root + one) }
+          : Registry.Scan.Definition.Stmt.t ) ) ;
+  expect_failure "duplicate Ethereum token address" (fun () ->
+      ignore
+        (run_scan_step (scan_elem tree first)
+           { stmt with
+             candidate =
+               { candidate with
+                 ethereum_token_address = first.ethereum_token_address
+               }
+           }
+          : Registry.Scan.Definition.Stmt.t ) ) ;
+  expect_failure "duplicate canonical asset ID" (fun () ->
+      ignore
+        (run_scan_step (scan_elem tree first)
+           { stmt with
+             candidate =
+               { candidate with
+                 asset_id_high = first.asset_id_high
+               ; asset_id_low = first.asset_id_low
+               }
+           }
+          : Registry.Scan.Definition.Stmt.t ) ) ;
+  expect_failure "duplicate L2 token owner" (fun () ->
+      ignore
+        (run_scan_step (scan_elem tree first)
+           { stmt with
+             candidate =
+               { candidate with
+                 token_owner_l2 = first.token_owner_l2
+               }
+           }
+          : Registry.Scan.Definition.Stmt.t ) ) ;
+  expect_failure "duplicate L2 token ID" (fun () ->
+      ignore
+        (run_scan_step (scan_elem tree first)
+           { stmt with
+             candidate =
+               { candidate with token_id_l2 = first.token_id_l2 }
+           }
+          : Registry.Scan.Definition.Stmt.t ) )
+
+type scan_proof =
+  { transition : Registry.Scan.trans; proof : Compile_simple.Proof.t }
+
+let scan_stmt_at (old_state : AR.Registry_state.t) candidate traversed =
+  ({ old_root = old_state.root
+   ; leaf_count = old_state.leaf_count
+   ; candidate
+   ; next_expected_index = Checked32.of_int traversed
+   ; traversed_count = Checked32.of_int traversed
+   } :
+    Registry.Scan.Definition.Stmt.t )
+
+let merge_scan_proofs proofs =
+  let rec merge_level = function
+    | [] ->
+        failwith "cannot merge an empty scan-proof list"
+    | [ proof ] ->
+        proof
+    | proofs ->
+        let rec pairs acc = function
+          | left :: right :: rest ->
+              let transition, proof =
+                Promise.block_on_async_exn
+                @@ fun () ->
+                (Lazy.force Registry.Scan.merge)
+                  { left = left.transition
+                  ; left_proof = left.proof
+                  ; right = right.transition
+                  ; right_proof = right.proof
+                  }
+              in
+              pairs ({ transition; proof } :: acc) rest
+          | [ last ] ->
+              List.rev (last :: acc)
+          | [] ->
+              List.rev acc
+        in
+        merge_level (pairs [] proofs)
+  in
+  merge_level proofs
+
+let prove_scan old_state candidate elems =
+  match elems with
+  | [] ->
+      let source = scan_stmt_at old_state candidate 0 in
+      let transition, proof =
+        Promise.block_on_async_exn
+        @@ fun () -> (Lazy.force Registry.Scan.leaf_option) ([], source)
+      in
+      { transition; proof }
+  | elems ->
+      List.chunks_of elems ~length:8
+      |> List.fold_map ~init:0 ~f:(fun traversed chunk ->
+             let source = scan_stmt_at old_state candidate traversed in
+             let transition, proof =
+               Promise.block_on_async_exn
+               @@ fun () -> (Lazy.force Registry.Scan.leaf) (chunk, source)
+             in
+             ( traversed + List.length chunk
+             , ({ transition; proof } : scan_proof) ) )
+      |> snd |> merge_scan_proofs
+
+let make_scan ?old_state ?records tree candidate =
+  let old_state = Option.value old_state ~default:(state tree) in
+  let init : Registry.Scan.Definition.Init.t =
+    { old_state; candidate }
+  in
+  let records =
+    Option.value records
+      ~default:
+        (List.init (AR.Merkle_list.count tree) ~f:(fun index -> record index))
+  in
+  let elems = List.map records ~f:(scan_elem tree) in
+  let { transition = { source = proof_source; target = proof_target }; proof } =
+    prove_scan old_state candidate elems
+  in
+  Registry.Scan_inst.make ~proof_source ~proof_target ~proof init []
+
+let register_record ?old_state ?records ?append_path tree candidate =
+  let append_path =
+    match append_path with
+    | Some path ->
+        path
+    | None ->
+        AR.Merkle_list.path tree ~index:(AR.Merkle_list.count tree)
+  in
+  let witness : Registry.Register.Witness.t =
+    { scan = make_scan ?old_state ?records tree candidate
+    ; append_path
+    ; registry_vk_hash = Field.of_int 91005
+    }
+  in
+  Promise.block_on_async_exn @@ fun () -> register witness
+
+let check_registration_transition () =
+  let empty = AR.Merkle_list.empty () in
+  let first = record 0 in
+  let (_statement, (body, _digest, _calls)), _proof =
+    register_record empty first
+  in
+  let expected_tree = AR.Merkle_list.append_exn empty first in
+  let updated_state =
+    Zkapp_state.V.to_list body.update.app_state
+    |> List.filter_map ~f:Zkapp_basic.Set_or_keep.to_option
+  in
+  if
+    not
+      ([%equal: Field.t list]
+         updated_state
+         [ AR.Merkle_list.root expected_tree
+         ; Checked32.to_field Checked32.one
+         ; Checked32.to_field
+             (Checked32.of_int
+                Zeko_constants.Ethereum_asset_registry.schema_version )
+         ] )
+  then failwith "registration did not expose the expected new root/count" ;
+  let tree1 = expected_tree in
+  let (_statement, (_body, _digest, _calls)), _proof =
+    register_record tree1 (record 1)
+  in
+  let tree2 = AR.Merkle_list.append_exn tree1 (record 1) in
+  expect_failure "too few traversal witnesses" (fun () ->
+      ignore
+        (register_record ~records:[ first ] tree2 (record 2)
+          : AR.Output.t * Compile_simple.Proof.t ) ) ;
+  expect_failure "too many traversal witnesses" (fun () ->
+      ignore
+        (register_record ~records:[ first; record 1 ] tree1 (record 1)
+          : AR.Output.t * Compile_simple.Proof.t ) ) ;
+  expect_failure "repeated traversal leaf" (fun () ->
+      ignore
+        (register_record ~records:[ first; first ] tree2 (record 2)
+          : AR.Output.t * Compile_simple.Proof.t ) ) ;
+  expect_failure "skipped traversal index" (fun () ->
+      ignore
+        (register_record ~records:[ record 1 ] tree2 (record 2)
+          : AR.Output.t * Compile_simple.Proof.t ) ) ;
+  expect_failure "reordered traversal indices" (fun () ->
+      ignore
+        (register_record ~records:[ record 1; first ] tree2 (record 2)
+          : AR.Output.t * Compile_simple.Proof.t ) ) ;
+  expect_failure "forged committed leaf count" (fun () ->
+      let forged_state =
+        { (state tree1) with leaf_count = Checked32.of_int 2 }
+      in
+      ignore
+        (register_record ~old_state:forged_state tree1 (record 1)
+          : AR.Output.t * Compile_simple.Proof.t ) ) ;
+  expect_failure "wrong old root" (fun () ->
+      let wrong_state =
+        { (state tree1) with root = Field.((state tree1).root + one) }
+      in
+      ignore
+        (register_record ~old_state:wrong_state tree1 (record 1)
+          : AR.Output.t * Compile_simple.Proof.t ) ) ;
+  expect_failure "non-member traversal record" (fun () ->
+      let modified =
+        { first with inventory_cap = amount 5_000_000 }
+      in
+      ignore
+        (register_record ~records:[ modified ] tree1 (record 1)
+          : AR.Output.t * Compile_simple.Proof.t ) ) ;
+  expect_failure "non-empty append slot" (fun () ->
+      let occupied_as_empty : AR.Registry_state.t =
+        { root = AR.Merkle_list.root tree1
+        ; leaf_count = Checked32.zero
+        ; schema_version =
+            Checked32.of_int
+              Zeko_constants.Ethereum_asset_registry.schema_version
+        }
+      in
+      ignore
+        (register_record ~old_state:occupied_as_empty ~records:[]
+           ~append_path:(AR.Merkle_list.path tree1 ~index:0)
+           tree1 first
+          : AR.Output.t * Compile_simple.Proof.t ) )
+
+let check_maximum_registration () =
+  let started_at = Time_ns.now () in
+  let tree =
+    List.init
+      (Zeko_constants.Ethereum_asset_registry.max_assets - 1)
+      ~f:Fn.id
+    |> List.fold ~init:(AR.Merkle_list.empty ()) ~f:(fun tree index ->
+           AR.Merkle_list.append_exn tree (record index) )
+  in
+  let candidate =
+    record (Zeko_constants.Ethereum_asset_registry.max_assets - 1)
+  in
+  let (_statement, (body, _digest, _calls)), _proof =
+    register_record tree candidate
+  in
+  let updated_state =
+    Zkapp_state.V.to_list body.update.app_state
+    |> List.filter_map ~f:Zkapp_basic.Set_or_keep.to_option
+  in
+  match updated_state with
+  | _root :: count :: _ ->
+      if
+        not
+          (Field.equal count
+             (Checked32.to_field
+                (Checked32.of_int
+                   Zeko_constants.Ethereum_asset_registry.max_assets ) ) )
+      then failwith "maximum-size registration did not reach the configured cap"
+      else
+        let elapsed_ms =
+          Time_ns.diff (Time_ns.now ()) started_at |> Time_ns.Span.to_ms
+        in
+        let heap_words = (Gc.quick_stat ()).top_heap_words in
+        printf
+          "asset registry maximum: assets=%d elapsed_ms=%.0f \
+           top_heap_words=%d word_bytes=%d\n%!"
+          Zeko_constants.Ethereum_asset_registry.max_assets elapsed_ms
+          heap_words (Sys.word_size / 8)
+  | _ ->
+      failwith "maximum-size registration omitted its new state"
+
+let print_membership_json () =
+  let first = record 0 in
+  let tree = AR.Merkle_list.append_exn (AR.Merkle_list.empty ()) first in
+  Registry.Membership_witness.
+    { state = state tree
+    ; record = first
+    ; path = AR.Merkle_list.path tree ~index:0
+    }
+  |> Registry.Membership_witness.to_yojson
+  |> Yojson.Safe.to_string |> printf "%s\n%!"
+
+let () =
+  check_append_only_paths () ;
+  check_membership () ;
+  check_exhaustive_scan_step () ;
+  check_registration_transition () ;
+  if
+    Array.exists (Sys.get_argv ()) ~f:(String.equal "--max")
+  then check_maximum_registration () ;
+  if
+    Array.exists (Sys.get_argv ()) ~f:(String.equal "--json")
+  then print_membership_json () ;
+  printf "asset registry vectors: ok\n%!"

--- a/src/app/zeko/tests/asset_registry_vectors.ml
+++ b/src/app/zeko/tests/asset_registry_vectors.ml
@@ -502,6 +502,12 @@ let print_membership_json () =
   |> Yojson.Safe.to_string |> printf "%s\n%!"
 
 let () =
+  ( match Registry.Scan.Definition.wrap_domain with
+  | Some `N14 ->
+      ()
+  | _ ->
+      failwith
+        "asset registry scan must use the real Pickles N14 wrap domain" ) ;
   check_append_only_paths () ;
   check_membership () ;
   check_exhaustive_scan_step () ;

--- a/src/app/zeko/tests/asset_registry_vectors.ml
+++ b/src/app/zeko/tests/asset_registry_vectors.ml
@@ -16,10 +16,19 @@ let vault_public_key = point_of_string "91002"
 
 let approved_mft_standard_vk_id = Field.of_int 91003
 
+let registration_authority = point_of_string "91006"
+
+let value_to_hash ~init (typ : ('var, 'value) Snark_params.Tick.Typ.t) value =
+  let (Typ typ) = typ in
+  let fields, _ = typ.value_to_fields value in
+  Random_oracle.hash ~init:(Hash_prefix_create.salt init) fields
+
 module Registry =
   AR.Make
     (struct
       let registry_public_key = registry_public_key
+
+      let registration_authority = registration_authority
 
       let schema_version =
         Checked32.of_int Zeko_constants.Ethereum_asset_registry.schema_version
@@ -36,35 +45,33 @@ module Registry =
 
 let register = Lazy.force Registry.register
 
-let amount value =
-  Unsigned.UInt64.of_int value |> Currency.Amount.of_uint64
+let amount value = Unsigned.UInt64.of_int value |> Currency.Amount.of_uint64
 
 let record index =
   let token_owner_l2 = point_of_string (Int.to_string (92000 + index)) in
   let owner = Account_id.create token_owner_l2 AR.Token_id.default in
-  ({ schema_version =
-       Checked32.of_int Zeko_constants.Ethereum_asset_registry.schema_version
-   ; registry_index = Checked32.of_int index
-   ; asset_id_high = Field.of_int (1000 + index)
-   ; asset_id_low = Field.of_int (2000 + index)
-   ; ethereum_token_address = Field.of_int (3000 + index)
-   ; token_owner_l2
-   ; token_id_l2 = Account_id.derive_token_id ~owner
-   ; decimals = Checked32.of_int (6 + (index mod 4))
-   ; inventory_cap = amount (1_000_000 + index)
-   ; mft_standard_vk_id = approved_mft_standard_vk_id
-   ; vault_public_key
-   ; universal_bridge_vk_id = Field.of_int 91004
-   } :
-    AR.Asset_record.t )
+  ( { schema_version =
+        Checked32.of_int Zeko_constants.Ethereum_asset_registry.schema_version
+    ; registry_index = Checked32.of_int index
+    ; asset_id_high = Field.of_int (1000 + index)
+    ; asset_id_low = Field.of_int (2000 + index)
+    ; ethereum_token_address = Field.of_int (3000 + index)
+    ; token_owner_l2
+    ; token_id_l2 = Account_id.derive_token_id ~owner
+    ; decimals = Checked32.of_int (6 + (index mod 4))
+    ; inventory_cap = amount (1_000_000 + index)
+    ; mft_standard_vk_id = approved_mft_standard_vk_id
+    ; vault_public_key
+    ; universal_bridge_vk_id = Field.of_int 91004
+    }
+    : AR.Asset_record.t )
 
-let state tree =
-  ({ root = AR.Merkle_list.root tree
-   ; leaf_count = Checked32.of_int (AR.Merkle_list.count tree)
-   ; schema_version =
-       Checked32.of_int Zeko_constants.Ethereum_asset_registry.schema_version
-   } :
-    AR.Registry_state.t )
+let state tree : AR.Registry_state.t =
+  { root = AR.Merkle_list.root tree
+  ; leaf_count = Checked32.of_int (AR.Merkle_list.count tree)
+  ; schema_version =
+      Checked32.of_int Zeko_constants.Ethereum_asset_registry.schema_version
+  }
 
 let expect_failure label f =
   if not (Exn.does_raise f) then failwithf "%s unexpectedly succeeded" label ()
@@ -78,14 +85,17 @@ let run_membership witness =
      As_prover.read
        Typ.(AR.Token_id.typ * Account_update.Body.typ ())
        ( Registry.Verified_asset.token_id verified
-       , Registry.Verified_asset.authenticated_registry_call verified ))
+       , Registry.Verified_asset.authenticated_registry_call verified ) )
 
 let check_membership () =
   let tree0 = AR.Merkle_list.empty () in
   let first = record 0 in
   let tree1 = AR.Merkle_list.append_exn tree0 first in
   let witness : Registry.Membership_witness.t =
-    { state = state tree1; record = first; path = AR.Merkle_list.path tree1 ~index:0 }
+    { state = state tree1
+    ; record = first
+    ; path = AR.Merkle_list.path tree1 ~index:0
+    }
   in
   let token_id, registry_call = run_membership witness in
   if not (AR.Token_id.equal token_id first.token_id_l2) then
@@ -98,8 +108,7 @@ let check_membership () =
   in
   if
     not
-      ([%equal: Field.t list]
-         checked_state
+      ([%equal: Field.t list] checked_state
          [ (state tree1).root
          ; Checked32.to_field (state tree1).leaf_count
          ; Checked32.to_field (state tree1).schema_version
@@ -114,57 +123,56 @@ let check_membership () =
   in
   expect_failure "wrong Merkle path" (fun () ->
       ignore
-        (run_membership
-           { witness with path = bad_path }
+        ( run_membership { witness with path = bad_path }
           : AR.Token_id.t * Account_update.Body.t ) ) ;
   expect_failure "modified immutable record" (fun () ->
       ignore
-        (run_membership
-           { witness with
-             record =
-               { first with inventory_cap = amount 2_000_000 }
-           }
+        ( run_membership
+            { witness with
+              record = { first with inventory_cap = amount 2_000_000 }
+            }
           : AR.Token_id.t * Account_update.Body.t ) ) ;
   expect_failure "record beyond committed count" (fun () ->
       ignore
-        (run_membership
-           { witness with
-             state = { witness.state with leaf_count = Checked32.zero }
-           }
+        ( run_membership
+            { witness with
+              state = { witness.state with leaf_count = Checked32.zero }
+            }
           : AR.Token_id.t * Account_update.Body.t ) ) ;
   expect_failure "unsupported schema version" (fun () ->
       ignore
-        (run_membership
-           { witness with
-             state =
-               { witness.state with schema_version = Checked32.of_int 2 }
-           }
+        ( run_membership
+            { witness with
+              state = { witness.state with schema_version = Checked32.of_int 2 }
+            }
           : AR.Token_id.t * Account_update.Body.t ) ) ;
   expect_failure "unsupported decimals" (fun () ->
       ignore
-        (run_membership
-           { witness with
-             record = { first with decimals = Checked32.of_int 10 }
-           }
+        ( run_membership
+            { witness with
+              record = { first with decimals = Checked32.of_int 10 }
+            }
           : AR.Token_id.t * Account_update.Body.t ) )
 
 let check_append_only_paths () =
   let tree0 = AR.Merkle_list.empty () in
-  if not (Field.equal (AR.Merkle_list.root tree0) AR.Merkle_list.empty_root) then
-    failwith "empty registry root is unstable" ;
+  if not (Field.equal (AR.Merkle_list.root tree0) AR.Merkle_list.empty_root)
+  then failwith "empty registry root is unstable" ;
   let first = record 0 in
   let tree1 = AR.Merkle_list.append_exn tree0 first in
   let first_path_at_one = AR.Merkle_list.path tree1 ~index:0 in
   if
     not
-      (AR.Merkle_list.verify ~root:(AR.Merkle_list.root tree1) first
-         first_path_at_one )
+      (AR.Merkle_list.verify
+         ~root:(AR.Merkle_list.root tree1)
+         first first_path_at_one )
   then failwith "first record is not a member after append" ;
   let second = record 1 in
   let tree2 = AR.Merkle_list.append_exn tree1 second in
   if
-    AR.Merkle_list.verify ~root:(AR.Merkle_list.root tree2) first
-      first_path_at_one
+    AR.Merkle_list.verify
+      ~root:(AR.Merkle_list.root tree2)
+      first first_path_at_one
   then failwith "stale membership path unexpectedly verified after append" ;
   let refreshed = AR.Merkle_list.path tree2 ~index:0 in
   if
@@ -173,7 +181,9 @@ let check_append_only_paths () =
   then failwith "historical record did not survive append with a refreshed path" ;
   if
     not
-      (AR.Merkle_list.verify ~root:(AR.Merkle_list.root tree2) second
+      (AR.Merkle_list.verify
+         ~root:(AR.Merkle_list.root tree2)
+         second
          (AR.Merkle_list.path tree2 ~index:1) )
   then failwith "second record is not a member after append"
 
@@ -186,25 +196,23 @@ let run_scan_step elem stmt =
        exists Registry.Scan.Definition.Stmt.typ ~compute:(fun _ -> stmt)
      in
      let*| target = Registry.Scan.Definition.step elem stmt in
-     As_prover.read Registry.Scan.Definition.Stmt.typ target)
+     As_prover.read Registry.Scan.Definition.Stmt.typ target )
 
-let scan_stmt tree candidate =
-  ({ old_root = AR.Merkle_list.root tree
-   ; leaf_count = Checked32.of_int (AR.Merkle_list.count tree)
-   ; candidate
-   ; next_expected_index = Checked32.zero
-   ; traversed_count = Checked32.zero
-   } :
-    Registry.Scan.Definition.Stmt.t )
+let scan_stmt tree candidate : Registry.Scan.Definition.Stmt.t =
+  { old_root = AR.Merkle_list.root tree
+  ; leaf_count = Checked32.of_int (AR.Merkle_list.count tree)
+  ; candidate
+  ; next_expected_index = Checked32.zero
+  ; traversed_count = Checked32.zero
+  }
 
-let scan_elem tree (existing : AR.Asset_record.t) =
-  ({ active = true
-   ; record = existing
-   ; path =
-       AR.Merkle_list.path tree
-         ~index:(Checked32.to_int existing.registry_index)
-   } :
-    Registry.Scan.Definition.Elem.t )
+let scan_elem tree (existing : AR.Asset_record.t) :
+    Registry.Scan.Definition.Elem.t =
+  { active = true
+  ; record = existing
+  ; path =
+      AR.Merkle_list.path tree ~index:(Checked32.to_int existing.registry_index)
+  }
 
 let check_exhaustive_scan_step () =
   let first = record 0 in
@@ -214,7 +222,7 @@ let check_exhaustive_scan_step () =
   let target = run_scan_step (scan_elem tree first) stmt in
   if
     not
-      (Checked32.equal target.next_expected_index Checked32.one
+      ( Checked32.equal target.next_expected_index Checked32.one
       && Checked32.equal target.traversed_count Checked32.one )
   then failwith "scan did not advance index and count exactly once" ;
   let repeated_index =
@@ -225,64 +233,61 @@ let check_exhaustive_scan_step () =
   in
   expect_failure "repeated or reordered scan leaf" (fun () ->
       ignore
-        (run_scan_step (scan_elem tree first) repeated_index
+        ( run_scan_step (scan_elem tree first) repeated_index
           : Registry.Scan.Definition.Stmt.t ) ) ;
   expect_failure "wrong scan root" (fun () ->
       ignore
-        (run_scan_step (scan_elem tree first)
-           { stmt with old_root = Field.(stmt.old_root + one) }
+        ( run_scan_step (scan_elem tree first)
+            { stmt with old_root = Field.(stmt.old_root + one) }
           : Registry.Scan.Definition.Stmt.t ) ) ;
   expect_failure "duplicate Ethereum token address" (fun () ->
       ignore
-        (run_scan_step (scan_elem tree first)
-           { stmt with
-             candidate =
-               { candidate with
-                 ethereum_token_address = first.ethereum_token_address
-               }
-           }
+        ( run_scan_step (scan_elem tree first)
+            { stmt with
+              candidate =
+                { candidate with
+                  ethereum_token_address = first.ethereum_token_address
+                }
+            }
           : Registry.Scan.Definition.Stmt.t ) ) ;
   expect_failure "duplicate canonical asset ID" (fun () ->
       ignore
-        (run_scan_step (scan_elem tree first)
-           { stmt with
-             candidate =
-               { candidate with
-                 asset_id_high = first.asset_id_high
-               ; asset_id_low = first.asset_id_low
-               }
-           }
+        ( run_scan_step (scan_elem tree first)
+            { stmt with
+              candidate =
+                { candidate with
+                  asset_id_high = first.asset_id_high
+                ; asset_id_low = first.asset_id_low
+                }
+            }
           : Registry.Scan.Definition.Stmt.t ) ) ;
   expect_failure "duplicate L2 token owner" (fun () ->
       ignore
-        (run_scan_step (scan_elem tree first)
-           { stmt with
-             candidate =
-               { candidate with
-                 token_owner_l2 = first.token_owner_l2
-               }
-           }
+        ( run_scan_step (scan_elem tree first)
+            { stmt with
+              candidate =
+                { candidate with token_owner_l2 = first.token_owner_l2 }
+            }
           : Registry.Scan.Definition.Stmt.t ) ) ;
   expect_failure "duplicate L2 token ID" (fun () ->
       ignore
-        (run_scan_step (scan_elem tree first)
-           { stmt with
-             candidate =
-               { candidate with token_id_l2 = first.token_id_l2 }
-           }
+        ( run_scan_step (scan_elem tree first)
+            { stmt with
+              candidate = { candidate with token_id_l2 = first.token_id_l2 }
+            }
           : Registry.Scan.Definition.Stmt.t ) )
 
 type scan_proof =
   { transition : Registry.Scan.trans; proof : Compile_simple.Proof.t }
 
-let scan_stmt_at (old_state : AR.Registry_state.t) candidate traversed =
-  ({ old_root = old_state.root
-   ; leaf_count = old_state.leaf_count
-   ; candidate
-   ; next_expected_index = Checked32.of_int traversed
-   ; traversed_count = Checked32.of_int traversed
-   } :
-    Registry.Scan.Definition.Stmt.t )
+let scan_stmt_at (old_state : AR.Registry_state.t) candidate traversed :
+    Registry.Scan.Definition.Stmt.t =
+  { old_root = old_state.root
+  ; leaf_count = old_state.leaf_count
+  ; candidate
+  ; next_expected_index = Checked32.of_int traversed
+  ; traversed_count = Checked32.of_int traversed
+  }
 
 let merge_scan_proofs proofs =
   let rec merge_level = function
@@ -336,9 +341,7 @@ let prove_scan old_state candidate elems =
 
 let make_scan ?old_state ?records tree candidate =
   let old_state = Option.value old_state ~default:(state tree) in
-  let init : Registry.Scan.Definition.Init.t =
-    { old_state; candidate }
-  in
+  let init : Registry.Scan.Definition.Init.t = { old_state; candidate } in
   let records =
     Option.value records
       ~default:
@@ -369,7 +372,7 @@ let register_record ?old_state ?records ?append_path tree candidate =
 let check_registration_transition () =
   let empty = AR.Merkle_list.empty () in
   let first = record 0 in
-  let (_statement, (body, _digest, _calls)), _proof =
+  let (_statement, (body, _digest, calls)), _proof =
     register_record empty first
   in
   let expected_tree = AR.Merkle_list.append_exn empty first in
@@ -379,8 +382,7 @@ let check_registration_transition () =
   in
   if
     not
-      ([%equal: Field.t list]
-         updated_state
+      ([%equal: Field.t list] updated_state
          [ AR.Merkle_list.root expected_tree
          ; Checked32.to_field Checked32.one
          ; Checked32.to_field
@@ -388,6 +390,29 @@ let check_registration_transition () =
                 Zeko_constants.Ethereum_asset_registry.schema_version )
          ] )
   then failwith "registration did not expose the expected new root/count" ;
+  let authority_calls = Zkapp_command.Call_forest.to_list calls in
+  let authority =
+    match authority_calls with
+    | [ authority ] ->
+        authority
+    | _ ->
+        failwith "registration must emit exactly one authority child"
+  in
+  if
+    not
+      ( PC.equal authority.body.public_key registration_authority
+      && [%equal: Account_update.Authorization_kind.t]
+           authority.body.authorization_kind Signature
+      && authority.body.use_full_commitment
+      && not authority.body.implicit_account_creation_fee )
+  then failwith "registration authority child is malformed" ;
+  let expected_call_data =
+    value_to_hash ~init:Zeko_constants.ethereum_asset_registry_registration_salt
+      Typ.(AR.Registry_state.typ * AR.Registry_state.typ * AR.Asset_record.typ)
+      ((state empty, state expected_tree), first)
+  in
+  if not (Field.equal authority.body.call_data expected_call_data) then
+    failwith "registration authority signature is not transition-bound" ;
   let tree1 = expected_tree in
   let (_statement, (_body, _digest, _calls)), _proof =
     register_record tree1 (record 1)
@@ -395,44 +420,42 @@ let check_registration_transition () =
   let tree2 = AR.Merkle_list.append_exn tree1 (record 1) in
   expect_failure "too few traversal witnesses" (fun () ->
       ignore
-        (register_record ~records:[ first ] tree2 (record 2)
+        ( register_record ~records:[ first ] tree2 (record 2)
           : AR.Output.t * Compile_simple.Proof.t ) ) ;
   expect_failure "too many traversal witnesses" (fun () ->
       ignore
-        (register_record ~records:[ first; record 1 ] tree1 (record 1)
+        ( register_record ~records:[ first; record 1 ] tree1 (record 1)
           : AR.Output.t * Compile_simple.Proof.t ) ) ;
   expect_failure "repeated traversal leaf" (fun () ->
       ignore
-        (register_record ~records:[ first; first ] tree2 (record 2)
+        ( register_record ~records:[ first; first ] tree2 (record 2)
           : AR.Output.t * Compile_simple.Proof.t ) ) ;
   expect_failure "skipped traversal index" (fun () ->
       ignore
-        (register_record ~records:[ record 1 ] tree2 (record 2)
+        ( register_record ~records:[ record 1 ] tree2 (record 2)
           : AR.Output.t * Compile_simple.Proof.t ) ) ;
   expect_failure "reordered traversal indices" (fun () ->
       ignore
-        (register_record ~records:[ record 1; first ] tree2 (record 2)
+        ( register_record ~records:[ record 1; first ] tree2 (record 2)
           : AR.Output.t * Compile_simple.Proof.t ) ) ;
   expect_failure "forged committed leaf count" (fun () ->
       let forged_state =
         { (state tree1) with leaf_count = Checked32.of_int 2 }
       in
       ignore
-        (register_record ~old_state:forged_state tree1 (record 1)
+        ( register_record ~old_state:forged_state tree1 (record 1)
           : AR.Output.t * Compile_simple.Proof.t ) ) ;
   expect_failure "wrong old root" (fun () ->
       let wrong_state =
         { (state tree1) with root = Field.((state tree1).root + one) }
       in
       ignore
-        (register_record ~old_state:wrong_state tree1 (record 1)
+        ( register_record ~old_state:wrong_state tree1 (record 1)
           : AR.Output.t * Compile_simple.Proof.t ) ) ;
   expect_failure "non-member traversal record" (fun () ->
-      let modified =
-        { first with inventory_cap = amount 5_000_000 }
-      in
+      let modified = { first with inventory_cap = amount 5_000_000 } in
       ignore
-        (register_record ~records:[ modified ] tree1 (record 1)
+        ( register_record ~records:[ modified ] tree1 (record 1)
           : AR.Output.t * Compile_simple.Proof.t ) ) ;
   expect_failure "non-empty append slot" (fun () ->
       let occupied_as_empty : AR.Registry_state.t =
@@ -444,17 +467,15 @@ let check_registration_transition () =
         }
       in
       ignore
-        (register_record ~old_state:occupied_as_empty ~records:[]
-           ~append_path:(AR.Merkle_list.path tree1 ~index:0)
-           tree1 first
+        ( register_record ~old_state:occupied_as_empty ~records:[]
+            ~append_path:(AR.Merkle_list.path tree1 ~index:0)
+            tree1 first
           : AR.Output.t * Compile_simple.Proof.t ) )
 
 let check_maximum_registration () =
   let started_at = Time_ns.now () in
   let tree =
-    List.init
-      (Zeko_constants.Ethereum_asset_registry.max_assets - 1)
-      ~f:Fn.id
+    List.init (Zeko_constants.Ethereum_asset_registry.max_assets - 1) ~f:Fn.id
     |> List.fold ~init:(AR.Merkle_list.empty ()) ~f:(fun tree index ->
            AR.Merkle_list.append_exn tree (record index) )
   in
@@ -483,8 +504,9 @@ let check_maximum_registration () =
         in
         let heap_words = (Gc.quick_stat ()).top_heap_words in
         printf
-          "asset registry maximum: assets=%d elapsed_ms=%.0f \
-           top_heap_words=%d word_bytes=%d\n%!"
+          "asset registry maximum: assets=%d elapsed_ms=%.0f top_heap_words=%d \
+           word_bytes=%d\n\
+           %!"
           Zeko_constants.Ethereum_asset_registry.max_assets elapsed_ms
           heap_words (Sys.word_size / 8)
   | _ ->
@@ -498,24 +520,22 @@ let print_membership_json () =
     ; record = first
     ; path = AR.Merkle_list.path tree ~index:0
     }
-  |> Registry.Membership_witness.to_yojson
-  |> Yojson.Safe.to_string |> printf "%s\n%!"
+  |> Registry.Membership_witness.to_yojson |> Yojson.Safe.to_string
+  |> printf "%s\n%!"
 
 let () =
   ( match Registry.Scan.Definition.wrap_domain with
   | Some `N14 ->
       ()
   | _ ->
-      failwith
-        "asset registry scan must use the real Pickles N14 wrap domain" ) ;
+      failwith "asset registry scan must use the real Pickles N14 wrap domain"
+  ) ;
   check_append_only_paths () ;
   check_membership () ;
   check_exhaustive_scan_step () ;
   check_registration_transition () ;
-  if
-    Array.exists (Sys.get_argv ()) ~f:(String.equal "--max")
-  then check_maximum_registration () ;
-  if
-    Array.exists (Sys.get_argv ()) ~f:(String.equal "--json")
-  then print_membership_json () ;
+  if Array.exists (Sys.get_argv ()) ~f:(String.equal "--max") then
+    check_maximum_registration () ;
+  if Array.exists (Sys.get_argv ()) ~f:(String.equal "--json") then
+    print_membership_json () ;
   printf "asset registry vectors: ok\n%!"

--- a/src/app/zeko/tests/asset_registry_vectors.ml
+++ b/src/app/zeko/tests/asset_registry_vectors.ml
@@ -110,9 +110,9 @@ let check_membership () =
   if
     not
       ([%equal: Field.t list] checked_state
-         [ (state tree1).root
-         ; Checked32.to_field (state tree1).leaf_count
-         ; Checked32.to_field (state tree1).schema_version
+         [ witness.state.root
+         ; Checked32.to_field witness.state.leaf_count
+         ; Checked32.to_field witness.state.schema_version
          ] )
   then failwith "registry account precondition did not bind root/count/version" ;
   let bad_path =

--- a/src/app/zeko/tests/asset_registry_vectors.ml
+++ b/src/app/zeko/tests/asset_registry_vectors.ml
@@ -87,16 +87,17 @@ let run_membership witness =
        ( Registry.Verified_asset.token_id verified
        , Registry.Verified_asset.authenticated_registry_call verified ) )
 
-let check_membership () =
-  let tree0 = AR.Merkle_list.empty () in
-  let first = record 0 in
-  let tree1 = AR.Merkle_list.append_exn tree0 first in
-  let witness : Registry.Membership_witness.t =
-    { state = state tree1
-    ; record = first
-    ; path = AR.Merkle_list.path tree1 ~index:0
+let membership_witness record =
+  let tree = AR.Merkle_list.append_exn (AR.Merkle_list.empty ()) record in
+  ( { Registry.Membership_witness.state = state tree
+    ; record
+    ; path = AR.Merkle_list.path tree ~index:0
     }
-  in
+    : Registry.Membership_witness.t )
+
+let check_membership () =
+  let first = record 0 in
+  let witness = membership_witness first in
   let token_id, registry_call = run_membership witness in
   if not (AR.Token_id.equal token_id first.token_id_l2) then
     failwith "verified membership returned the wrong token ID" ;
@@ -146,12 +147,14 @@ let check_membership () =
               state = { witness.state with schema_version = Checked32.of_int 2 }
             }
           : AR.Token_id.t * Account_update.Body.t ) ) ;
-  expect_failure "unsupported decimals" (fun () ->
+  let maximum_decimals = { first with decimals = Checked32.of_int 255 } in
+  ignore
+    ( run_membership (membership_witness maximum_decimals)
+      : AR.Token_id.t * Account_update.Body.t ) ;
+  let overflowing_decimals = { first with decimals = Checked32.of_int 256 } in
+  expect_failure "decimals outside UInt8" (fun () ->
       ignore
-        ( run_membership
-            { witness with
-              record = { first with decimals = Checked32.of_int 10 }
-            }
+        ( run_membership (membership_witness overflowing_decimals)
           : AR.Token_id.t * Account_update.Body.t ) )
 
 let check_append_only_paths () =

--- a/src/app/zeko/tests/compile_circuits.ml
+++ b/src/app/zeko/tests/compile_circuits.ml
@@ -89,8 +89,6 @@ module Inputs = struct
 
   let ethereum_asset_registry_public_key = None
 
-  let ethereum_asset_registration_authority = inner_public_key
-
   let ethereum_asset_registry_schema_version =
     Zeko_circuits.Zeko_util.Checked32.zero
 

--- a/src/app/zeko/tests/compile_circuits.ml
+++ b/src/app/zeko/tests/compile_circuits.ml
@@ -14,10 +14,14 @@ module Inputs = struct
 
   let holder_accounts_l1 = [ point_of_string "89888" ]
 
+  let ethereum_holder_account_l1 = None
+
   let multisig_update =
     { Zeko_circuits.Multisig.public_keys = holder_accounts_l1
     ; quorum = Snark_params.Tick.Field.of_int 1
     }
+
+  let multisig_key = multisig_update
 
   let holder_account_l2 = point_of_string "11111"
 
@@ -30,6 +34,14 @@ module Inputs = struct
   let emergency_da_public_key = point_of_string "43210"
 
   let withdrawal_delay = Mina_numbers.Global_slot_span.of_string "5"
+
+  let bridge_proof_fee = Currency.Amount.zero
+
+  let bridge_fee_recipient_l1 = point_of_string "765431"
+
+  let bridge_fee_recipient_l2 = point_of_string "765432"
+
+  let outer_account_creation_fee = Currency.Fee.zero
 
   let max_sequencer_inactivity = 128
 
@@ -74,6 +86,25 @@ module Inputs = struct
   let token_owner_l2 =
     Mina_base.Account_id.create (point_of_string "344213")
       Mina_base.Account_id.Digest.default
+
+  let ethereum_asset_registry_public_key = None
+
+  let ethereum_asset_registration_authority = inner_public_key
+
+  let ethereum_asset_registry_schema_version =
+    Zeko_circuits.Zeko_util.Checked32.zero
+
+  let ethereum_asset_approved_mft_standard_vk_id = Snark_params.Tick.Field.zero
+
+  let ethereum_asset_approved_mft_token_vk_hash = Snark_params.Tick.Field.zero
+
+  let ethereum_asset_approved_mft_admin_vk_hash = Snark_params.Tick.Field.zero
+
+  let ethereum_asset_universal_bridge_vk_id = Snark_params.Tick.Field.zero
+
+  let ethereum_asset_universal_bridge_vk_hash = Snark_params.Tick.Field.zero
+
+  let ethereum_asset_vault_public_key = inner_public_key
 end
 
 module Inner_rules_inst = Zeko_circuits.Inner_rules.Make (Inputs) ()

--- a/src/app/zeko/tests/dune
+++ b/src/app/zeko/tests/dune
@@ -88,8 +88,15 @@
   is_compile_simple_real_fake
   zeko_constants)
  (preprocess
-  (pps ppx_jane))
+ (pps ppx_jane))
  (modules ethereum_bridge_vectors))
+
+(executable
+ (name asset_registry_vectors)
+ (libraries zeko_circuits compile_simple_fake zeko_constants)
+ (preprocess
+  (pps ppx_jane))
+ (modules asset_registry_vectors))
 
 (executable
  (name test_pause_fake)

--- a/src/app/zeko/tests/dune
+++ b/src/app/zeko/tests/dune
@@ -40,6 +40,8 @@
  (libraries
   zeko_circuits
   compile_simple_fake
+  sequencer_lib
+  is_compile_simple_real_fake
   account_set_data
   zeko_constants)
  (instrumentation

--- a/src/app/zeko/tests/dune
+++ b/src/app/zeko/tests/dune
@@ -90,14 +90,16 @@
   is_compile_simple_real_fake
   zeko_constants)
  (preprocess
- (pps ppx_jane))
+  (pps ppx_jane))
  (modules ethereum_bridge_vectors))
 
 (executable
  (name asset_registry_vectors)
  (libraries zeko_circuits compile_simple_fake zeko_constants)
+ (instrumentation
+  (backend bisect_ppx))
  (preprocess
-  (pps ppx_jane))
+  (pps ppx_version ppx_jane))
  (modules asset_registry_vectors))
 
 (executable

--- a/src/app/zeko/tests/ethereum_bridge_vectors.ml
+++ b/src/app/zeko/tests/ethereum_bridge_vectors.ml
@@ -36,14 +36,14 @@ let erc20_aux ~asset_id_high ~asset_id_low ~amount:value ~recipient_x
     ; timeout = Mina_numbers.Global_slot_since_genesis.max_value
     }
   in
-  let params : Zeko_circuits.Bridge_state.Deposit_params_ethereum_token.t =
+  let params : Zeko_circuits.Bridge_state.Deposit_params_ethereum_token_v1.t =
     { asset_id_high = Field.of_string asset_id_high
     ; asset_id_low = Field.of_string asset_id_low
     ; base
     }
   in
   Utils.value_to_hash ~init:Zeko_constants.ethereum_erc20_deposit_salt
-    Zeko_circuits.Bridge_state.Deposit_params_ethereum_token.typ params
+    Zeko_circuits.Bridge_state.Deposit_params_ethereum_token_v1.typ params
   |> field_to_hex
 
 let point_of_string value =
@@ -51,7 +51,75 @@ let point_of_string value =
     to_affine_exn @@ point_near_x @@ Field.of_string value)
   |> Signature_lib.Public_key.compress
 
-let erc20_deposit_params ?(asset_id_low = Field.of_int 2) () =
+let commit_registry_public_key = point_of_string "61001"
+
+let commit_registration_authority = point_of_string "62001"
+
+let commit_vault_public_key = point_of_string "63001"
+
+let commit_owner_public_key = point_of_string "64001"
+
+let commit_admin_public_key = point_of_string "65001"
+
+let commit_circulation_public_key = commit_owner_public_key
+
+let commit_vk = Mina_base.Side_loaded_verification_key.dummy
+
+let commit_vk_hash = Mina_base.Verification_key_wire.digest_vk commit_vk
+
+module Commit_rule = Zeko_circuits.Rule_commit.Make (struct
+  let max_valid_while_size = 1
+
+  let inner_public_key = point_of_string "66001"
+
+  let chain_l1 = Mina_signature_kind.Testnet
+
+  let chain_l2 = Mina_signature_kind.Testnet
+
+  let max_sequencer_inactivity = 1
+
+  let emergency_da_public_key = point_of_string "67001"
+
+  let ethereum_asset_registry_public_key = Some commit_registry_public_key
+
+  let ethereum_asset_registration_authority = commit_registration_authority
+
+  let ethereum_asset_registry_schema_version =
+    Zeko_circuits.Zeko_util.Checked32.of_int
+      Zeko_constants.Ethereum_asset_registry.schema_version
+
+  let ethereum_asset_approved_mft_standard_vk_id = Field.of_int 61008
+
+  let ethereum_asset_approved_mft_token_vk_hash = commit_vk_hash
+
+  let ethereum_asset_approved_mft_admin_vk_hash = commit_vk_hash
+
+  let ethereum_asset_universal_bridge_vk_id = Field.of_int 61009
+
+  let ethereum_asset_universal_bridge_vk_hash = commit_vk_hash
+
+  let ethereum_asset_vault_public_key = commit_vault_public_key
+end)
+
+type registration_account_mutation =
+  | Valid_registration
+  | Wrong_owner_id
+  | Wrong_owner_vk
+  | Wrong_owner_permissions
+  | Wrong_admin_id
+  | Wrong_admin_vk
+  | Wrong_admin_permissions
+  | Wrong_admin_authority
+  | Wrong_vault_id
+  | Wrong_vault_vk
+  | Wrong_vault_permissions
+  | Wrong_vault_balance
+  | Wrong_circulation_id
+  | Wrong_circulation_permissions
+  | Wrong_circulation_balance
+  | Wrong_inventory_cap
+
+let erc20_deposit_params_v1 ?(asset_id_low = Field.of_int 2) () =
   let base : Zeko_circuits.Bridge_state.Deposit_params_base.t =
     { children = []
     ; holder_account_l1 = ({ x = Field.one; is_odd = false } : PC.t)
@@ -61,14 +129,14 @@ let erc20_deposit_params ?(asset_id_low = Field.of_int 2) () =
     }
   in
   ( { asset_id_high = Field.one; asset_id_low; base }
-    : Zeko_circuits.Bridge_state.Deposit_params_ethereum_token.t )
+    : Zeko_circuits.Bridge_state.Deposit_params_ethereum_token_v1.t )
 
 let run_erc20_deposit_action ~expected_asset_low =
   let open Snark_params.Tick in
-  let params = erc20_deposit_params () in
+  let params = erc20_deposit_params_v1 () in
   run_and_check_exn
     (let%bind.Checked params =
-       exists Zeko_circuits.Bridge_state.Deposit_params_ethereum_token.typ
+       exists Zeko_circuits.Bridge_state.Deposit_params_ethereum_token_v1.typ
          ~compute:(fun _ -> params)
      in
      let%map.Checked action =
@@ -80,7 +148,8 @@ let run_erc20_deposit_action ~expected_asset_low =
                 ~ethereum_holder_account_l1:
                   (Some ({ x = Field.one; is_odd = false } : PC.t))
                 ~ethereum_asset_id:(Some (Field.one, expected_asset_low))
-                (module Zeko_circuits.Bridge_state.Deposit_params_ethereum_token)
+                ( module Zeko_circuits.Bridge_state
+                         .Deposit_params_ethereum_token_v1 )
                 params
                 ~bridge_fee_recipient_l1:
                   (constant PC.typ (point_of_string "765431"))
@@ -113,6 +182,8 @@ module Ethereum_token_bridge =
     (struct
       let registry_public_key = point_of_string "22222"
 
+      let registration_authority = point_of_string "33333"
+
       let registry_schema_version =
         Zeko_circuits.Zeko_util.Checked32.of_int
           Zeko_constants.Ethereum_asset_registry.schema_version
@@ -143,22 +214,22 @@ module Ethereum_token_bridge =
 let registered_asset index token_owner_l2 asset_id_low =
   let open Mina_base in
   let owner = Account_id.create token_owner_l2 Token_id.default in
-  ({ schema_version =
-       Zeko_circuits.Zeko_util.Checked32.of_int
-         Zeko_constants.Ethereum_asset_registry.schema_version
-   ; registry_index = Zeko_circuits.Zeko_util.Checked32.of_int index
-   ; asset_id_high = Field.one
-   ; asset_id_low
-   ; ethereum_token_address = Field.of_int (5000 + index)
-   ; token_owner_l2
-   ; token_id_l2 = Account_id.derive_token_id ~owner
-   ; decimals = Zeko_circuits.Zeko_util.Checked32.of_int 6
-   ; inventory_cap = amount "100000000"
-   ; mft_standard_vk_id = Field.of_int 777
-   ; vault_public_key = point_of_string "11111"
-   ; universal_bridge_vk_id = Field.of_int 778
-   } :
-    Zeko_circuits.Asset_registry.Asset_record.t )
+  ( { schema_version =
+        Zeko_circuits.Zeko_util.Checked32.of_int
+          Zeko_constants.Ethereum_asset_registry.schema_version
+    ; registry_index = Zeko_circuits.Zeko_util.Checked32.of_int index
+    ; asset_id_high = Field.one
+    ; asset_id_low
+    ; ethereum_token_address = Field.of_int (5000 + index)
+    ; token_owner_l2
+    ; token_id_l2 = Account_id.derive_token_id ~owner
+    ; decimals = Zeko_circuits.Zeko_util.Checked32.of_int 6
+    ; inventory_cap = amount "100000000"
+    ; mft_standard_vk_id = Field.of_int 777
+    ; vault_public_key = point_of_string "11111"
+    ; universal_bridge_vk_id = Field.of_int 778
+    }
+    : Zeko_circuits.Asset_registry.Asset_record.t )
 
 let first_registered_asset =
   registered_asset 0 (point_of_string "344213") (Field.of_int 2)
@@ -171,8 +242,7 @@ let first_registry_tree =
 
 let first_membership : Ethereum_token_bridge.Registry.Membership_witness.t =
   { state =
-      { root =
-          Zeko_circuits.Asset_registry.Merkle_list.root first_registry_tree
+      { root = Zeko_circuits.Asset_registry.Merkle_list.root first_registry_tree
       ; leaf_count = Zeko_circuits.Zeko_util.Checked32.one
       ; schema_version =
           Zeko_circuits.Zeko_util.Checked32.of_int
@@ -201,8 +271,489 @@ let second_membership : Ethereum_token_bridge.Registry.Membership_witness.t =
       }
   ; record = second_registered_asset
   ; path =
-      Zeko_circuits.Asset_registry.Merkle_list.path second_registry_tree ~index:1
+      Zeko_circuits.Asset_registry.Merkle_list.path second_registry_tree
+        ~index:1
   }
+
+type commit_registration_fixture =
+  { source_ledger : Mina_base.Ledger_hash.t
+  ; target_ledger : Mina_base.Ledger_hash.t
+  ; old_registry_acc : Mina_base.Account.t
+  ; old_registry_path : Commit_rule.Registry_path.t
+  ; new_registry_acc : Mina_base.Account.t
+  ; new_registry_path : Commit_rule.Registry_path.t
+  ; registration : Commit_rule.Registration_witness.t
+  }
+
+let registry_state tree : Zeko_circuits.Asset_registry.Registry_state.t =
+  { root = Zeko_circuits.Asset_registry.Merkle_list.root tree
+  ; leaf_count =
+      Zeko_circuits.Zeko_util.Checked32.of_int
+        (Zeko_circuits.Asset_registry.Merkle_list.count tree)
+  ; schema_version =
+      Zeko_circuits.Zeko_util.Checked32.of_int
+        Zeko_constants.Ethereum_asset_registry.schema_version
+  }
+
+let commit_candidate inventory_cap : Zeko_circuits.Asset_registry.Asset_record.t
+    =
+  let owner =
+    Mina_base.Account_id.create commit_owner_public_key
+      Mina_base.Token_id.default
+  in
+  { schema_version =
+      Zeko_circuits.Zeko_util.Checked32.of_int
+        Zeko_constants.Ethereum_asset_registry.schema_version
+  ; registry_index = Zeko_circuits.Zeko_util.Checked32.zero
+  ; asset_id_high = Field.of_int 61010
+  ; asset_id_low = Field.of_int 61011
+  ; ethereum_token_address = Field.of_int 61012
+  ; token_owner_l2 = commit_owner_public_key
+  ; token_id_l2 = Mina_base.Account_id.derive_token_id ~owner
+  ; decimals = Zeko_circuits.Zeko_util.Checked32.of_int 6
+  ; inventory_cap
+  ; mft_standard_vk_id = Field.of_int 61008
+  ; vault_public_key = commit_vault_public_key
+  ; universal_bridge_vk_id = Field.of_int 61009
+  }
+
+let zkapp_with_vk ~app_state ~vk_hash : Mina_base.Zkapp_account.t =
+  { Mina_base.Zkapp_account.default with
+    app_state = Mina_base.Zkapp_state.V.of_list_exn app_state
+  ; verification_key = Some { data = commit_vk; hash = vk_hash }
+  }
+
+let registry_account (state : Zeko_circuits.Asset_registry.Registry_state.t) =
+  let open Mina_base in
+  { Account.empty with
+    public_key = commit_registry_public_key
+  ; token_id = Token_id.default
+  ; zkapp =
+      Some
+        { Zkapp_account.default with
+          app_state =
+            Zkapp_state.V.of_list_exn
+              [ state.root
+              ; Zeko_circuits.Zeko_util.Checked32.to_field state.leaf_count
+              ; Zeko_circuits.Zeko_util.Checked32.to_field state.schema_version
+              ; Field.zero
+              ; Field.zero
+              ; Field.zero
+              ; Field.zero
+              ; Field.zero
+              ]
+        }
+  }
+
+let balance_of_amount value =
+  Currency.Amount.to_uint64 value |> Currency.Balance.of_uint64
+
+let make_commit_accounts mutation
+    (candidate : Zeko_circuits.Asset_registry.Asset_record.t) =
+  let open Mina_base in
+  let base_inventory = amount "100000000" in
+  let token_id =
+    candidate.Zeko_circuits.Asset_registry.Asset_record.token_id_l2
+  in
+  let owner_zkapp =
+    zkapp_with_vk ~vk_hash:commit_vk_hash
+      ~app_state:
+        [ Zeko_circuits.Zeko_util.Checked32.to_field candidate.decimals
+        ; commit_admin_public_key.x
+        ; (if commit_admin_public_key.is_odd then Field.one else Field.zero)
+        ; Field.zero
+        ; Field.zero
+        ; Field.zero
+        ; Field.zero
+        ; Field.zero
+        ]
+  in
+  let admin_zkapp =
+    zkapp_with_vk ~vk_hash:commit_vk_hash
+      ~app_state:
+        [ commit_registration_authority.x
+        ; ( if commit_registration_authority.is_odd then Field.one
+          else Field.zero )
+        ; Field.zero
+        ; Field.zero
+        ; Field.zero
+        ; Field.zero
+        ; Field.zero
+        ; Field.zero
+        ]
+  in
+  let vault_zkapp =
+    zkapp_with_vk ~vk_hash:commit_vk_hash
+      ~app_state:(List.init 8 ~f:(fun _ -> Field.zero))
+  in
+  let owner =
+    { Account.empty with
+      public_key = commit_owner_public_key
+    ; token_id = Token_id.default
+    ; permissions = Commit_rule.expected_token_owner_permissions
+    ; zkapp = Some owner_zkapp
+    }
+  in
+  let admin =
+    { Account.empty with
+      public_key = commit_admin_public_key
+    ; token_id = Token_id.default
+    ; permissions = Commit_rule.expected_token_admin_permissions
+    ; zkapp = Some admin_zkapp
+    }
+  in
+  let vault =
+    { Account.empty with
+      public_key = commit_vault_public_key
+    ; token_id
+    ; balance = balance_of_amount base_inventory
+    ; permissions = Commit_rule.expected_vault_permissions
+    ; zkapp = Some vault_zkapp
+    }
+  in
+  let circulation =
+    { Account.empty with
+      public_key = commit_circulation_public_key
+    ; token_id
+    ; balance = balance_of_amount base_inventory
+    ; permissions = Commit_rule.expected_circulation_permissions
+    }
+  in
+  match mutation with
+  | Valid_registration | Wrong_inventory_cap ->
+      (owner, admin, vault, circulation)
+  | Wrong_owner_id ->
+      ( { owner with public_key = point_of_string "61101" }
+      , admin
+      , vault
+      , circulation )
+  | Wrong_owner_vk ->
+      ( { owner with
+          zkapp =
+            Some
+              (zkapp_with_vk
+                 ~vk_hash:Field.(commit_vk_hash + one)
+                 ~app_state:(Zkapp_state.V.to_list owner_zkapp.app_state) )
+        }
+      , admin
+      , vault
+      , circulation )
+  | Wrong_owner_permissions ->
+      ( { owner with permissions = Permissions.user_default }
+      , admin
+      , vault
+      , circulation )
+  | Wrong_admin_id ->
+      ( owner
+      , { admin with public_key = point_of_string "61102" }
+      , vault
+      , circulation )
+  | Wrong_admin_vk ->
+      ( owner
+      , { admin with
+          zkapp =
+            Some
+              (zkapp_with_vk
+                 ~vk_hash:Field.(commit_vk_hash + one)
+                 ~app_state:(Zkapp_state.V.to_list admin_zkapp.app_state) )
+        }
+      , vault
+      , circulation )
+  | Wrong_admin_permissions ->
+      ( owner
+      , { admin with permissions = Permissions.user_default }
+      , vault
+      , circulation )
+  | Wrong_admin_authority ->
+      let bad_admin_zkapp =
+        zkapp_with_vk ~vk_hash:commit_vk_hash
+          ~app_state:
+            [ Field.(commit_registration_authority.x + one)
+            ; ( if commit_registration_authority.is_odd then Field.one
+              else Field.zero )
+            ; Field.zero
+            ; Field.zero
+            ; Field.zero
+            ; Field.zero
+            ; Field.zero
+            ; Field.zero
+            ]
+      in
+      (owner, { admin with zkapp = Some bad_admin_zkapp }, vault, circulation)
+  | Wrong_vault_id ->
+      ( owner
+      , admin
+      , { vault with public_key = point_of_string "61103" }
+      , circulation )
+  | Wrong_vault_vk ->
+      ( owner
+      , admin
+      , { vault with
+          zkapp =
+            Some
+              (zkapp_with_vk
+                 ~vk_hash:Field.(commit_vk_hash + one)
+                 ~app_state:(Zkapp_state.V.to_list vault_zkapp.app_state) )
+        }
+      , circulation )
+  | Wrong_vault_permissions ->
+      ( owner
+      , admin
+      , { vault with permissions = Permissions.user_default }
+      , circulation )
+  | Wrong_vault_balance ->
+      ( owner
+      , admin
+      , { vault with balance = Currency.Balance.of_uint64 Unsigned.UInt64.one }
+      , circulation )
+  | Wrong_circulation_id ->
+      ( owner
+      , admin
+      , vault
+      , { circulation with public_key = point_of_string "61104" } )
+  | Wrong_circulation_permissions ->
+      ( owner
+      , admin
+      , vault
+      , { circulation with permissions = Permissions.user_default } )
+  | Wrong_circulation_balance ->
+      ( owner
+      , admin
+      , vault
+      , { circulation with
+          balance = Currency.Balance.of_uint64 Unsigned.UInt64.one
+        } )
+
+let sparse_ledger accounts =
+  let ledger =
+    Mina_ledger.Ledger.create_ephemeral
+      ~depth:Zeko_constants.constraint_constants.ledger_depth ()
+  in
+  List.iter accounts ~f:(fun account ->
+      Mina_ledger.Ledger.create_new_account_exn ledger
+        (Mina_base.Account.identifier account)
+        account ) ;
+  Mina_ledger.Sparse_ledger.of_ledger_subset_exn ledger
+    (List.map accounts ~f:Mina_base.Account.identifier)
+
+let commit_opening sparse account =
+  let index =
+    Mina_ledger.Sparse_ledger.find_index_exn sparse
+      (Mina_base.Account.identifier account)
+  in
+  let account = Mina_ledger.Sparse_ledger.get_exn sparse index in
+  let path =
+    Mina_ledger.Sparse_ledger.path_exn sparse index
+    |> List.map ~f:(function
+         | `Left hash ->
+             ( { Commit_rule.Registry_path.Step.hash_other = hash
+               ; is_right = false
+               }
+               : Commit_rule.Registry_path.Step.t )
+         | `Right hash ->
+             { hash_other = hash; is_right = true } )
+  in
+  (account, path)
+
+let make_commit_registration_fixture ?(mutation = Valid_registration)
+    ?(did_append = true) ?(wrong_count = false) ?(wrong_root = false) () =
+  let base_inventory = amount "100000000" in
+  let candidate_inventory =
+    if Poly.equal mutation Wrong_inventory_cap then amount "100000001"
+    else base_inventory
+  in
+  let candidate = commit_candidate candidate_inventory in
+  let owner, admin, vault, circulation =
+    make_commit_accounts mutation candidate
+  in
+  let old_tree = Zeko_circuits.Asset_registry.Merkle_list.empty () in
+  let new_tree =
+    if did_append then
+      Zeko_circuits.Asset_registry.Merkle_list.append_exn old_tree candidate
+    else old_tree
+  in
+  let old_state = registry_state old_tree in
+  let new_state =
+    let state = registry_state new_tree in
+    { state with
+      root = (if wrong_root then Field.(state.root + one) else state.root)
+    ; leaf_count =
+        ( if wrong_count then
+          Zeko_circuits.Zeko_util.Checked32.(
+            if did_append then old_state.leaf_count else one)
+        else state.leaf_count )
+    }
+  in
+  let old_registry = registry_account old_state in
+  let new_registry = registry_account new_state in
+  let source =
+    sparse_ledger [ old_registry; owner; admin; vault; circulation ]
+  in
+  let target =
+    sparse_ledger [ new_registry; owner; admin; vault; circulation ]
+  in
+  let old_registry_acc, old_registry_path =
+    commit_opening source old_registry
+  in
+  let new_registry_acc, new_registry_path =
+    commit_opening target new_registry
+  in
+  let token_owner_acc, token_owner_path = commit_opening target owner in
+  let admin_acc, admin_path = commit_opening target admin in
+  let vault_acc, vault_path = commit_opening target vault in
+  let circulation_acc, circulation_path = commit_opening target circulation in
+  { source_ledger = Mina_ledger.Sparse_ledger.merkle_root source
+  ; target_ledger = Mina_ledger.Sparse_ledger.merkle_root target
+  ; old_registry_acc
+  ; old_registry_path
+  ; new_registry_acc
+  ; new_registry_path
+  ; registration =
+      { did_append
+      ; candidate
+      ; append_path =
+          ( if did_append then
+            Zeko_circuits.Asset_registry.Merkle_list.path new_tree ~index:0
+          else
+            List.init Zeko_constants.Ethereum_asset_registry.depth ~f:(fun _ ->
+                Field.zero ) )
+      ; token_owner_acc
+      ; token_owner_path
+      ; admin_acc
+      ; admin_path
+      ; vault_acc
+      ; vault_path
+      ; circulation_acc
+      ; circulation_path
+      }
+  }
+
+let run_commit_registration_fixture fixture =
+  let open Snark_params.Tick in
+  let open Zeko_circuits.Zeko_util in
+  run_and_check_exn
+    (let%bind.Checked source_ledger =
+       exists Mina_base.Ledger_hash.typ ~compute:(fun _ ->
+           fixture.source_ledger )
+     in
+     let%bind.Checked target_ledger =
+       exists Mina_base.Ledger_hash.typ ~compute:(fun _ ->
+           fixture.target_ledger )
+     in
+     let%bind.Checked old_registry_acc =
+       exists Mina_base.Account.typ ~compute:(fun _ -> fixture.old_registry_acc)
+     in
+     let%bind.Checked old_registry_path =
+       exists Commit_rule.Registry_path.typ ~compute:(fun _ ->
+           fixture.old_registry_path )
+     in
+     let%bind.Checked new_registry_acc =
+       exists Mina_base.Account.typ ~compute:(fun _ -> fixture.new_registry_acc)
+     in
+     let%bind.Checked new_registry_path =
+       exists Commit_rule.Registry_path.typ ~compute:(fun _ ->
+           fixture.new_registry_path )
+     in
+     let%bind.Checked registration =
+       exists Commit_rule.Registration_witness.typ ~compute:(fun _ ->
+           fixture.registration )
+     in
+     let%bind.Checked implied_old_root =
+       Commit_rule.implied_registry_root old_registry_acc old_registry_path
+     in
+     let%bind.Checked () =
+       assert_equal ~label:"test source registry opening"
+         Mina_base.Ledger_hash.typ source_ledger
+         (Mina_base.Ledger_hash.var_of_hash_packed implied_old_root)
+     in
+     let%bind.Checked implied_new_root =
+       Commit_rule.implied_registry_root new_registry_acc new_registry_path
+     in
+     let%bind.Checked () =
+       assert_equal ~label:"test target registry opening"
+         Mina_base.Ledger_hash.typ target_ledger
+         (Mina_base.Ledger_hash.var_of_hash_packed implied_new_root)
+     in
+     let%bind.Checked old_state =
+       Commit_rule.registry_state_of_account
+         ~registry_public_key:commit_registry_public_key old_registry_acc
+     in
+     let%bind.Checked new_state =
+       Commit_rule.registry_state_of_account
+         ~registry_public_key:commit_registry_public_key new_registry_acc
+     in
+     let%map.Checked () =
+       Commit_rule.validate_registration_accounts ~target_ledger ~old_state
+         ~new_state registration
+     in
+     As_prover.return () )
+
+let corrupt_commit_path (path : Commit_rule.Registry_path.t) :
+    Commit_rule.Registry_path.t =
+  match path with
+  | { Commit_rule.Registry_path.Step.hash_other; is_right } :: rest ->
+      { Commit_rule.Registry_path.Step.hash_other = Field.(hash_other + one)
+      ; is_right
+      }
+      :: rest
+  | [] ->
+      assert false
+
+let expect_commit_failure label fixture =
+  if not (Exn.does_raise (fun () -> run_commit_registration_fixture fixture))
+  then failwithf "%s unexpectedly satisfied commit constraints" label ()
+
+let check_commit_registration_constraints () =
+  run_commit_registration_fixture (make_commit_registration_fixture ()) ;
+  run_commit_registration_fixture
+    (make_commit_registration_fixture ~did_append:false ()) ;
+  expect_commit_failure "no-append registry count mutation"
+    (make_commit_registration_fixture ~did_append:false ~wrong_count:true ()) ;
+  expect_commit_failure "no-append registry root mutation"
+    (make_commit_registration_fixture ~did_append:false ~wrong_root:true ()) ;
+  let bad_source_path = make_commit_registration_fixture () in
+  expect_commit_failure "forged source registry opening"
+    { bad_source_path with
+      old_registry_path = corrupt_commit_path bad_source_path.old_registry_path
+    } ;
+  let bad_target_path = make_commit_registration_fixture () in
+  expect_commit_failure "forged target registry opening"
+    { bad_target_path with
+      new_registry_path = corrupt_commit_path bad_target_path.new_registry_path
+    } ;
+  expect_commit_failure "forged registry count transition"
+    (make_commit_registration_fixture ~wrong_count:true ()) ;
+  expect_commit_failure "forged registry root transition"
+    (make_commit_registration_fixture ~wrong_root:true ()) ;
+  let bad_owner_path = make_commit_registration_fixture () in
+  expect_commit_failure "forged token owner opening"
+    { bad_owner_path with
+      registration =
+        { bad_owner_path.registration with
+          token_owner_path =
+            corrupt_commit_path bad_owner_path.registration.token_owner_path
+        }
+    } ;
+  List.iter
+    [ ("wrong token owner ID", Wrong_owner_id)
+    ; ("wrong token owner VK", Wrong_owner_vk)
+    ; ("wrong token owner permissions", Wrong_owner_permissions)
+    ; ("wrong token admin ID", Wrong_admin_id)
+    ; ("wrong token admin VK", Wrong_admin_vk)
+    ; ("wrong token admin permissions", Wrong_admin_permissions)
+    ; ("wrong token admin authority", Wrong_admin_authority)
+    ; ("wrong vault ID", Wrong_vault_id)
+    ; ("wrong vault VK", Wrong_vault_vk)
+    ; ("wrong vault permissions", Wrong_vault_permissions)
+    ; ("wrong vault balance", Wrong_vault_balance)
+    ; ("wrong circulation ID", Wrong_circulation_id)
+    ; ("wrong circulation permissions", Wrong_circulation_permissions)
+    ; ("wrong circulation balance", Wrong_circulation_balance)
+    ; ("wrong inventory cap", Wrong_inventory_cap)
+    ]
+    ~f:(fun (label, mutation) ->
+      expect_commit_failure label
+        (make_commit_registration_fixture ~mutation ()) )
 
 let check_erc20_finalize_deposit
     ~(membership : Ethereum_token_bridge.Registry.Membership_witness.t) =
@@ -210,13 +761,28 @@ let check_erc20_finalize_deposit
   let open Zeko_circuits in
   let open Zeko_util in
   let registered_asset = membership.record in
-  let params =
-    erc20_deposit_params ~asset_id_low:registered_asset.asset_id_low ()
+  let params : Bridge_state.Deposit_params_ethereum_token.t =
+    let base : Bridge_state.Deposit_params_base.t =
+      { children = []
+      ; holder_account_l1 = ({ x = Field.one; is_odd = false } : PC.t)
+      ; amount = amount "2000000"
+      ; recipient = ({ x = Field.of_int 0x01020304; is_odd = false } : PC.t)
+      ; timeout = Mina_numbers.Global_slot_since_genesis.max_value
+      }
+    in
+    { encoding_version = Checked32.of_int 2
+    ; registry_index = registered_asset.registry_index
+    ; record_commitment =
+        Asset_registry.Asset_record.commitment registered_asset
+    ; asset_id_high = registered_asset.asset_id_high
+    ; asset_id_low = registered_asset.asset_id_low
+    ; base
+    }
   in
   let base = params.base in
   let witness : Rollup_state.Outer_action.Witness.t =
     { aux =
-        Utils.value_to_hash ~init:Zeko_constants.ethereum_erc20_deposit_salt
+        Utils.value_to_hash ~init:Zeko_constants.ethereum_erc20_deposit_v2_salt
           Bridge_state.Deposit_params_ethereum_token.typ params
     ; children = []
     ; slot_range = Slot_range.infinite
@@ -359,10 +925,8 @@ let check_erc20_finalize_deposit
           (Currency.Amount.Signed.equal zero_fee.body.balance_change
              Currency.Amount.Signed.zero )
       then failwith "Ethereum ERC20 circuit emitted a token-denominated fee" ;
-      if
-        not
-          (PC.equal registry.body.public_key (point_of_string "22222"))
-      then failwith "Ethereum ERC20 circuit did not authenticate the registry" ;
+      if not (PC.equal registry.body.public_key (point_of_string "22222")) then
+        failwith "Ethereum ERC20 circuit did not authenticate the registry" ;
       if
         not
           (Mina_base.Account_update.Authorization_kind.equal
@@ -420,7 +984,15 @@ let erc20_withdrawal_params_fields () =
     }
   in
   let params : Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token.t =
-    { asset_id_high = Field.one; asset_id_low = Field.of_int 2; custom }
+    { encoding_version = Zeko_circuits.Zeko_util.Checked32.of_int 2
+    ; registry_index = first_registered_asset.registry_index
+    ; record_commitment =
+        Zeko_circuits.Asset_registry.Asset_record.commitment
+          first_registered_asset
+    ; asset_id_high = Field.one
+    ; asset_id_low = Field.of_int 2
+    ; custom
+    }
   in
   let Compile_simple.[ _finalize; inner_receive; _multisig ] =
     Lazy.force Ethereum_token_bridge.System_L2.provers
@@ -443,20 +1015,21 @@ let erc20_withdrawal_params_fields () =
   then failwith "Ethereum ERC20 withdrawal used the wrong registered token" ;
   if
     not
-      (String.equal (field_to_hex vault_body.call_data)
+      (String.equal
+         (field_to_hex vault_body.call_data)
          "19a86bb8c106848e3bab8dd79491cbc4589f28b33227007eb60409efa56e12d0" )
   then failwith "Ethereum ERC20 bridge call-data vector mismatch" ;
   ( match Zkapp_command.Call_forest.to_account_updates registry_calls with
   | [ registry ] ->
-      if
-        not
-          (PC.equal registry.body.public_key (point_of_string "22222"))
-      then failwith "Ethereum ERC20 withdrawal did not authenticate the registry"
+      if not (PC.equal registry.body.public_key (point_of_string "22222")) then
+        failwith "Ethereum ERC20 withdrawal did not authenticate the registry"
       else if not registry.body.use_full_commitment then
-        failwith "Ethereum ERC20 registry precondition omitted the full commitment"
+        failwith
+          "Ethereum ERC20 registry precondition omitted the full commitment"
       else if not registry.body.implicit_account_creation_fee then
         failwith
-          "Ethereum ERC20 registry precondition omitted the account-creation fee"
+          "Ethereum ERC20 registry precondition omitted the account-creation \
+           fee"
       else if
         not
           (String.equal
@@ -482,13 +1055,29 @@ let erc20_withdrawal_params_fields () =
   | _ ->
       failwith "Ethereum ERC20 withdrawal debit forest is not singular" ) ;
   let withdrawal_aux =
-    Utils.value_to_hash ~init:Zeko_constants.ethereum_erc20_withdrawal_salt
+    Utils.value_to_hash ~init:Zeko_constants.ethereum_erc20_withdrawal_v2_salt
       Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token.typ params
     |> field_to_hex
   in
   (params_fields, withdrawal_aux)
 
 let () =
+  let packed_x = String.make 63 '0' ^ "1" in
+  let even_key : PC.t = { x = Field.one; is_odd = false } in
+  let odd_key : PC.t = { x = Field.one; is_odd = true } in
+  if
+    not
+      (String.equal
+         (Sequencer_lib.Ethereum_settlement_export.packed_public_key_hex
+            even_key )
+         ("0x" ^ packed_x) )
+  then failwith "even Mina public-key settlement packing mismatch" ;
+  if
+    not
+      (String.equal
+         (Sequencer_lib.Ethereum_settlement_export.packed_public_key_hex odd_key)
+         ("0x8" ^ String.drop_prefix packed_x 1) )
+  then failwith "odd Mina public-key settlement packing mismatch" ;
   let expected_registry_permissions : Mina_base.Permissions.t =
     { Sequencer_lib.Deploy.Z.proof_permissions with access = None }
   in
@@ -503,6 +1092,7 @@ let () =
   let Compile_simple.[ _; _; _ ] =
     Lazy.force Ethereum_token_bridge.System_L2.provers
   in
+  check_commit_registration_constraints () ;
   check_erc20_deposit_witness_action () ;
   let first_helper_token =
     check_erc20_finalize_deposit ~membership:first_membership
@@ -518,7 +1108,7 @@ let () =
   if
     not
       (String.equal withdrawal_aux
-         "350ed8b22bbaac628364ea5d8ee44a8f12d7814dc9c1432264ece93ccd5b364d" )
+         "3832fb1d782fc05d8aa1a0185046c4f25a4d7fb87d1fb3bb4b71850cd00a455e" )
   then
     failwithf "Ethereum ERC20 withdrawal circuit/settlement aux mismatch: %s"
       withdrawal_aux () ;

--- a/src/app/zeko/tests/ethereum_bridge_vectors.ml
+++ b/src/app/zeko/tests/ethereum_bridge_vectors.ml
@@ -1105,8 +1105,7 @@ let run_erc20_withdrawal_action_with_recipient recipient =
   in
   run_and_check_exn
     (let%bind.Checked params =
-       exists
-         Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token.typ
+       exists Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token.typ
          ~compute:(fun _ -> params)
      in
      let%map.Checked _action =
@@ -1191,8 +1190,8 @@ let run_legacy_erc20_withdrawal_action_with_recipient recipient =
         }
       ~authorization:Control.Poly.None_given
   in
-  let params :
-      Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token_v1.t =
+  let params : Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token_v1.t
+      =
     { asset_id_high = first_registered_asset.asset_id_high
     ; asset_id_low = first_registered_asset.asset_id_low
     ; custom =
@@ -1210,8 +1209,7 @@ let run_legacy_erc20_withdrawal_action_with_recipient recipient =
   in
   run_and_check_exn
     (let%bind.Checked params =
-       exists
-         Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token_v1.typ
+       exists Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token_v1.typ
          ~compute:(fun _ -> params)
      in
      let%map.Checked _action =
@@ -1256,13 +1254,11 @@ let registry_count_update_command ?(updates = 1) () : Mina_base.User_command.t =
           ~authorization:Control.Poly.None_given )
     |> List.fold_right ~init:[] ~f:(fun update forest ->
            Zkapp_command.Call_forest.cons
-             ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 update forest
-       )
+             ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 update forest )
   in
   User_command.Zkapp_command
     { fee_payer =
-        Account_update.Fee_payer.make
-          ~body:Account_update.Body.Fee_payer.dummy
+        Account_update.Fee_payer.make ~body:Account_update.Body.Fee_payer.dummy
           ~authorization:Signature.dummy
     ; account_updates
     ; memo = Signed_command_memo.empty
@@ -1325,8 +1321,7 @@ let () =
             recipient ) ;
       run_native_withdrawal_action_with_recipient
         ~recipient_domain:
-          Zeko_circuits.Bridge_state.Withdrawal_recipient_domain.Mina
-        recipient ) ;
+          Zeko_circuits.Bridge_state.Withdrawal_recipient_domain.Mina recipient ) ;
   let valid_ethereum_key : PC.t =
     { x = Field.of_int 0x01020304; is_odd = false }
   in
@@ -1349,10 +1344,10 @@ let () =
       ~registry_id:(Admission.account_id ())
       (registry_count_update_command ~updates:2 ())
   in
-  if not (Int.equal single_update_count 1)
-  then failwith "registry count update escaped common admission counting" ;
-  if not (Int.equal batched_update_count 2)
-  then failwith "batched registry count updates collapsed during admission" ;
+  if not (Int.equal single_update_count 1) then
+    failwith "registry count update escaped common admission counting" ;
+  if not (Int.equal batched_update_count 2) then
+    failwith "batched registry count updates collapsed during admission" ;
   if
     Result.is_ok
       (Admission.validate_counts ~committed_count:0 ~current_count:0
@@ -1420,16 +1415,16 @@ let () =
         token_preimage
     with
   | ( "tokenWithdrawal"
-      , `Assoc
-          [ ("token", `String "0x0000000000000000000000000000000000000001")
-          ; ( "assetId"
-            , `String
-                "0x0000000000000000000000000000000100000000000000000000000000000002"
-            )
-          ; ("recipient", `String "0x0000000000000000000000000000000001020304")
-          ; ("amount", `Intlit "2000000")
-          ; ("paramsFields", `List params_fields)
-          ] )
+    , `Assoc
+        [ ("token", `String "0x0000000000000000000000000000000000000001")
+        ; ( "assetId"
+          , `String
+              "0x0000000000000000000000000000000100000000000000000000000000000002"
+          )
+        ; ("recipient", `String "0x0000000000000000000000000000000001020304")
+        ; ("amount", `Intlit "2000000")
+        ; ("paramsFields", `List params_fields)
+        ] )
     when List.length params_fields >= 6 ->
       ()
   | _ ->

--- a/src/app/zeko/tests/ethereum_bridge_vectors.ml
+++ b/src/app/zeko/tests/ethereum_bridge_vectors.ml
@@ -452,6 +452,19 @@ let erc20_withdrawal_params_fields () =
         not
           (PC.equal registry.body.public_key (point_of_string "22222"))
       then failwith "Ethereum ERC20 withdrawal did not authenticate the registry"
+      else if not registry.body.use_full_commitment then
+        failwith "Ethereum ERC20 registry precondition omitted the full commitment"
+      else if not registry.body.implicit_account_creation_fee then
+        failwith
+          "Ethereum ERC20 registry precondition omitted the account-creation fee"
+      else if
+        not
+          (String.equal
+             (field_to_hex
+                (Account_update.Body.digest
+                   ~signature_kind:Mina_signature_kind.Testnet registry.body ) )
+             "2c383e7260ea384af96f3c833feee18b10a1d614f852076287c1cb513e5b47d6" )
+      then failwith "Ethereum ERC20 registry precondition body vector mismatch"
   | _ ->
       failwith "unexpected ERC20 registry precondition forest" ) ;
   let params_fields =

--- a/src/app/zeko/tests/ethereum_bridge_vectors.ml
+++ b/src/app/zeko/tests/ethereum_bridge_vectors.ml
@@ -333,6 +333,44 @@ let erc20_withdrawal_params_fields () =
   let params : Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token.t =
     { asset_id_high = Field.one; asset_id_low = Field.of_int 2; custom }
   in
+  let configured_token_owner =
+    Zeko_circuits_config.Inputs.Ethereum_token.token_owner_l2
+  in
+  let configured_debit =
+    Account_update.with_aux
+      ~body:
+        { debit_body with
+          token_id = Account_id.derive_token_id ~owner:configured_token_owner
+        }
+      ~authorization:Control.Poly.None_given
+  in
+  let precompute_params :
+      Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token.t =
+    { Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token.asset_id_high =
+        Zeko_circuits_config.Inputs.Ethereum_token.ethereum_asset_id_high
+    ; asset_id_low =
+        Zeko_circuits_config.Inputs.Ethereum_token.ethereum_asset_id_low
+    ; custom =
+        { custom with
+          token_owner_body =
+            { custom.token_owner_body with
+              public_key = Account_id.public_key configured_token_owner
+            ; token_id = Account_id.token_id configured_token_owner
+            }
+        ; nested_children =
+            Zkapp_command.Call_forest.cons
+              ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+              configured_debit []
+        }
+    }
+  in
+  let (_ : Sequencer_lib.Bridge_prover.precomputed_forest) =
+    Sequencer_lib.Bridge_prover.Ethereum_token_withdrawal_request
+    .precompute_forest_with_vk_hashes
+      ~bridge_ethereum_token_l2_vk_hash:Field.one
+      ~inner_rules_vk_hash:(Field.of_int 2) precompute_params
+    |> Or_error.ok_exn
+  in
   let params_fields =
     Utils.value_to_fields
       Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token.typ params

--- a/src/app/zeko/tests/ethereum_bridge_vectors.ml
+++ b/src/app/zeko/tests/ethereum_bridge_vectors.ml
@@ -82,8 +82,6 @@ module Commit_rule = Zeko_circuits.Rule_commit.Make (struct
 
   let ethereum_asset_registry_public_key = Some commit_registry_public_key
 
-  let ethereum_asset_registration_authority = commit_registration_authority
-
   let ethereum_asset_registry_schema_version =
     Zeko_circuits.Zeko_util.Checked32.of_int
       Zeko_constants.Ethereum_asset_registry.schema_version

--- a/src/app/zeko/tests/ethereum_bridge_vectors.ml
+++ b/src/app/zeko/tests/ethereum_bridge_vectors.ml
@@ -364,13 +364,26 @@ let erc20_withdrawal_params_fields () =
         }
     }
   in
-  let (_ : Sequencer_lib.Bridge_prover.precomputed_forest) =
+  let precomputed : Sequencer_lib.Bridge_prover.precomputed_forest =
     Sequencer_lib.Bridge_prover.Ethereum_token_withdrawal_request
     .precompute_forest_with_vk_hashes
       ~bridge_ethereum_token_l2_vk_hash:Field.one
       ~inner_rules_vk_hash:(Field.of_int 2) precompute_params
     |> Or_error.ok_exn
   in
+  ( match precomputed with
+  | [ { elt = { calls = { elt = { calls = [ _debit; vault ]; _ }; _ } :: _; _ }
+      ; _
+      }
+    ] ->
+      let vault_body = vault.elt.account_update.body in
+      if vault_body.use_full_commitment then
+        failwith "Ethereum ERC20 withdrawal vault uses the full commitment" ;
+      if vault_body.implicit_account_creation_fee then
+        failwith
+          "Ethereum ERC20 withdrawal vault charges an account-creation fee"
+  | _ ->
+      failwith "unexpected ERC20 precomputed forest" ) ;
   let params_fields =
     Utils.value_to_fields
       Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token.typ params

--- a/src/app/zeko/tests/ethereum_bridge_vectors.ml
+++ b/src/app/zeko/tests/ethereum_bridge_vectors.ml
@@ -1059,10 +1059,130 @@ let erc20_withdrawal_params_fields () =
   in
   (params_fields, withdrawal_aux)
 
+let run_erc20_withdrawal_action_with_recipient recipient =
+  let open Mina_base in
+  let open Snark_params.Tick in
+  let chain = Mina_signature_kind.Testnet in
+  let token_owner =
+    Account_id.create (point_of_string "344213") Token_id.default
+  in
+  let token_id = Account_id.derive_token_id ~owner:token_owner in
+  let withdrawal_amount = amount "2000000" in
+  let debit =
+    Account_update.with_aux
+      ~body:
+        { Account_update.Body.dummy with
+          public_key = point_of_string "98881"
+        ; token_id
+        ; balance_change =
+            Currency.Amount.Signed.(of_unsigned withdrawal_amount |> negate)
+        ; may_use_token = Parents_own_token
+        ; authorization_kind = Signature
+        ; use_full_commitment = true
+        }
+      ~authorization:Control.Poly.None_given
+  in
+  let params : Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token.t =
+    { encoding_version = Zeko_circuits.Zeko_util.Checked32.of_int 2
+    ; registry_index = first_registered_asset.registry_index
+    ; record_commitment =
+        Zeko_circuits.Asset_registry.Asset_record.commitment
+          first_registered_asset
+    ; asset_id_high = first_registered_asset.asset_id_high
+    ; asset_id_low = first_registered_asset.asset_id_low
+    ; custom =
+        { token_owner_body =
+            { Account_update.Body.dummy with
+              public_key = Account_id.public_key token_owner
+            ; token_id = Account_id.token_id token_owner
+            ; authorization_kind = Proof Field.one
+            }
+        ; nested_children =
+            Zkapp_command.Call_forest.cons ~signature_kind:chain debit []
+        ; base = { children = []; amount = withdrawal_amount; recipient }
+        }
+    }
+  in
+  run_and_check_exn
+    (let%bind.Checked params =
+       exists
+         Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token.typ
+         ~compute:(fun _ -> params)
+     in
+     let%map.Checked _action =
+       make_checked (fun () ->
+           Run.run_checked
+             (Zeko_circuits.Bridge_state.withdrawal_action ~chain_l2:chain
+                ~holder_account_l2:first_registered_asset.vault_public_key
+                ~token_owner_l2:(Some token_owner)
+                ~ethereum_asset_id:
+                  (Some
+                     ( first_registered_asset.asset_id_high
+                     , first_registered_asset.asset_id_low ) )
+                ~ethereum_registry_binding:
+                  (Some
+                     ( first_registered_asset.registry_index
+                     , Zeko_circuits.Asset_registry.Asset_record.commitment
+                         first_registered_asset ) )
+                ~l2_holder_vk_hash:(constant Field.typ Field.one)
+                ~bridge_fee_recipient_l2:
+                  (constant PC.typ (point_of_string "98882"))
+                ~bridge_proof_fee:
+                  (constant Currency.Amount.typ Currency.Amount.zero)
+                ( module Zeko_circuits.Bridge_state
+                         .Withdrawal_params_ethereum_token )
+                params ) )
+     in
+     As_prover.return () )
+
+let registry_count_update_command () =
+  let open Mina_base in
+  let app_state =
+    List.init 8 ~f:(fun index ->
+        if Int.equal index 1 then Zkapp_basic.Set_or_keep.Set Field.one
+        else Zkapp_basic.Set_or_keep.Keep )
+    |> Zkapp_state.V.of_list_exn
+  in
+  let update =
+    Account_update.with_aux
+      ~body:
+        { Account_update.Body.dummy with
+          public_key =
+            Zeko_circuits_config.Inputs.Ethereum_assets.registry_public_key
+        ; update = { Account_update.Update.dummy with app_state }
+        }
+      ~authorization:Control.Poly.None_given
+  in
+  User_command.Zkapp_command
+    { fee_payer =
+        Account_update.Fee_payer.make
+          ~body:Account_update.Body.Fee_payer.dummy
+          ~authorization:Signature.dummy
+    ; account_updates =
+        Zkapp_command.Call_forest.cons
+          ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 update []
+    ; memo = Signed_command_memo.empty
+    }
+
 let () =
   let packed_x = String.make 63 '0' ^ "1" in
   let even_key : PC.t = { x = Field.one; is_odd = false } in
   let odd_key : PC.t = { x = Field.one; is_odd = true } in
+  let checkpoint_state : Zeko_circuits.Asset_registry.Registry_state.t =
+    { root = Field.of_int 17
+    ; leaf_count = Zeko_circuits.Zeko_util.Checked32.of_int 3
+    ; schema_version =
+        Zeko_circuits.Zeko_util.Checked32.of_int
+          Zeko_constants.Ethereum_asset_registry.schema_version
+    }
+  in
+  if
+    Field.equal
+      (Zeko_circuits.Asset_registry.Checkpoint.commitment
+         ~registry_public_key:even_key checkpoint_state )
+      (Zeko_circuits.Asset_registry.Checkpoint.commitment
+         ~registry_public_key:odd_key checkpoint_state )
+  then failwith "registry checkpoint collides for opposite key parity" ;
   if
     not
       (String.equal
@@ -1076,6 +1196,45 @@ let () =
          (Sequencer_lib.Ethereum_settlement_export.packed_public_key_hex odd_key)
          ("0x8" ^ String.drop_prefix packed_x 1) )
   then failwith "odd Mina public-key settlement packing mismatch" ;
+  Zeko_circuits.Bridge_state.Ethereum_address.validate even_key
+  |> Or_error.ok_exn ;
+  let oversized_key : PC.t =
+    { x = Field.of_bits (List.init 161 ~f:(Int.equal 160)); is_odd = false }
+  in
+  List.iter [ odd_key; oversized_key ] ~f:(fun recipient ->
+      if
+        Result.is_ok
+          (Zeko_circuits.Bridge_state.Ethereum_address.validate recipient)
+      then failwith "invalid Ethereum withdrawal recipient was accepted" ;
+      if
+        Result.is_ok
+          (Or_error.try_with (fun () ->
+               run_erc20_withdrawal_action_with_recipient recipient ) )
+      then
+        failwith
+          "ERC20 withdrawal circuit accepted an invalid Ethereum recipient" ) ;
+  run_erc20_withdrawal_action_with_recipient
+    ({ x = Field.of_int 0x01020304; is_odd = false } : PC.t) ;
+  let module Admission =
+    Sequencer_lib.Zeko_sequencer.Sequencer.Ethereum_asset_registry_admission
+  in
+  if
+    not
+      (Admission.command_updates_count_for_account
+         ~registry_id:(Admission.account_id ())
+         (registry_count_update_command ()) )
+  then failwith "registry count update escaped common admission detection" ;
+  Admission.validate_counts ~committed_count:0 ~current_count:0
+    ~updates_registry_count:true
+  |> Or_error.ok_exn ;
+  if
+    Result.is_ok
+      (Admission.validate_counts ~committed_count:0 ~current_count:1
+         ~updates_registry_count:true )
+  then failwith "second pending registry registration was accepted" ;
+  Admission.validate_counts ~committed_count:1 ~current_count:1
+    ~updates_registry_count:true
+  |> Or_error.ok_exn ;
   let expected_registry_permissions : Mina_base.Permissions.t =
     { Sequencer_lib.Deploy.Z.proof_permissions with access = None }
   in
@@ -1126,8 +1285,7 @@ let () =
       Sequencer_lib.Ethereum_settlement_export.ethereum_withdrawal_preimage_json
         token_preimage
     with
-  | Some
-      ( "tokenWithdrawal"
+  | ( "tokenWithdrawal"
       , `Assoc
           [ ("token", `String "0x0000000000000000000000000000000000000001")
           ; ( "assetId"
@@ -1142,6 +1300,14 @@ let () =
       ()
   | _ ->
       failwith "Ethereum ERC20 withdrawal export mismatch" ) ;
+  if
+    Result.is_ok
+      (Or_error.try_with (fun () ->
+           Sequencer_lib.Ethereum_settlement_export
+           .ethereum_withdrawal_preimage_json
+             { token_preimage with recipient = odd_key }
+           |> ignore ) )
+  then failwith "invalid withdrawal recipient was silently omitted" ;
   let vectors =
     [ ( "1000000000"
       , "16909060"

--- a/src/app/zeko/tests/ethereum_bridge_vectors.ml
+++ b/src/app/zeko/tests/ethereum_bridge_vectors.ml
@@ -1135,12 +1135,13 @@ let run_erc20_withdrawal_action_with_recipient recipient =
      in
      As_prover.return () )
 
-let run_native_withdrawal_action_with_recipient ~recipient_domain recipient =
+let run_native_withdrawal_action_with_recipient ~recipient_domain:domain
+    recipient =
   let open Snark_params.Tick in
   let module Withdrawal_params = struct
     include Zeko_circuits.Bridge_state.Withdrawal_params_base
 
-    let recipient_domain = recipient_domain
+    let recipient_domain = domain
   end in
   let params : Withdrawal_params.t =
     { children = []; amount = amount "2000000"; recipient }
@@ -1235,7 +1236,7 @@ let run_legacy_erc20_withdrawal_action_with_recipient recipient =
      in
      As_prover.return () )
 
-let registry_count_update_command ?(updates = 1) () =
+let registry_count_update_command ?(updates = 1) () : Mina_base.User_command.t =
   let open Mina_base in
   let app_state =
     List.init 8 ~f:(fun index ->
@@ -1302,7 +1303,7 @@ let () =
   Zeko_circuits.Bridge_state.Ethereum_address.validate even_key
   |> Or_error.ok_exn ;
   let oversized_key : PC.t =
-    { x = Field.of_bits (List.init 161 ~f:(Int.equal 160)); is_odd = false }
+    { x = Field.project (List.init 161 ~f:(Int.equal 160)); is_odd = false }
   in
   let assert_recipient_rejected label f =
     if Result.is_ok (Or_error.try_with f) then
@@ -1436,10 +1437,11 @@ let () =
   if
     Result.is_ok
       (Or_error.try_with (fun () ->
-           Sequencer_lib.Ethereum_settlement_export
-           .ethereum_withdrawal_preimage_json
-             { token_preimage with recipient = odd_key }
-           |> ignore ) )
+           ignore
+             ( Sequencer_lib.Ethereum_settlement_export
+               .ethereum_withdrawal_preimage_json
+                 { token_preimage with recipient = odd_key }
+               : string * Yojson.Safe.t ) ) )
   then failwith "invalid withdrawal recipient was silently omitted" ;
   let vectors =
     [ ( "1000000000"

--- a/src/app/zeko/tests/ethereum_bridge_vectors.ml
+++ b/src/app/zeko/tests/ethereum_bridge_vectors.ml
@@ -318,9 +318,13 @@ let erc20_withdrawal_params_fields () =
     }
   in
   let custom : Zeko_circuits.Bridge_state.Withdrawal_params_custom.t =
-    { authorization_kind = Proof Field.one
+    { token_owner_body =
+        { Account_update.Body.dummy with
+          public_key = Account_id.public_key token_owner
+        ; token_id = Account_id.token_id token_owner
+        ; authorization_kind = Proof Field.one
+        }
     ; nested_children = debit_forest
-    ; call_data = Field.zero
     ; base
     }
   in
@@ -360,8 +364,10 @@ let () =
   if
     not
       (String.equal withdrawal_aux
-         "24c550ad1d37bd8711148b1b4ad5f1724c521a62aec4b978a1a19a7629bd59cf" )
-  then failwith "Ethereum ERC20 withdrawal circuit/settlement aux mismatch" ;
+         "350ed8b22bbaac628364ea5d8ee44a8f12d7814dc9c1432264ece93ccd5b364d" )
+  then
+    failwithf "Ethereum ERC20 withdrawal circuit/settlement aux mismatch: %s"
+      withdrawal_aux () ;
   let token_preimage : Sequencer_lib.Archive.Ethereum_withdrawal.t =
     { recipient = { x = Field.of_int 0x01020304; is_odd = false }
     ; amount = amount "2000000"

--- a/src/app/zeko/tests/ethereum_bridge_vectors.ml
+++ b/src/app/zeko/tests/ethereum_bridge_vectors.ml
@@ -441,6 +441,11 @@ let erc20_withdrawal_params_fields () =
     failwith "Ethereum ERC20 withdrawal vault charges an account-creation fee" ;
   if not (Token_id.equal vault_body.token_id first_registered_asset.token_id_l2)
   then failwith "Ethereum ERC20 withdrawal used the wrong registered token" ;
+  if
+    not
+      (String.equal (field_to_hex vault_body.call_data)
+         "19a86bb8c106848e3bab8dd79491cbc4589f28b33227007eb60409efa56e12d0" )
+  then failwith "Ethereum ERC20 bridge call-data vector mismatch" ;
   ( match Zkapp_command.Call_forest.to_account_updates registry_calls with
   | [ registry ] ->
       if

--- a/src/app/zeko/tests/ethereum_bridge_vectors.ml
+++ b/src/app/zeko/tests/ethereum_bridge_vectors.ml
@@ -1135,7 +1135,107 @@ let run_erc20_withdrawal_action_with_recipient recipient =
      in
      As_prover.return () )
 
-let registry_count_update_command () =
+let run_native_withdrawal_action_with_recipient ~recipient_domain recipient =
+  let open Snark_params.Tick in
+  let module Withdrawal_params = struct
+    include Zeko_circuits.Bridge_state.Withdrawal_params_base
+
+    let recipient_domain = recipient_domain
+  end in
+  let params : Withdrawal_params.t =
+    { children = []; amount = amount "2000000"; recipient }
+  in
+  run_and_check_exn
+    (let%bind.Checked params =
+       exists Withdrawal_params.typ ~compute:(fun _ -> params)
+     in
+     let%map.Checked _action =
+       make_checked (fun () ->
+           Run.run_checked
+             (Zeko_circuits.Bridge_state.withdrawal_action
+                ~chain_l2:Mina_signature_kind.Testnet
+                ~holder_account_l2:(point_of_string "98883")
+                ~token_owner_l2:None ~ethereum_asset_id:None
+                ~ethereum_registry_binding:None
+                ~l2_holder_vk_hash:(constant Field.typ Field.one)
+                ~bridge_fee_recipient_l2:
+                  (constant PC.typ (point_of_string "98884"))
+                ~bridge_proof_fee:
+                  (constant Currency.Amount.typ Currency.Amount.zero)
+                (module Withdrawal_params)
+                params ) )
+     in
+     As_prover.return () )
+
+let run_legacy_erc20_withdrawal_action_with_recipient recipient =
+  let open Mina_base in
+  let open Snark_params.Tick in
+  let chain = Mina_signature_kind.Testnet in
+  let token_owner =
+    Account_id.create (point_of_string "344213") Token_id.default
+  in
+  let token_id = Account_id.derive_token_id ~owner:token_owner in
+  let withdrawal_amount = amount "2000000" in
+  let debit =
+    Account_update.with_aux
+      ~body:
+        { Account_update.Body.dummy with
+          public_key = point_of_string "98881"
+        ; token_id
+        ; balance_change =
+            Currency.Amount.Signed.(of_unsigned withdrawal_amount |> negate)
+        ; may_use_token = Parents_own_token
+        ; authorization_kind = Signature
+        ; use_full_commitment = true
+        }
+      ~authorization:Control.Poly.None_given
+  in
+  let params :
+      Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token_v1.t =
+    { asset_id_high = first_registered_asset.asset_id_high
+    ; asset_id_low = first_registered_asset.asset_id_low
+    ; custom =
+        { token_owner_body =
+            { Account_update.Body.dummy with
+              public_key = Account_id.public_key token_owner
+            ; token_id = Account_id.token_id token_owner
+            ; authorization_kind = Proof Field.one
+            }
+        ; nested_children =
+            Zkapp_command.Call_forest.cons ~signature_kind:chain debit []
+        ; base = { children = []; amount = withdrawal_amount; recipient }
+        }
+    }
+  in
+  run_and_check_exn
+    (let%bind.Checked params =
+       exists
+         Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token_v1.typ
+         ~compute:(fun _ -> params)
+     in
+     let%map.Checked _action =
+       make_checked (fun () ->
+           Run.run_checked
+             (Zeko_circuits.Bridge_state.withdrawal_action ~chain_l2:chain
+                ~holder_account_l2:first_registered_asset.vault_public_key
+                ~token_owner_l2:(Some token_owner)
+                ~ethereum_asset_id:
+                  (Some
+                     ( first_registered_asset.asset_id_high
+                     , first_registered_asset.asset_id_low ) )
+                ~ethereum_registry_binding:None
+                ~l2_holder_vk_hash:(constant Field.typ Field.one)
+                ~bridge_fee_recipient_l2:
+                  (constant PC.typ (point_of_string "98882"))
+                ~bridge_proof_fee:
+                  (constant Currency.Amount.typ Currency.Amount.zero)
+                ( module Zeko_circuits.Bridge_state
+                         .Withdrawal_params_ethereum_token_v1 )
+                params ) )
+     in
+     As_prover.return () )
+
+let registry_count_update_command ?(updates = 1) () =
   let open Mina_base in
   let app_state =
     List.init 8 ~f:(fun index ->
@@ -1143,24 +1243,27 @@ let registry_count_update_command () =
         else Zkapp_basic.Set_or_keep.Keep )
     |> Zkapp_state.V.of_list_exn
   in
-  let update =
-    Account_update.with_aux
-      ~body:
-        { Account_update.Body.dummy with
-          public_key =
-            Zeko_circuits_config.Inputs.Ethereum_assets.registry_public_key
-        ; update = { Account_update.Update.dummy with app_state }
-        }
-      ~authorization:Control.Poly.None_given
+  let account_updates =
+    List.init updates ~f:(fun _ ->
+        Account_update.with_aux
+          ~body:
+            { Account_update.Body.dummy with
+              public_key =
+                Zeko_circuits_config.Inputs.Ethereum_assets.registry_public_key
+            ; update = { Account_update.Update.dummy with app_state }
+            }
+          ~authorization:Control.Poly.None_given )
+    |> List.fold_right ~init:[] ~f:(fun update forest ->
+           Zkapp_command.Call_forest.cons
+             ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 update forest
+       )
   in
   User_command.Zkapp_command
     { fee_payer =
         Account_update.Fee_payer.make
           ~body:Account_update.Body.Fee_payer.dummy
           ~authorization:Signature.dummy
-    ; account_updates =
-        Zkapp_command.Call_forest.cons
-          ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 update []
+    ; account_updates
     ; memo = Signed_command_memo.empty
     }
 
@@ -1201,39 +1304,69 @@ let () =
   let oversized_key : PC.t =
     { x = Field.of_bits (List.init 161 ~f:(Int.equal 160)); is_odd = false }
   in
+  let assert_recipient_rejected label f =
+    if Result.is_ok (Or_error.try_with f) then
+      failwithf "%s accepted an invalid Ethereum recipient" label ()
+  in
   List.iter [ odd_key; oversized_key ] ~f:(fun recipient ->
       if
         Result.is_ok
           (Zeko_circuits.Bridge_state.Ethereum_address.validate recipient)
       then failwith "invalid Ethereum withdrawal recipient was accepted" ;
-      if
-        Result.is_ok
-          (Or_error.try_with (fun () ->
-               run_erc20_withdrawal_action_with_recipient recipient ) )
-      then
-        failwith
-          "ERC20 withdrawal circuit accepted an invalid Ethereum recipient" ) ;
-  run_erc20_withdrawal_action_with_recipient
-    ({ x = Field.of_int 0x01020304; is_odd = false } : PC.t) ;
+      assert_recipient_rejected "registry V2 withdrawal circuit" (fun () ->
+          run_erc20_withdrawal_action_with_recipient recipient ) ;
+      assert_recipient_rejected "legacy V1 withdrawal circuit" (fun () ->
+          run_legacy_erc20_withdrawal_action_with_recipient recipient ) ;
+      assert_recipient_rejected "native Ethereum withdrawal circuit" (fun () ->
+          run_native_withdrawal_action_with_recipient
+            ~recipient_domain:
+              Zeko_circuits.Bridge_state.Withdrawal_recipient_domain.Ethereum
+            recipient ) ;
+      run_native_withdrawal_action_with_recipient
+        ~recipient_domain:
+          Zeko_circuits.Bridge_state.Withdrawal_recipient_domain.Mina
+        recipient ) ;
+  let valid_ethereum_key : PC.t =
+    { x = Field.of_int 0x01020304; is_odd = false }
+  in
+  run_erc20_withdrawal_action_with_recipient valid_ethereum_key ;
+  run_legacy_erc20_withdrawal_action_with_recipient valid_ethereum_key ;
+  run_native_withdrawal_action_with_recipient
+    ~recipient_domain:
+      Zeko_circuits.Bridge_state.Withdrawal_recipient_domain.Ethereum
+    valid_ethereum_key ;
   let module Admission =
     Sequencer_lib.Zeko_sequencer.Sequencer.Ethereum_asset_registry_admission
   in
+  let single_update_count =
+    Admission.count_command_updates_for_account
+      ~registry_id:(Admission.account_id ())
+      (registry_count_update_command ())
+  in
+  let batched_update_count =
+    Admission.count_command_updates_for_account
+      ~registry_id:(Admission.account_id ())
+      (registry_count_update_command ~updates:2 ())
+  in
+  if not (Int.equal single_update_count 1)
+  then failwith "registry count update escaped common admission counting" ;
+  if not (Int.equal batched_update_count 2)
+  then failwith "batched registry count updates collapsed during admission" ;
   if
-    not
-      (Admission.command_updates_count_for_account
-         ~registry_id:(Admission.account_id ())
-         (registry_count_update_command ()) )
-  then failwith "registry count update escaped common admission detection" ;
+    Result.is_ok
+      (Admission.validate_counts ~committed_count:0 ~current_count:0
+         ~registry_update_count:batched_update_count )
+  then failwith "two registry updates in one command were accepted" ;
   Admission.validate_counts ~committed_count:0 ~current_count:0
-    ~updates_registry_count:true
+    ~registry_update_count:single_update_count
   |> Or_error.ok_exn ;
   if
     Result.is_ok
       (Admission.validate_counts ~committed_count:0 ~current_count:1
-         ~updates_registry_count:true )
+         ~registry_update_count:single_update_count )
   then failwith "second pending registry registration was accepted" ;
   Admission.validate_counts ~committed_count:1 ~current_count:1
-    ~updates_registry_count:true
+    ~registry_update_count:single_update_count
   |> Or_error.ok_exn ;
   let expected_registry_permissions : Mina_base.Permissions.t =
     { Sequencer_lib.Deploy.Z.proof_permissions with access = None }

--- a/src/app/zeko/tests/ethereum_bridge_vectors.ml
+++ b/src/app/zeko/tests/ethereum_bridge_vectors.ml
@@ -51,7 +51,7 @@ let point_of_string value =
     to_affine_exn @@ point_near_x @@ Field.of_string value)
   |> Signature_lib.Public_key.compress
 
-let erc20_deposit_params () =
+let erc20_deposit_params ?(asset_id_low = Field.of_int 2) () =
   let base : Zeko_circuits.Bridge_state.Deposit_params_base.t =
     { children = []
     ; holder_account_l1 = ({ x = Field.one; is_odd = false } : PC.t)
@@ -60,7 +60,7 @@ let erc20_deposit_params () =
     ; timeout = Mina_numbers.Global_slot_since_genesis.max_value
     }
   in
-  ( { asset_id_high = Field.one; asset_id_low = Field.of_int 2; base }
+  ( { asset_id_high = Field.one; asset_id_low; base }
     : Zeko_circuits.Bridge_state.Deposit_params_ethereum_token.t )
 
 let run_erc20_deposit_action ~expected_asset_low =
@@ -109,21 +109,23 @@ let check_erc20_deposit_witness_action () =
   then failwith "Ethereum ERC20 deposit circuit accepted the wrong asset"
 
 module Ethereum_token_bridge =
-  Zeko_circuits.Bridge_rules.Make_ethereum_token
+  Zeko_circuits.Bridge_rules.Make_ethereum_assets
     (struct
-      let token_owner_l2 =
-        Mina_base.Account_id.create (point_of_string "344213")
-          Mina_base.Token_id.default
+      let registry_public_key = point_of_string "22222"
+
+      let registry_schema_version =
+        Zeko_circuits.Zeko_util.Checked32.of_int
+          Zeko_constants.Ethereum_asset_registry.schema_version
+
+      let approved_mft_standard_vk_id = Field.of_int 777
+
+      let universal_bridge_vk_id = Field.of_int 778
+
+      let vault_public_key = point_of_string "11111"
 
       let ethereum_holder_account_l1 : PC.t = { x = Field.one; is_odd = false }
 
-      let ethereum_asset_id_high = Field.one
-
-      let ethereum_asset_id_low = Field.of_int 2
-
       let zeko_l2 = point_of_string "39921"
-
-      let holder_account_l2 = point_of_string "11111"
 
       let bridge_fee_recipient_l1 = point_of_string "765431"
 
@@ -138,11 +140,79 @@ module Ethereum_token_bridge =
     end)
     ()
 
-let check_erc20_finalize_deposit () =
+let registered_asset index token_owner_l2 asset_id_low =
+  let open Mina_base in
+  let owner = Account_id.create token_owner_l2 Token_id.default in
+  ({ schema_version =
+       Zeko_circuits.Zeko_util.Checked32.of_int
+         Zeko_constants.Ethereum_asset_registry.schema_version
+   ; registry_index = Zeko_circuits.Zeko_util.Checked32.of_int index
+   ; asset_id_high = Field.one
+   ; asset_id_low
+   ; ethereum_token_address = Field.of_int (5000 + index)
+   ; token_owner_l2
+   ; token_id_l2 = Account_id.derive_token_id ~owner
+   ; decimals = Zeko_circuits.Zeko_util.Checked32.of_int 6
+   ; inventory_cap = amount "100000000"
+   ; mft_standard_vk_id = Field.of_int 777
+   ; vault_public_key = point_of_string "11111"
+   ; universal_bridge_vk_id = Field.of_int 778
+   } :
+    Zeko_circuits.Asset_registry.Asset_record.t )
+
+let first_registered_asset =
+  registered_asset 0 (point_of_string "344213") (Field.of_int 2)
+
+let first_registry_tree =
+  Zeko_circuits.Asset_registry.Merkle_list.empty ()
+  |> fun tree ->
+  Zeko_circuits.Asset_registry.Merkle_list.append_exn tree
+    first_registered_asset
+
+let first_membership : Ethereum_token_bridge.Registry.Membership_witness.t =
+  { state =
+      { root =
+          Zeko_circuits.Asset_registry.Merkle_list.root first_registry_tree
+      ; leaf_count = Zeko_circuits.Zeko_util.Checked32.one
+      ; schema_version =
+          Zeko_circuits.Zeko_util.Checked32.of_int
+            Zeko_constants.Ethereum_asset_registry.schema_version
+      }
+  ; record = first_registered_asset
+  ; path =
+      Zeko_circuits.Asset_registry.Merkle_list.path first_registry_tree ~index:0
+  }
+
+let second_registered_asset =
+  registered_asset 1 (point_of_string "344214") (Field.of_int 3)
+
+let second_registry_tree =
+  Zeko_circuits.Asset_registry.Merkle_list.append_exn first_registry_tree
+    second_registered_asset
+
+let second_membership : Ethereum_token_bridge.Registry.Membership_witness.t =
+  { state =
+      { root =
+          Zeko_circuits.Asset_registry.Merkle_list.root second_registry_tree
+      ; leaf_count = Zeko_circuits.Zeko_util.Checked32.of_int 2
+      ; schema_version =
+          Zeko_circuits.Zeko_util.Checked32.of_int
+            Zeko_constants.Ethereum_asset_registry.schema_version
+      }
+  ; record = second_registered_asset
+  ; path =
+      Zeko_circuits.Asset_registry.Merkle_list.path second_registry_tree ~index:1
+  }
+
+let check_erc20_finalize_deposit
+    ~(membership : Ethereum_token_bridge.Registry.Membership_witness.t) =
   let open Mina_base in
   let open Zeko_circuits in
   let open Zeko_util in
-  let params = erc20_deposit_params () in
+  let registered_asset = membership.record in
+  let params =
+    erc20_deposit_params ~asset_id_low:registered_asset.asset_id_low ()
+  in
   let base = params.base in
   let witness : Rollup_state.Outer_action.Witness.t =
     { aux =
@@ -235,8 +305,9 @@ let check_erc20_finalize_deposit () =
     Promise.block_on_async_exn
     @@ fun () ->
     finalize_deposit
-      { public_key = point_of_string "11111"
+      { public_key = registered_asset.vault_public_key
       ; vk_hash
+      ; asset = membership
       ; may_use_token = Parents_own_token
       ; inner_authorization_kind = Rule_bridge_finalize_deposit.A.None_given
       ; ase =
@@ -249,10 +320,7 @@ let check_erc20_finalize_deposit () =
       ; helper_account_new = true
       }
   in
-  let token_owner =
-    Account_id.create (point_of_string "344213") Token_id.default
-  in
-  let token_id = Account_id.derive_token_id ~owner:token_owner in
+  let token_id = registered_asset.token_id_l2 in
   if not (Token_id.equal vault.token_id token_id) then
     failwith "Ethereum ERC20 deposit debited the wrong vault token" ;
   if
@@ -263,7 +331,15 @@ let check_erc20_finalize_deposit () =
   if vault.implicit_account_creation_fee then
     failwith "Ethereum ERC20 vault charged an implicit MINA fee" ;
   match Zkapp_command.Call_forest.to_account_updates calls with
-  | [ _helper; _inner_witness; recipient; zero_fee ] ->
+  | [ helper; _inner_witness; recipient; zero_fee; registry ] ->
+      let expected_helper_token =
+        Account_id.create registered_asset.vault_public_key token_id
+        |> fun owner -> Account_id.derive_token_id ~owner
+      in
+      if not (Token_id.equal helper.body.token_id expected_helper_token) then
+        failwith
+          "Ethereum ERC20 replay helper did not derive from the full vault \
+           account ID" ;
       if not (Token_id.equal recipient.body.token_id token_id) then
         failwith "Ethereum ERC20 deposit credited the wrong token" ;
       if
@@ -282,7 +358,12 @@ let check_erc20_finalize_deposit () =
         not
           (Currency.Amount.Signed.equal zero_fee.body.balance_change
              Currency.Amount.Signed.zero )
-      then failwith "Ethereum ERC20 circuit emitted a token-denominated fee"
+      then failwith "Ethereum ERC20 circuit emitted a token-denominated fee" ;
+      if
+        not
+          (PC.equal registry.body.public_key (point_of_string "22222"))
+      then failwith "Ethereum ERC20 circuit did not authenticate the registry" ;
+      helper.body.token_id
   | _ ->
       failwith "Ethereum ERC20 finalize-deposit forest shape mismatch"
 
@@ -333,57 +414,33 @@ let erc20_withdrawal_params_fields () =
   let params : Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token.t =
     { asset_id_high = Field.one; asset_id_low = Field.of_int 2; custom }
   in
-  let configured_token_owner =
-    Zeko_circuits_config.Inputs.Ethereum_token.token_owner_l2
+  let Compile_simple.[ _finalize; inner_receive; _multisig ] =
+    Lazy.force Ethereum_token_bridge.System_L2.provers
   in
-  let configured_debit =
-    Account_update.with_aux
-      ~body:
-        { debit_body with
-          token_id = Account_id.derive_token_id ~owner:configured_token_owner
-        }
-      ~authorization:Control.Poly.None_given
-  in
-  let precompute_params :
-      Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token.t =
-    { Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token.asset_id_high =
-        Zeko_circuits_config.Inputs.Ethereum_token.ethereum_asset_id_high
-    ; asset_id_low =
-        Zeko_circuits_config.Inputs.Ethereum_token.ethereum_asset_id_low
-    ; custom =
-        { custom with
-          token_owner_body =
-            { custom.token_owner_body with
-              public_key = Account_id.public_key configured_token_owner
-            ; token_id = Account_id.token_id configured_token_owner
-            }
-        ; nested_children =
-            Zkapp_command.Call_forest.cons
-              ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
-              configured_debit []
-        }
-    }
-  in
-  let precomputed : Sequencer_lib.Bridge_prover.precomputed_forest =
-    Sequencer_lib.Bridge_prover.Ethereum_token_withdrawal_request
-    .precompute_forest_with_vk_hashes
-      ~bridge_ethereum_token_l2_vk_hash:Field.one
-      ~inner_rules_vk_hash:(Field.of_int 2) precompute_params
-    |> Or_error.ok_exn
-  in
-  ( match precomputed with
-  | [ { elt = { calls = { elt = { calls = [ _debit; vault ]; _ }; _ } :: _; _ }
-      ; _
+  let (_statement, (vault_body, _digest, registry_calls)), _proof =
+    Promise.block_on_async_exn
+    @@ fun () ->
+    inner_receive
+      { public_key = first_registered_asset.vault_public_key
+      ; vk_hash = Field.one
+      ; asset = first_membership
+      ; amount = withdrawal_amount
       }
-    ] ->
-      let vault_body = vault.elt.account_update.body in
-      if vault_body.use_full_commitment then
-        failwith "Ethereum ERC20 withdrawal vault uses the full commitment" ;
-      if vault_body.implicit_account_creation_fee then
-        failwith
-          "Ethereum ERC20 withdrawal vault charges an account-creation fee"
+  in
+  if vault_body.use_full_commitment then
+    failwith "Ethereum ERC20 withdrawal vault uses the full commitment" ;
+  if vault_body.implicit_account_creation_fee then
+    failwith "Ethereum ERC20 withdrawal vault charges an account-creation fee" ;
+  if not (Token_id.equal vault_body.token_id first_registered_asset.token_id_l2)
+  then failwith "Ethereum ERC20 withdrawal used the wrong registered token" ;
+  ( match Zkapp_command.Call_forest.to_account_updates registry_calls with
+  | [ registry ] ->
+      if
+        not
+          (PC.equal registry.body.public_key (point_of_string "22222"))
+      then failwith "Ethereum ERC20 withdrawal did not authenticate the registry"
   | _ ->
-      failwith "unexpected ERC20 precomputed forest" ) ;
+      failwith "unexpected ERC20 registry precondition forest" ) ;
   let params_fields =
     Utils.value_to_fields
       Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token.typ params
@@ -410,7 +467,14 @@ let () =
     Lazy.force Ethereum_token_bridge.System_L2.provers
   in
   check_erc20_deposit_witness_action () ;
-  check_erc20_finalize_deposit () ;
+  let first_helper_token =
+    check_erc20_finalize_deposit ~membership:first_membership
+  in
+  let second_helper_token =
+    check_erc20_finalize_deposit ~membership:second_membership
+  in
+  if Mina_base.Token_id.equal first_helper_token second_helper_token then
+    failwith "distinct registered assets reused a replay-helper token ID" ;
   let withdrawal_params_fields, withdrawal_aux =
     erc20_withdrawal_params_fields ()
   in

--- a/src/app/zeko/tests/ethereum_bridge_vectors.ml
+++ b/src/app/zeko/tests/ethereum_bridge_vectors.ml
@@ -363,6 +363,14 @@ let check_erc20_finalize_deposit
         not
           (PC.equal registry.body.public_key (point_of_string "22222"))
       then failwith "Ethereum ERC20 circuit did not authenticate the registry" ;
+      if
+        not
+          (Mina_base.Account_update.Authorization_kind.equal
+             registry.body.authorization_kind None_given )
+      then
+        failwith
+          "Ethereum ERC20 registry precondition unexpectedly requires \
+           authorization" ;
       helper.body.token_id
   | _ ->
       failwith "Ethereum ERC20 finalize-deposit forest shape mismatch"
@@ -463,6 +471,17 @@ let erc20_withdrawal_params_fields () =
   (params_fields, withdrawal_aux)
 
 let () =
+  let expected_registry_permissions : Mina_base.Permissions.t =
+    { Sequencer_lib.Deploy.Z.proof_permissions with access = None }
+  in
+  if
+    not
+      (Mina_base.Permissions.equal
+         Sequencer_lib.Deploy.Z.proof_permissions_with_unconditional_access
+         expected_registry_permissions )
+  then
+    failwith
+      "Ethereum asset registry permissions reject precondition-only access" ;
   let Compile_simple.[ _; _; _ ] =
     Lazy.force Ethereum_token_bridge.System_L2.provers
   in

--- a/src/app/zeko/tests/ethereum_bridge_vectors.ml
+++ b/src/app/zeko/tests/ethereum_bridge_vectors.ml
@@ -369,11 +369,11 @@ let make_commit_accounts mutation
         ]
   in
   let admin_zkapp =
+    let revoked_authority = PC.empty in
     zkapp_with_vk ~vk_hash:commit_vk_hash
       ~app_state:
-        [ commit_registration_authority.x
-        ; ( if commit_registration_authority.is_odd then Field.one
-          else Field.zero )
+        [ revoked_authority.x
+        ; (if revoked_authority.is_odd then Field.one else Field.zero)
         ; Field.zero
         ; Field.zero
         ; Field.zero
@@ -468,7 +468,7 @@ let make_commit_accounts mutation
       let bad_admin_zkapp =
         zkapp_with_vk ~vk_hash:commit_vk_hash
           ~app_state:
-            [ Field.(commit_registration_authority.x + one)
+            [ commit_registration_authority.x
             ; ( if commit_registration_authority.is_odd then Field.one
               else Field.zero )
             ; Field.zero
@@ -741,7 +741,7 @@ let check_commit_registration_constraints () =
     ; ("wrong token admin ID", Wrong_admin_id)
     ; ("wrong token admin VK", Wrong_admin_vk)
     ; ("wrong token admin permissions", Wrong_admin_permissions)
-    ; ("wrong token admin authority", Wrong_admin_authority)
+    ; ("live registration signer as token admin", Wrong_admin_authority)
     ; ("wrong vault ID", Wrong_vault_id)
     ; ("wrong vault VK", Wrong_vault_vk)
     ; ("wrong vault permissions", Wrong_vault_permissions)

--- a/src/app/zeko/tests/ethereum_bridge_vectors.ml
+++ b/src/app/zeko/tests/ethereum_bridge_vectors.ml
@@ -260,6 +260,8 @@ let check_erc20_finalize_deposit () =
       (Currency.Amount.Signed.equal vault.balance_change
          Currency.Amount.Signed.(of_unsigned base.amount |> negate) )
   then failwith "Ethereum ERC20 deposit vault debit mismatch" ;
+  if vault.implicit_account_creation_fee then
+    failwith "Ethereum ERC20 vault charged an implicit MINA fee" ;
   match Zkapp_command.Call_forest.to_account_updates calls with
   | [ _helper; _inner_witness; recipient; zero_fee ] ->
       if not (Token_id.equal recipient.body.token_id token_id) then

--- a/src/app/zeko/tests/ethereum_bridge_vectors.ml
+++ b/src/app/zeko/tests/ethereum_bridge_vectors.ml
@@ -1,5 +1,4 @@
 open Core
-
 module Field = Snark_params.Tick.Field
 module PC = Signature_lib.Public_key.Compressed
 
@@ -10,8 +9,7 @@ let field_to_hex field =
   |> String.chop_prefix_if_exists ~prefix:"0x"
   |> fun hex -> String.make (64 - String.length hex) '0' ^ hex
 
-let amount value =
-  Unsigned.UInt64.of_string value |> Currency.Amount.of_uint64
+let amount value = Unsigned.UInt64.of_string value |> Currency.Amount.of_uint64
 
 let aux ~amount:value ~recipient_x ~recipient_is_odd =
   let params : Zeko_circuits.Bridge_state.Deposit_params_base.t =
@@ -27,27 +25,402 @@ let aux ~amount:value ~recipient_x ~recipient_is_odd =
     Zeko_circuits.Bridge_state.Deposit_params_base.typ params
   |> field_to_hex
 
+let erc20_aux ~asset_id_high ~asset_id_low ~amount:value ~recipient_x
+    ~recipient_is_odd =
+  let base : Zeko_circuits.Bridge_state.Deposit_params_base.t =
+    { children = []
+    ; holder_account_l1 = ({ x = Field.one; is_odd = false } : PC.t)
+    ; amount = amount value
+    ; recipient =
+        ({ x = Field.of_string recipient_x; is_odd = recipient_is_odd } : PC.t)
+    ; timeout = Mina_numbers.Global_slot_since_genesis.max_value
+    }
+  in
+  let params : Zeko_circuits.Bridge_state.Deposit_params_ethereum_token.t =
+    { asset_id_high = Field.of_string asset_id_high
+    ; asset_id_low = Field.of_string asset_id_low
+    ; base
+    }
+  in
+  Utils.value_to_hash ~init:Zeko_constants.ethereum_erc20_deposit_salt
+    Zeko_circuits.Bridge_state.Deposit_params_ethereum_token.typ params
+  |> field_to_hex
+
+let point_of_string value =
+  Snark_params.Tick.Inner_curve.(
+    to_affine_exn @@ point_near_x @@ Field.of_string value)
+  |> Signature_lib.Public_key.compress
+
+let erc20_deposit_params () =
+  let base : Zeko_circuits.Bridge_state.Deposit_params_base.t =
+    { children = []
+    ; holder_account_l1 = ({ x = Field.one; is_odd = false } : PC.t)
+    ; amount = amount "2000000"
+    ; recipient = ({ x = Field.of_int 0x01020304; is_odd = false } : PC.t)
+    ; timeout = Mina_numbers.Global_slot_since_genesis.max_value
+    }
+  in
+  ( { asset_id_high = Field.one; asset_id_low = Field.of_int 2; base }
+    : Zeko_circuits.Bridge_state.Deposit_params_ethereum_token.t )
+
+let run_erc20_deposit_action ~expected_asset_low =
+  let open Snark_params.Tick in
+  let params = erc20_deposit_params () in
+  run_and_check_exn
+    (let%bind.Checked params =
+       exists Zeko_circuits.Bridge_state.Deposit_params_ethereum_token.typ
+         ~compute:(fun _ -> params)
+     in
+     let%map.Checked action =
+       make_checked (fun () ->
+           Run.run_checked
+             (Zeko_circuits.Bridge_state.deposit_action
+                ~chain_l1:Mina_signature_kind.Testnet ~holder_accounts_l1:[]
+                ~token_owner_l1:None
+                ~ethereum_holder_account_l1:
+                  (Some ({ x = Field.one; is_odd = false } : PC.t))
+                ~ethereum_asset_id:(Some (Field.one, expected_asset_low))
+                (module Zeko_circuits.Bridge_state.Deposit_params_ethereum_token)
+                params
+                ~bridge_fee_recipient_l1:
+                  (constant PC.typ (point_of_string "765431"))
+                ~bridge_proof_fee:
+                  (constant Currency.Amount.typ Currency.Amount.zero) ) )
+     in
+     As_prover.read Zeko_circuits.Rollup_state.Outer_action.Witness.typ action
+    )
+
+let check_erc20_deposit_witness_action () =
+  let witness = run_erc20_deposit_action ~expected_asset_low:(Field.of_int 2) in
+  if
+    not
+      (String.equal (field_to_hex witness.aux)
+         "0fc821581944d768e902d37d6527e3011992e5368fb33dca2f5ccc24a6f417f7" )
+  then failwith "Ethereum ERC20 deposit circuit/SP1 aux mismatch" ;
+  if not (List.is_empty witness.children) then
+    failwith "Ethereum ERC20 witness unexpectedly contains Mina L1 calls" ;
+  if
+    not
+      (Exn.does_raise (fun () ->
+           let (_ : Zeko_circuits.Rollup_state.Outer_action.Witness.t) =
+             run_erc20_deposit_action ~expected_asset_low:(Field.of_int 3)
+           in
+           () ) )
+  then failwith "Ethereum ERC20 deposit circuit accepted the wrong asset"
+
+module Ethereum_token_bridge =
+  Zeko_circuits.Bridge_rules.Make_ethereum_token
+    (struct
+      let token_owner_l2 =
+        Mina_base.Account_id.create (point_of_string "344213")
+          Mina_base.Token_id.default
+
+      let ethereum_holder_account_l1 : PC.t = { x = Field.one; is_odd = false }
+
+      let ethereum_asset_id_high = Field.one
+
+      let ethereum_asset_id_low = Field.of_int 2
+
+      let zeko_l2 = point_of_string "39921"
+
+      let holder_account_l2 = point_of_string "11111"
+
+      let bridge_fee_recipient_l1 = point_of_string "765431"
+
+      let bridge_fee_recipient_l2 = point_of_string "765432"
+
+      let chain_l1 = Mina_signature_kind.Testnet
+
+      let chain_l2 = Mina_signature_kind.Testnet
+
+      let multisig_key : Zeko_circuits.Multisig.t =
+        { public_keys = [ point_of_string "89888" ]; quorum = Field.one }
+    end)
+    ()
+
+let check_erc20_finalize_deposit () =
+  let open Mina_base in
+  let open Zeko_circuits in
+  let open Zeko_util in
+  let params = erc20_deposit_params () in
+  let base = params.base in
+  let witness : Rollup_state.Outer_action.Witness.t =
+    { aux =
+        Utils.value_to_hash ~init:Zeko_constants.ethereum_erc20_deposit_salt
+          Bridge_state.Deposit_params_ethereum_token.typ params
+    ; children = []
+    ; slot_range = Slot_range.infinite
+    }
+  in
+  let original_action_state = Zkapp_account.Actions.empty_state_element in
+  let deposit_action_hash =
+    Zkapp_account.Actions_impl.hash (Utils.witness_to_actions witness)
+  in
+  let mid_outer_action_state =
+    Rollup_state.Outer_action_state.With_length.unsafe_value_of_fields
+      ~state:
+        ( Zkapp_account.Actions_impl.push_hash original_action_state
+            deposit_action_hash
+        |> Rollup_state.Outer_action_state.unsafe_value_of_field )
+      ~length:Checked32.one
+  in
+  let commit_witness : Rollup_state.Outer_action.Commit.t =
+    { ledger = Field.zero
+    ; inner_action_state = Rollup_state.Inner_action_state.With_length.empty
+    ; synchronized_outer_action_state = mid_outer_action_state
+    ; slot_range = { lower = Slot.zero; upper = Slot.of_int 30 }
+    }
+  in
+  let commit_action_hash =
+    Zkapp_account.Actions_impl.hash (Utils.commit_to_actions commit_witness)
+  in
+  let target_outer_action_state =
+    Rollup_state.Outer_action_state.With_length.unsafe_value_of_fields
+      ~state:
+        ( Zkapp_account.Actions_impl.push_hash
+            Rollup_state.Outer_action_state.(
+              With_length.state mid_outer_action_state |> raw)
+            commit_action_hash
+        |> Rollup_state.Outer_action_state.unsafe_value_of_field )
+      ~length:(Checked32.of_int 2)
+  in
+  let check_accepted =
+    let Ethereum_token_bridge.Check_accepted.{ source; target }, proof =
+      Promise.block_on_async_exn
+      @@ fun () ->
+      (Lazy.force Ethereum_token_bridge.Check_accepted.leaf_option)
+        ( [ Commit commit_witness ]
+        , { Ethereum_token_bridge.Check_accepted.Definition.Stmt.params
+          ; action_state =
+              Rollup_state.Outer_action_state.With_length.state
+                mid_outer_action_state
+          ; deposit_index = Checked32.zero
+          ; n_steps = Checked32.zero
+          ; is_rejected = false
+          ; is_accepted = false
+          } )
+    in
+    if (not target.is_accepted) || target.is_rejected then
+      failwith "Ethereum ERC20 deposit was not accepted" ;
+    Ethereum_token_bridge.Rule_bridge_finalize_deposit.Check_accepted_inst.make
+      ~proof_source:source ~proof_target:target ~proof
+      { params
+      ; original_action_state =
+          Rollup_state.Outer_action_state.unsafe_value_of_field
+            original_action_state
+      ; deposit_index = Checked32.zero
+      }
+      []
+  in
+  let Compile_simple.[ finalize_deposit; _; _ ] =
+    Lazy.force Ethereum_token_bridge.System_L2.provers
+  in
+  let vk_hash =
+    ( Promise.block_on_async_exn
+    @@ fun () ->
+    Compile_simple.Verification_key.of_tag
+      (Lazy.force Ethereum_token_bridge.System_L2.tag) )
+    |> Compile_simple.Verification_key.hash
+  in
+  let action_state : Ase.With_length.Stmt.t =
+    { action_state =
+        Rollup_state.Outer_action_state.(
+          With_length.state target_outer_action_state |> raw)
+    ; length =
+        Rollup_state.Outer_action_state.With_length.length
+          target_outer_action_state
+    }
+  in
+  let (_statement, (vault, _digest, calls)), _proof =
+    Promise.block_on_async_exn
+    @@ fun () ->
+    finalize_deposit
+      { public_key = point_of_string "11111"
+      ; vk_hash
+      ; may_use_token = Parents_own_token
+      ; inner_authorization_kind = Rule_bridge_finalize_deposit.A.None_given
+      ; ase =
+          Ethereum_token_bridge.Rule_bridge_finalize_deposit.Ase_inst.make
+            ~proof_source:action_state ~proof_target:action_state action_state
+            []
+      ; check_accepted
+      ; prev_next_deposit = Checked32.zero
+      ; prev_nonce = Checked32.zero
+      ; helper_account_new = true
+      }
+  in
+  let token_owner =
+    Account_id.create (point_of_string "344213") Token_id.default
+  in
+  let token_id = Account_id.derive_token_id ~owner:token_owner in
+  if not (Token_id.equal vault.token_id token_id) then
+    failwith "Ethereum ERC20 deposit debited the wrong vault token" ;
+  if
+    not
+      (Currency.Amount.Signed.equal vault.balance_change
+         Currency.Amount.Signed.(of_unsigned base.amount |> negate) )
+  then failwith "Ethereum ERC20 deposit vault debit mismatch" ;
+  match Zkapp_command.Call_forest.to_account_updates calls with
+  | [ _helper; _inner_witness; recipient; zero_fee ] ->
+      if not (Token_id.equal recipient.body.token_id token_id) then
+        failwith "Ethereum ERC20 deposit credited the wrong token" ;
+      if
+        not
+          (Account_update.May_use_token.equal recipient.body.may_use_token
+             Inherit_from_parent )
+      then failwith "Ethereum ERC20 recipient does not inherit the vault token" ;
+      if recipient.body.implicit_account_creation_fee then
+        failwith "Ethereum ERC20 recipient charged an implicit MINA fee" ;
+      if
+        not
+          (Currency.Amount.Signed.equal recipient.body.balance_change
+             Currency.Amount.Signed.(of_unsigned base.amount) )
+      then failwith "Ethereum ERC20 recipient credit mismatch" ;
+      if
+        not
+          (Currency.Amount.Signed.equal zero_fee.body.balance_change
+             Currency.Amount.Signed.zero )
+      then failwith "Ethereum ERC20 circuit emitted a token-denominated fee"
+  | _ ->
+      failwith "Ethereum ERC20 finalize-deposit forest shape mismatch"
+
+let erc20_withdrawal_params_fields () =
+  let open Mina_base in
+  let chain = Mina_signature_kind.Testnet in
+  let token_owner =
+    Account_id.create (point_of_string "344213") Token_id.default
+  in
+  let token_id = Account_id.derive_token_id ~owner:token_owner in
+  let sender = point_of_string "98881" in
+  let withdrawal_amount = amount "2000000" in
+  let debit_body =
+    { Account_update.Body.dummy with
+      public_key = sender
+    ; token_id
+    ; balance_change =
+        Currency.Amount.Signed.(of_unsigned withdrawal_amount |> negate)
+    ; may_use_token = Parents_own_token
+    ; authorization_kind = Signature
+    ; use_full_commitment = true
+    }
+  in
+  let debit =
+    Account_update.with_aux ~body:debit_body
+      ~authorization:Control.Poly.None_given
+  in
+  let debit_forest =
+    Zkapp_command.Call_forest.cons ~signature_kind:chain debit []
+  in
+  let base : Zeko_circuits.Bridge_state.Withdrawal_params_base.t =
+    { children = []
+    ; amount = withdrawal_amount
+    ; recipient = ({ x = Field.of_int 0x01020304; is_odd = false } : PC.t)
+    }
+  in
+  let custom : Zeko_circuits.Bridge_state.Withdrawal_params_custom.t =
+    { authorization_kind = Proof Field.one
+    ; nested_children = debit_forest
+    ; call_data = Field.zero
+    ; base
+    }
+  in
+  let params : Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token.t =
+    { asset_id_high = Field.one; asset_id_low = Field.of_int 2; custom }
+  in
+  let params_fields =
+    Utils.value_to_fields
+      Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token.typ params
+    |> Array.to_list
+  in
+  ( match Zkapp_command.Call_forest.to_account_updates debit_forest with
+  | [ debit ] ->
+      if
+        not
+          (Currency.Amount.Signed.equal debit.body.balance_change
+             Currency.Amount.Signed.(of_unsigned withdrawal_amount |> negate) )
+      then failwith "Ethereum ERC20 withdrawal does not start with the debit"
+  | _ ->
+      failwith "Ethereum ERC20 withdrawal debit forest is not singular" ) ;
+  let withdrawal_aux =
+    Utils.value_to_hash ~init:Zeko_constants.ethereum_erc20_withdrawal_salt
+      Zeko_circuits.Bridge_state.Withdrawal_params_ethereum_token.typ params
+    |> field_to_hex
+  in
+  (params_fields, withdrawal_aux)
+
 let () =
+  let Compile_simple.[ _; _; _ ] =
+    Lazy.force Ethereum_token_bridge.System_L2.provers
+  in
+  check_erc20_deposit_witness_action () ;
+  check_erc20_finalize_deposit () ;
+  let withdrawal_params_fields, withdrawal_aux =
+    erc20_withdrawal_params_fields ()
+  in
+  if
+    not
+      (String.equal withdrawal_aux
+         "24c550ad1d37bd8711148b1b4ad5f1724c521a62aec4b978a1a19a7629bd59cf" )
+  then failwith "Ethereum ERC20 withdrawal circuit/settlement aux mismatch" ;
+  let token_preimage : Sequencer_lib.Archive.Ethereum_withdrawal.t =
+    { recipient = { x = Field.of_int 0x01020304; is_odd = false }
+    ; amount = amount "2000000"
+    ; asset =
+        Some
+          { token = "0x0000000000000000000000000000000000000001"
+          ; asset_id =
+              "0x0000000000000000000000000000000100000000000000000000000000000002"
+          ; params_fields = withdrawal_params_fields
+          }
+    }
+  in
+  ( match
+      Sequencer_lib.Ethereum_settlement_export.ethereum_withdrawal_preimage_json
+        token_preimage
+    with
+  | Some
+      ( "tokenWithdrawal"
+      , `Assoc
+          [ ("token", `String "0x0000000000000000000000000000000000000001")
+          ; ( "assetId"
+            , `String
+                "0x0000000000000000000000000000000100000000000000000000000000000002"
+            )
+          ; ("recipient", `String "0x0000000000000000000000000000000001020304")
+          ; ("amount", `Intlit "2000000")
+          ; ("paramsFields", `List params_fields)
+          ] )
+    when List.length params_fields >= 6 ->
+      ()
+  | _ ->
+      failwith "Ethereum ERC20 withdrawal export mismatch" ) ;
   let vectors =
     [ ( "1000000000"
       , "16909060"
       , false
-      , "2e9d1b29cea8eaba8c1dfe6d8c78b21127ce44a8378b3c9d2ee9ba0ddbd7c849"
-      )
+      , "2e9d1b29cea8eaba8c1dfe6d8c78b21127ce44a8378b3c9d2ee9ba0ddbd7c849" )
     ; ( "2000000000"
       , "84281096"
       , false
-      , "1a03b5b4a38e241ee071764a843e5b7bf29aa0e455d7ccd53a83f729885bfb18"
-      )
+      , "1a03b5b4a38e241ee071764a843e5b7bf29aa0e455d7ccd53a83f729885bfb18" )
     ; ( "3000000000"
       , "151653132"
       , true
-      , "1adc48d4e3b4478369ec2d8ce4ca72c397c9e75f019b24c9d65c262ae9757fa9"
-      )
+      , "1adc48d4e3b4478369ec2d8ce4ca72c397c9e75f019b24c9d65c262ae9757fa9" )
     ]
   in
   List.iter vectors ~f:(fun (amount, recipient_x, recipient_is_odd, expected) ->
       let actual = aux ~amount ~recipient_x ~recipient_is_odd in
       if not (String.equal actual expected) then
         failwithf "Ethereum deposit aux mismatch: expected %s, got %s" expected
-          actual () )
+          actual () ) ;
+  let actual =
+    erc20_aux ~asset_id_high:"1" ~asset_id_low:"2" ~amount:"2000000"
+      ~recipient_x:"16909060" ~recipient_is_odd:false
+  in
+  let expected =
+    "0fc821581944d768e902d37d6527e3011992e5368fb33dca2f5ccc24a6f417f7"
+  in
+  if not (String.equal actual expected) then
+    failwithf "Ethereum ERC20 deposit aux mismatch: expected %s, got %s"
+      expected actual ()

--- a/src/app/zeko/tests/test_all_real.ml
+++ b/src/app/zeko/tests/test_all_real.ml
@@ -1875,6 +1875,7 @@ open struct
               Compile_simple.Verification_key.of_tag
                 (Lazy.force Bridge.System_L2.tag) )
               |> Compile_simple.Verification_key.hash
+          ; asset = ()
           ; may_use_token = Bridge.Rule_bridge_finalize_deposit.May_use_token.No
           ; inner_authorization_kind = Rule_bridge_finalize_deposit.A.None_given
           ; ase =

--- a/src/app/zeko/tests/test_all_real.ml
+++ b/src/app/zeko/tests/test_all_real.ml
@@ -185,6 +185,24 @@ open struct
         let max_sequencer_inactivity = 128
 
         let emergency_da_public_key = point_of_string "223344"
+
+        let ethereum_asset_registry_public_key = None
+
+        let ethereum_asset_registration_authority = inner_public_key
+
+        let ethereum_asset_registry_schema_version = Zeko_util.Checked32.zero
+
+        let ethereum_asset_approved_mft_standard_vk_id = Field.zero
+
+        let ethereum_asset_approved_mft_token_vk_hash = Field.zero
+
+        let ethereum_asset_approved_mft_admin_vk_hash = Field.zero
+
+        let ethereum_asset_universal_bridge_vk_id = Field.zero
+
+        let ethereum_asset_universal_bridge_vk_hash = Field.zero
+
+        let ethereum_asset_vault_public_key = inner_public_key
       end)
       ()
 
@@ -855,6 +873,43 @@ open struct
         }
 
       let base_witness : Outer_rules_inst.Rule_commit_inst.Base_witness.t =
+        let empty_registry_path =
+          List.init Zeko_constants.constraint_constants.ledger_depth
+            ~f:(fun _ : Outer_rules_inst.Rule_commit_inst.Registry_path.Step.t
+               -> { hash_other = Field.zero; is_right = false } )
+        in
+        let ethereum_asset_registration :
+            Outer_rules_inst.Rule_commit_inst.Registration_witness.t =
+          let candidate : Asset_registry.Asset_record.t =
+            { schema_version = Zeko_util.Checked32.zero
+            ; registry_index = Zeko_util.Checked32.zero
+            ; asset_id_high = Field.zero
+            ; asset_id_low = Field.zero
+            ; ethereum_token_address = Field.zero
+            ; token_owner_l2 = Public_key.Compressed.empty
+            ; token_id_l2 = Mina_base.Token_id.default
+            ; decimals = Zeko_util.Checked32.zero
+            ; inventory_cap = Currency.Amount.zero
+            ; mft_standard_vk_id = Field.zero
+            ; vault_public_key = Public_key.Compressed.empty
+            ; universal_bridge_vk_id = Field.zero
+            }
+          in
+          { did_append = false
+          ; candidate
+          ; append_path =
+              List.init Zeko_constants.Ethereum_asset_registry.depth
+                ~f:(fun _ -> Field.zero)
+          ; token_owner_acc = Mina_base.Account.empty
+          ; token_owner_path = empty_registry_path
+          ; admin_acc = Mina_base.Account.empty
+          ; admin_path = empty_registry_path
+          ; vault_acc = Mina_base.Account.empty
+          ; vault_path = empty_registry_path
+          ; circulation_acc = Mina_base.Account.empty
+          ; circulation_path = empty_registry_path
+          }
+        in
         { public_key = point_of_string "29421"
         ; vk_hash = Snark_params.Tick.Field.zero
         ; slot_range =
@@ -867,6 +922,11 @@ open struct
         ; new_inner_acc_path
         ; da_multisig
         ; emergency_mode = false
+        ; old_ethereum_asset_registry_acc = Mina_base.Account.empty
+        ; old_ethereum_asset_registry_path = empty_registry_path
+        ; new_ethereum_asset_registry_acc = Mina_base.Account.empty
+        ; new_ethereum_asset_registry_path = empty_registry_path
+        ; ethereum_asset_registration
         }
 
       let witness : Outer_rules_inst.Rule_commit_inst.Witness.t =
@@ -884,11 +944,16 @@ open struct
             ()
         | Some fixture_dir ->
             let verification_key =
-              Promise.block_on_async_exn @@ fun () ->
+              Promise.block_on_async_exn
+              @@ fun () ->
               Compile_simple.Verification_key.of_tag
                 (Lazy.force Outer_rules_inst.tag)
             in
             let app_statement, (body, _body_digest, calls) = commit_stmt in
+            let calls =
+              Mina_base.Zkapp_command.Call_forest.map calls
+                ~f:Mina_base.Account_update.read_all_proofs_from_disk
+            in
             let state_before : Rollup_state.Outer_state.t =
               { pause_key = point_of_string_even "987654321"
               ; status_flags =
@@ -909,9 +974,9 @@ open struct
             let settlement_export =
               Async.Thread_safe.block_on_async_exn (fun () ->
                   Sequencer_lib.Ethereum_settlement_export
-                  .create_with_verification_key
-                    ~signature_kind ~body ~calls ~state_before
-                    ~proof:commit_proof ~verification_key )
+                  .create_with_verification_key ~signature_kind ~body ~calls
+                    ~state_before ~proof:commit_proof ~verification_key
+                    ?inner_action_batch:None ?asset_registry_batch:None )
               |> Or_error.ok_exn
             in
             let transaction_hash = "0x" ^ String.make 64 '1' in
@@ -1135,8 +1200,7 @@ open struct
         ; new_account = fee_payer_acc_after_first
         ; ledger_path = to_emergency_path fee_payer_path_0
         ; source_acc_set = to_account_set source_acc_set
-        ; acc_set_witness =
-            make_single_update_acc_set_witness acc_set_data_0
+        ; acc_set_witness = make_single_update_acc_set_witness acc_set_data_0
         }
 
       let emergency_da_witness_2 : Rule_emergency_da.Witness.t =
@@ -1146,8 +1210,7 @@ open struct
         ; new_account = old_inner_acc
         ; ledger_path = to_emergency_path inner_path_1
         ; source_acc_set = to_account_set acc_set_data_0.hash
-        ; acc_set_witness =
-            make_single_update_acc_set_witness acc_set_data_1
+        ; acc_set_witness = make_single_update_acc_set_witness acc_set_data_1
         }
 
       let emergency_da_witness_3 : Rule_emergency_da.Witness.t =
@@ -1157,8 +1220,7 @@ open struct
         ; new_account = fee_payer_acc_after_third
         ; ledger_path = to_emergency_path fee_payer_path_2
         ; source_acc_set = to_account_set acc_set_data_1.hash
-        ; acc_set_witness =
-            make_single_update_acc_set_witness acc_set_data_2
+        ; acc_set_witness = make_single_update_acc_set_witness acc_set_data_2
         }
 
       let emergency_da_witness_4 : Rule_emergency_da.Witness.t =
@@ -1168,8 +1230,7 @@ open struct
         ; new_account = new_account_created
         ; ledger_path = to_emergency_path new_path_3
         ; source_acc_set = to_account_set acc_set_data_2.hash
-        ; acc_set_witness =
-            make_single_update_acc_set_witness acc_set_data_3
+        ; acc_set_witness = make_single_update_acc_set_witness acc_set_data_3
         }
 
       let emergency_da_out_1, _emergency_da_proof_1 =
@@ -1550,6 +1611,8 @@ open struct
       ; point_of_string "46513"
       ]
 
+    let ethereum_holder_account_l1 = None
+
     let multisig_key =
       { Zeko_circuits.Multisig.public_keys = [ multisig_update_pk ]
       ; quorum = Snark_params.Tick.Field.of_int 1
@@ -1576,6 +1639,24 @@ open struct
     let outer_account_creation_fee = Currency.Fee.zero
 
     let max_sequencer_inactivity = 128
+
+    let ethereum_asset_registry_public_key = None
+
+    let ethereum_asset_registration_authority = inner_public_key
+
+    let ethereum_asset_registry_schema_version = Zeko_util.Checked32.zero
+
+    let ethereum_asset_approved_mft_standard_vk_id = Field.zero
+
+    let ethereum_asset_approved_mft_token_vk_hash = Field.zero
+
+    let ethereum_asset_approved_mft_admin_vk_hash = Field.zero
+
+    let ethereum_asset_universal_bridge_vk_id = Field.zero
+
+    let ethereum_asset_universal_bridge_vk_hash = Field.zero
+
+    let ethereum_asset_vault_public_key = inner_public_key
 
     let holder_account_l1_permissions_enabled : Mina_base.Permissions.t =
       { edit_state = Proof
@@ -2366,6 +2447,7 @@ open struct
               Compile_simple.Verification_key.of_tag
                 (Lazy.force Inner_rules.tag) )
               |> Compile_simple.Verification_key.hash
+          ; asset = ()
           ; amount
           }
       in

--- a/src/app/zeko/tests/test_all_real.ml
+++ b/src/app/zeko/tests/test_all_real.ml
@@ -188,8 +188,6 @@ open struct
 
         let ethereum_asset_registry_public_key = None
 
-        let ethereum_asset_registration_authority = inner_public_key
-
         let ethereum_asset_registry_schema_version = Zeko_util.Checked32.zero
 
         let ethereum_asset_approved_mft_standard_vk_id = Field.zero
@@ -1641,8 +1639,6 @@ open struct
     let max_sequencer_inactivity = 128
 
     let ethereum_asset_registry_public_key = None
-
-    let ethereum_asset_registration_authority = inner_public_key
 
     let ethereum_asset_registry_schema_version = Zeko_util.Checked32.zero
 

--- a/src/app/zeko/tests/test_all_real.ml
+++ b/src/app/zeko/tests/test_all_real.ml
@@ -1817,7 +1817,20 @@ open struct
                ~authorization:
                  (* Account_update.Checked.t == Account_update.Body.Checked.t so authorization is dropped anyways *)
                  Control.Poly.None_given )
-            []
+            (Zkapp_command.Call_forest.cons ~signature_kind:Inputs.chain_l1
+               (Account_update.with_aux
+                  ~body:
+                    { Mina_base.Account_update.Body.dummy with
+                      use_full_commitment = true
+                    ; public_key = Inputs.bridge_fee_recipient_l1
+                    ; balance_change =
+                        Currency.Amount.Signed.(
+                          of_unsigned Inputs.bridge_proof_fee)
+                    ; may_use_token = Parents_own_token
+                    ; authorization_kind = None_given
+                    }
+                  ~authorization:Control.Poly.None_given )
+               [] )
       ; slot_range = deposit_slot_range
       }
 
@@ -1981,7 +1994,11 @@ open struct
       assert (Public_key.Compressed.equal au.public_key Inputs.holder_account_l2) ;
       let helper_account, witness_inner =
         match Zkapp_command.Call_forest.to_account_updates calls with
-        | [ helper_account; witness_inner ] ->
+        | [ helper_account
+          ; witness_inner
+          ; _recipient_payout
+          ; _sequencer_fee_payout
+          ] ->
             (helper_account, witness_inner)
         | _ ->
             failwith
@@ -2089,7 +2106,20 @@ open struct
                ~authorization:
                  (* Account_update.Checked.t == Account_update.Body.Checked.t so authorization is dropped anyways *)
                  Control.Poly.None_given )
-            []
+            (Zkapp_command.Call_forest.cons ~signature_kind:Inputs.chain_l1
+               (Account_update.with_aux
+                  ~body:
+                    { Mina_base.Account_update.Body.dummy with
+                      use_full_commitment = true
+                    ; public_key = Inputs.bridge_fee_recipient_l1
+                    ; balance_change =
+                        Currency.Amount.Signed.(
+                          of_unsigned Inputs.bridge_proof_fee)
+                    ; may_use_token = Parents_own_token
+                    ; authorization_kind = None_given
+                    }
+                  ~authorization:Control.Poly.None_given )
+               [] )
       ; slot_range = deposit_slot_range
       }
 
@@ -2333,6 +2363,8 @@ open struct
             ; _
             }
           ; { elt = { account_update = witness_outer; calls = []; _ }; _ }
+          ; { elt = { calls = []; _ }; _ }
+          ; { elt = { calls = []; _ }; _ }
           ] ->
             ((helper_token_owner, helper_account), witness_outer)
         | _ ->
@@ -2464,7 +2496,20 @@ open struct
                ~authorization:
                  (* Account_update.Checked.t == Account_update.Body.Checked.t so authorization is dropped anyways *)
                  Control.Poly.None_given )
-            []
+            (Zkapp_command.Call_forest.cons ~signature_kind:Inputs.chain_l2
+               (Account_update.with_aux
+                  ~body:
+                    { Mina_base.Account_update.Body.dummy with
+                      use_full_commitment = true
+                    ; public_key = Inputs.bridge_fee_recipient_l2
+                    ; balance_change =
+                        Currency.Amount.Signed.(
+                          of_unsigned Inputs.bridge_proof_fee)
+                    ; may_use_token = Parents_own_token
+                    ; authorization_kind = None_given
+                    }
+                  ~authorization:Control.Poly.None_given )
+               [] )
       }
 
     let withdrawal_action =
@@ -2605,6 +2650,8 @@ open struct
             ; _
             }
           ; { elt = { account_update = witness_outer; calls = []; _ }; _ }
+          ; { elt = { calls = []; _ }; _ }
+          ; { elt = { calls = []; _ }; _ }
           ] ->
             ((helper_token_owner, helper_account), witness_outer)
         | _ ->

--- a/src/app/zeko/tests/test_pause_real.ml
+++ b/src/app/zeko/tests/test_pause_real.ml
@@ -18,7 +18,9 @@ module Outer_rules_inst =
 
       let chain_l1 = Mina_signature_kind.Testnet
 
-      let multisig_update =
+      let chain_l2 = Mina_signature_kind.Testnet
+
+      let multisig_key =
         { Multisig.public_keys = [ inner_public_key ]; quorum = Field.one }
 
       let max_sequencer_inactivity = 128
@@ -30,6 +32,24 @@ module Outer_rules_inst =
             @@ Snark_params.Tick.Field.of_int 223344)
         in
         Signature_lib.Public_key.compress pk
+
+      let ethereum_asset_registry_public_key = None
+
+      let ethereum_asset_registration_authority = inner_public_key
+
+      let ethereum_asset_registry_schema_version = Zeko_util.Checked32.zero
+
+      let ethereum_asset_approved_mft_standard_vk_id = Field.zero
+
+      let ethereum_asset_approved_mft_token_vk_hash = Field.zero
+
+      let ethereum_asset_approved_mft_admin_vk_hash = Field.zero
+
+      let ethereum_asset_universal_bridge_vk_id = Field.zero
+
+      let ethereum_asset_universal_bridge_vk_hash = Field.zero
+
+      let ethereum_asset_vault_public_key = inner_public_key
     end)
     ()
 

--- a/src/app/zeko/tests/test_pause_real.ml
+++ b/src/app/zeko/tests/test_pause_real.ml
@@ -35,8 +35,6 @@ module Outer_rules_inst =
 
       let ethereum_asset_registry_public_key = None
 
-      let ethereum_asset_registration_authority = inner_public_key
-
       let ethereum_asset_registry_schema_version = Zeko_util.Checked32.zero
 
       let ethereum_asset_approved_mft_standard_vk_id = Field.zero

--- a/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
+++ b/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
@@ -18,6 +18,16 @@ module Ethereum_token = struct
   [@@deriving yojson]
 end
 
+module Ethereum_assets = struct
+  type t =
+    { registry_public_key : Public_key.Compressed.t
+    ; vault_public_key : Public_key.Compressed.t
+    ; approved_mft_standard_vk_id : string
+    ; universal_bridge_vk_id : string
+    }
+  [@@deriving yojson]
+end
+
 type t =
   { chain_l1 : Mina_signature_kind.t
   ; chain_l2 : Mina_signature_kind.t
@@ -26,6 +36,7 @@ type t =
   ; holder_accounts_l1 : Public_key.Compressed.t list
   ; ethereum_holder_account_l1 : Public_key.Compressed.t option [@default None]
   ; ethereum_token : Ethereum_token.t option [@default None]
+  ; ethereum_assets : Ethereum_assets.t option [@default None]
   ; helper_token_owner_l1 : Public_key.Compressed.t
   ; zeko_l1 : Public_key.Compressed.t
   ; emergency_da_public_key : Public_key.Compressed.t
@@ -169,6 +180,7 @@ let (t, deploy_config) : t * Deploy.t option =
         ; holder_accounts_l1 = List.map holder_accounts_l1 ~f:fst
         ; ethereum_holder_account_l1 = None
         ; ethereum_token = None
+        ; ethereum_assets = None
         ; helper_token_owner_l1 = fst helper_token_owner_l1
         ; zeko_l1 = fst zeko_l1
         ; emergency_da_public_key = fst emergency_da
@@ -273,6 +285,48 @@ module Inputs = struct
       | false, None ->
           Zeko_constants.inner_holder_key
   end
+
+  module Ethereum_assets = struct
+    let enabled = Option.is_some t.ethereum_assets
+
+    let config =
+      Option.value t.ethereum_assets
+        ~default:
+          { Ethereum_assets.registry_public_key = Zeko_constants.inner_holder_key
+          ; vault_public_key = Zeko_constants.inner_holder_key
+          ; approved_mft_standard_vk_id = "1"
+          ; universal_bridge_vk_id = "2"
+          }
+
+    let registry_public_key = config.registry_public_key
+
+    let registry_schema_version =
+      Zeko_circuits.Zeko_util.Checked32.of_int
+        Zeko_constants.Ethereum_asset_registry.schema_version
+
+    let approved_mft_standard_vk_id =
+      Snark_params.Tick.Field.of_string config.approved_mft_standard_vk_id
+
+    let universal_bridge_vk_id =
+      Snark_params.Tick.Field.of_string config.universal_bridge_vk_id
+
+    let vault_public_key = config.vault_public_key
+
+    let ethereum_holder_account_l1 =
+      match (enabled, t.ethereum_holder_account_l1) with
+      | true, None ->
+          failwith
+            "ethereum_assets requires ethereum_holder_account_l1 (or \
+             ZEKO_ETHEREUM_BRIDGE_ADDRESS)"
+      | _, Some holder ->
+          holder
+      | false, None ->
+          Zeko_constants.inner_holder_key
+  end
+
+  let ethereum_asset_registry_public_key =
+    if Ethereum_assets.enabled then Some Ethereum_assets.registry_public_key
+    else None
 
   let holder_account_l2 = Zeko_constants.inner_holder_key
 

--- a/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
+++ b/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
@@ -21,9 +21,13 @@ end
 module Ethereum_assets = struct
   type t =
     { registry_public_key : Public_key.Compressed.t
+    ; registration_authority : Public_key.Compressed.t
     ; vault_public_key : Public_key.Compressed.t
     ; approved_mft_standard_vk_id : string
+    ; approved_mft_token_vk_hash : string
+    ; approved_mft_admin_vk_hash : string
     ; universal_bridge_vk_id : string
+    ; universal_bridge_vk_hash : string
     }
   [@@deriving yojson]
 end
@@ -292,13 +296,20 @@ module Inputs = struct
     let config =
       Option.value t.ethereum_assets
         ~default:
-          { Ethereum_assets.registry_public_key = Zeko_constants.inner_holder_key
+          { Ethereum_assets.registry_public_key =
+              Zeko_constants.inner_holder_key
+          ; registration_authority = Zeko_constants.inner_holder_key
           ; vault_public_key = Zeko_constants.inner_holder_key
           ; approved_mft_standard_vk_id = "1"
+          ; approved_mft_token_vk_hash = "3"
+          ; approved_mft_admin_vk_hash = "4"
           ; universal_bridge_vk_id = "2"
+          ; universal_bridge_vk_hash = "5"
           }
 
     let registry_public_key = config.registry_public_key
+
+    let registration_authority = config.registration_authority
 
     let registry_schema_version =
       Zeko_circuits.Zeko_util.Checked32.of_int
@@ -307,8 +318,17 @@ module Inputs = struct
     let approved_mft_standard_vk_id =
       Snark_params.Tick.Field.of_string config.approved_mft_standard_vk_id
 
+    let approved_mft_token_vk_hash =
+      Snark_params.Tick.Field.of_string config.approved_mft_token_vk_hash
+
+    let approved_mft_admin_vk_hash =
+      Snark_params.Tick.Field.of_string config.approved_mft_admin_vk_hash
+
     let universal_bridge_vk_id =
       Snark_params.Tick.Field.of_string config.universal_bridge_vk_id
+
+    let universal_bridge_vk_hash =
+      Snark_params.Tick.Field.of_string config.universal_bridge_vk_hash
 
     let vault_public_key = config.vault_public_key
 
@@ -327,6 +347,29 @@ module Inputs = struct
   let ethereum_asset_registry_public_key =
     if Ethereum_assets.enabled then Some Ethereum_assets.registry_public_key
     else None
+
+  let ethereum_asset_registration_authority =
+    Ethereum_assets.registration_authority
+
+  let ethereum_asset_registry_schema_version =
+    Ethereum_assets.registry_schema_version
+
+  let ethereum_asset_approved_mft_standard_vk_id =
+    Ethereum_assets.approved_mft_standard_vk_id
+
+  let ethereum_asset_approved_mft_token_vk_hash =
+    Ethereum_assets.approved_mft_token_vk_hash
+
+  let ethereum_asset_approved_mft_admin_vk_hash =
+    Ethereum_assets.approved_mft_admin_vk_hash
+
+  let ethereum_asset_universal_bridge_vk_id =
+    Ethereum_assets.universal_bridge_vk_id
+
+  let ethereum_asset_universal_bridge_vk_hash =
+    Ethereum_assets.universal_bridge_vk_hash
+
+  let ethereum_asset_vault_public_key = Ethereum_assets.vault_public_key
 
   let holder_account_l2 = Zeko_constants.inner_holder_key
 

--- a/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
+++ b/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
@@ -8,6 +8,16 @@ module Mina_signature_kind = struct
   [@@deriving yojson]
 end
 
+module Ethereum_token = struct
+  type t =
+    { asset_id : string
+    ; ethereum_token_address : string
+    ; token_owner_l2 : Public_key.Compressed.t
+    ; holder_account_l2 : Public_key.Compressed.t
+    }
+  [@@deriving yojson]
+end
+
 type t =
   { chain_l1 : Mina_signature_kind.t
   ; chain_l2 : Mina_signature_kind.t
@@ -15,6 +25,7 @@ type t =
   ; multisig_key : Zeko_circuits.Multisig.t
   ; holder_accounts_l1 : Public_key.Compressed.t list
   ; ethereum_holder_account_l1 : Public_key.Compressed.t option [@default None]
+  ; ethereum_token : Ethereum_token.t option [@default None]
   ; helper_token_owner_l1 : Public_key.Compressed.t
   ; zeko_l1 : Public_key.Compressed.t
   ; emergency_da_public_key : Public_key.Compressed.t
@@ -26,8 +37,9 @@ type t =
 [@@deriving yojson]
 
 let ethereum_address_to_public_key address =
-  let address = String.lowercase address in
-  let hex = String.chop_prefix_if_exists address ~prefix:"0x" in
+  let hex =
+    String.lowercase address |> String.chop_prefix_if_exists ~prefix:"0x"
+  in
   if String.length hex <> 40 then
     failwithf
       "Ethereum bridge address must contain exactly 20 bytes, got %d hex \
@@ -52,10 +64,55 @@ let ethereum_address_to_public_key address =
   in
   ({ x; is_odd = false } : Public_key.Compressed.t)
 
+let normalize_ethereum_address_exn ~label address =
+  let hex =
+    String.lowercase address |> String.chop_prefix_if_exists ~prefix:"0x"
+  in
+  let is_hex_digit = function '0' .. '9' | 'a' .. 'f' -> true | _ -> false in
+  if String.length hex <> 40 then
+    failwithf "%s must contain exactly 20 bytes" label ()
+  else if not (String.for_all hex ~f:is_hex_digit) then
+    failwithf "%s contains a non-hexadecimal character" label ()
+  else if String.for_all hex ~f:(Char.equal '0') then
+    failwithf "%s must not be zero" label ()
+  else "0x" ^ hex
+
 let with_ethereum_holder_address t address =
   { t with
     ethereum_holder_account_l1 = Some (ethereum_address_to_public_key address)
   }
+
+let normalize_bytes32_exn ~label value =
+  let hex =
+    String.lowercase value |> String.chop_prefix_if_exists ~prefix:"0x"
+  in
+  let is_hex_digit = function '0' .. '9' | 'a' .. 'f' -> true | _ -> false in
+  if String.length hex <> 64 then
+    failwithf "%s must contain exactly 32 bytes" label ()
+  else if not (String.for_all hex ~f:is_hex_digit) then
+    failwithf "%s contains a non-hexadecimal character" label ()
+  else if String.for_all hex ~f:(Char.equal '0') then
+    failwithf "%s must not be zero" label ()
+  else "0x" ^ hex
+
+let field_of_uint128_hex_exn ~label hex =
+  match
+    Snark_params.Tick.Field.of_yojson (`String ("0x" ^ String.make 32 '0' ^ hex))
+  with
+  | Ok field ->
+      field
+  | Error error ->
+      failwithf "Failed to decode %s: %s" label error ()
+
+let asset_id_limbs_exn asset_id =
+  let asset_id =
+    normalize_bytes32_exn ~label:"Ethereum token asset ID" asset_id
+  in
+  let hex = String.drop_prefix asset_id 2 in
+  ( field_of_uint128_hex_exn ~label:"Ethereum token asset ID high limb"
+      (String.prefix hex 32)
+  , field_of_uint128_hex_exn ~label:"Ethereum token asset ID low limb"
+      (String.drop_prefix hex 32) )
 
 module Deploy = struct
   type t =
@@ -111,6 +168,7 @@ let (t, deploy_config) : t * Deploy.t option =
             }
         ; holder_accounts_l1 = List.map holder_accounts_l1 ~f:fst
         ; ethereum_holder_account_l1 = None
+        ; ethereum_token = None
         ; helper_token_owner_l1 = fst helper_token_owner_l1
         ; zeko_l1 = fst zeko_l1
         ; emergency_da_public_key = fst emergency_da
@@ -167,6 +225,54 @@ module Inputs = struct
   let holder_accounts_l1 = t.holder_accounts_l1
 
   let ethereum_holder_account_l1 = t.ethereum_holder_account_l1
+
+  module Ethereum_token = struct
+    let enabled = Option.is_some t.ethereum_token
+
+    let config =
+      Option.value t.ethereum_token
+        ~default:
+          { Ethereum_token.asset_id =
+              "0x0000000000000000000000000000000000000000000000000000000000000001"
+          ; ethereum_token_address =
+              "0x0000000000000000000000000000000000000001"
+          ; token_owner_l2 = Zeko_constants.inner_holder_key
+          ; holder_account_l2 = Zeko_constants.inner_holder_key
+          }
+
+    let () =
+      if
+        enabled
+        && Public_key.Compressed.equal config.token_owner_l2
+             config.holder_account_l2
+      then failwith "Ethereum token owner and bridge vault must be distinct"
+
+    let asset_id =
+      normalize_bytes32_exn ~label:"Ethereum token asset ID" config.asset_id
+
+    let ethereum_token_address =
+      normalize_ethereum_address_exn ~label:"Ethereum token address"
+        config.ethereum_token_address
+
+    let ethereum_asset_id_high, ethereum_asset_id_low =
+      asset_id_limbs_exn asset_id
+
+    let token_owner_l2 =
+      Account_id.create config.token_owner_l2 Token_id.default
+
+    let holder_account_l2 = config.holder_account_l2
+
+    let ethereum_holder_account_l1 =
+      match (enabled, t.ethereum_holder_account_l1) with
+      | true, None ->
+          failwith
+            "ethereum_token requires ethereum_holder_account_l1 (or \
+             ZEKO_ETHEREUM_BRIDGE_ADDRESS)"
+      | _, Some holder ->
+          holder
+      | false, None ->
+          Zeko_constants.inner_holder_key
+  end
 
   let holder_account_l2 = Zeko_constants.inner_holder_key
 

--- a/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
+++ b/src/app/zeko/zeko_circuits_config/zeko_circuits_config.ml
@@ -348,9 +348,6 @@ module Inputs = struct
     if Ethereum_assets.enabled then Some Ethereum_assets.registry_public_key
     else None
 
-  let ethereum_asset_registration_authority =
-    Ethereum_assets.registration_authority
-
   let ethereum_asset_registry_schema_version =
     Ethereum_assets.registry_schema_version
 

--- a/src/app/zeko/zeko_constants.ml
+++ b/src/app/zeko/zeko_constants.ml
@@ -57,6 +57,8 @@ let ethereum_asset_registry_leaf_salt = "Ethereum asset registry leaf V1"
 
 let ethereum_asset_registry_node_salt = "Ethereum asset registry node V1"
 
+let ethereum_asset_registry_checkpoint_salt = "Zeko registry checkpoint V1"
+
 let ethereum_asset_bridge_call_salt = "Ethereum asset bridge call V1"
 
 let bridge_prover_cache = "bridge prover cache"

--- a/src/app/zeko/zeko_constants.ml
+++ b/src/app/zeko/zeko_constants.ml
@@ -53,7 +53,25 @@ let withdrawal_salt = "Withdrawal_params - qFB3jXP*)"
 
 let ethereum_erc20_withdrawal_salt = "Ethereum ERC20 withdrawal V1"
 
+let ethereum_asset_registry_leaf_salt = "Ethereum asset registry leaf V1"
+
+let ethereum_asset_registry_node_salt = "Ethereum asset registry node V1"
+
+let ethereum_asset_bridge_call_salt = "Ethereum asset bridge call V1"
+
 let bridge_prover_cache = "bridge prover cache"
+
+module Ethereum_asset_registry = struct
+  let schema_version = 1
+
+  (* A depth-eight immutable list supports 256 mirrors. Registration proving is
+     recursive and linear in the current leaf count; normal bridge operations
+     authenticate one eight-element path. Keep this value synchronized with the
+     cross-language registry implementations and the proving benchmark. *)
+  let depth = 8
+
+  let max_assets = Int.pow 2 depth
+end
 
 module Max_excess_actions = struct
   module Inner_sync = struct
@@ -137,6 +155,16 @@ module Folder_iterations = struct
   module Count_commits : FOLDER_ITERATIONS = Check_accepted
 
   module Emergency_da : FOLDER_ITERATIONS = struct
+    let leaf_iterations = 8
+
+    let leaf_option_iterations = 4
+
+    let extend_iterations = 4
+
+    let extend_option_iterations = 2
+  end
+
+  module Ethereum_asset_registry_scan : FOLDER_ITERATIONS = struct
     let leaf_iterations = 8
 
     let leaf_option_iterations = 4

--- a/src/app/zeko/zeko_constants.ml
+++ b/src/app/zeko/zeko_constants.ml
@@ -49,15 +49,21 @@ let ethereum_deposit_salt = "Ethereum deposit V1"
 
 let ethereum_erc20_deposit_salt = "Ethereum ERC20 deposit V1"
 
+let ethereum_erc20_deposit_v2_salt = "Ethereum ERC20 deposit V2"
+
 let withdrawal_salt = "Withdrawal_params - qFB3jXP*)"
 
 let ethereum_erc20_withdrawal_salt = "Ethereum ERC20 withdrawal V1"
+
+let ethereum_erc20_withdrawal_v2_salt = "Ethereum ERC20 withdrawal V2"
 
 let ethereum_asset_registry_leaf_salt = "Ethereum asset registry leaf V1"
 
 let ethereum_asset_registry_node_salt = "Ethereum asset registry node V1"
 
 let ethereum_asset_registry_checkpoint_salt = "Zeko registry checkpoint V1"
+
+let ethereum_asset_registry_registration_salt = "Ethereum asset reg V1"
 
 let ethereum_asset_bridge_call_salt = "Ethereum asset bridge call V1"
 

--- a/src/app/zeko/zeko_constants.ml
+++ b/src/app/zeko/zeko_constants.ml
@@ -47,7 +47,11 @@ let deposit_salt = "Deposit_params - qFB3jXP*)"
    action, this action has no Mina child call forest. *)
 let ethereum_deposit_salt = "Ethereum deposit V1"
 
+let ethereum_erc20_deposit_salt = "Ethereum ERC20 deposit V1"
+
 let withdrawal_salt = "Withdrawal_params - qFB3jXP*)"
+
+let ethereum_erc20_withdrawal_salt = "Ethereum ERC20 withdrawal V1"
 
 let bridge_prover_cache = "bridge prover cache"
 

--- a/src/app/zeko/zeko_constants.ml
+++ b/src/app/zeko/zeko_constants.ml
@@ -61,7 +61,7 @@ let ethereum_asset_registry_leaf_salt = "Ethereum asset registry leaf V1"
 
 let ethereum_asset_registry_node_salt = "Ethereum asset registry node V1"
 
-let ethereum_asset_registry_checkpoint_salt = "Zeko registry checkpoint V1"
+let ethereum_asset_registry_checkpoint_v2_salt = "Zeko registry checkpoint V2"
 
 let ethereum_asset_registry_registration_salt = "Ethereum asset reg V1"
 

--- a/src/app/zeko/zeko_types/zeko_types.ml
+++ b/src/app/zeko/zeko_types/zeko_types.ml
@@ -57,10 +57,10 @@ module Bridge_inst_mina =
   Bridge_rules.Make_mina (Zeko_circuits_config.Inputs) ()
 
 module Bridge_inst_ethereum_token =
-  Bridge_rules.Make_ethereum_token
+  Bridge_rules.Make_ethereum_assets
     (struct
       include Zeko_circuits_config.Inputs
-      include Zeko_circuits_config.Inputs.Ethereum_token
+      include Zeko_circuits_config.Inputs.Ethereum_assets
     end)
     ()
 
@@ -782,6 +782,9 @@ module Outer_commit = struct
       ; new_inner_acc_path : Path.t
       ; da_multisig : Multisig.Witness.t
       ; slot_range : Slot_range.t
+      ; ethereum_asset_registry_root : F.t
+      ; ethereum_asset_registry_count : F.t
+      ; ethereum_asset_registry_schema : F.t
       ; verify_both_ases : Verify_both_ases.serializable
       }
     [@@deriving yojson]
@@ -797,6 +800,9 @@ module Outer_commit = struct
          ; new_inner_acc_path
          ; da_multisig
          ; slot_range
+         ; ethereum_asset_registry_root
+         ; ethereum_asset_registry_count
+         ; ethereum_asset_registry_schema
          } :
           serializable ) ~vk_hash : t =
       { base_witness =
@@ -809,6 +815,9 @@ module Outer_commit = struct
           ; new_inner_acc_path
           ; da_multisig
           ; slot_range
+          ; ethereum_asset_registry_root
+          ; ethereum_asset_registry_count
+          ; ethereum_asset_registry_schema
           }
       ; txn_snark = Txn_snark.of_serializable txn_snark
       ; verify_both_ases = Verify_both_ases.of_serializable verify_both_ases
@@ -1101,6 +1110,68 @@ module Bridge = struct
         excess
   end
 
+  module Ethereum_asset_registry = struct
+    module Registry = Bridge_inst_ethereum_token.Registry
+
+    module Scan = struct
+      include Registry.Scan
+      include Registry.Scan.Definition
+
+      module Stmt = struct
+        type t = Registry.Scan.Definition.Stmt.t =
+          { old_root : F.t
+          ; leaf_count : Checked32.t
+          ; candidate : Asset_registry.Asset_record.t
+          ; next_expected_index : Checked32.t
+          ; traversed_count : Checked32.t
+          }
+        [@@deriving yojson]
+      end
+
+      module Elem = struct
+        type t = Registry.Scan.Definition.Elem.t =
+          { active : bool
+          ; record : Asset_registry.Asset_record.t
+          ; path : Asset_registry.Path.t
+          }
+        [@@deriving yojson]
+      end
+
+      module Init = struct
+        type t = Registry.Scan.Definition.Init.t =
+          { old_state : Asset_registry.Registry_state.t
+          ; candidate : Asset_registry.Asset_record.t
+          }
+        [@@deriving yojson]
+      end
+    end
+
+    type serializable =
+      { proof : Compile_simple.Proof.t option
+      ; proof_source : Scan.Stmt.t
+      ; proof_target : Scan.Stmt.t
+      ; init : Scan.Init.t
+      ; excess : Scan.Elem.t list
+      ; append_path : Asset_registry.Path.t
+      }
+    [@@deriving yojson]
+
+    let of_serializable ~registry_vk_hash
+        ({ proof
+         ; proof_source
+         ; proof_target
+         ; init
+         ; excess
+         ; append_path
+         } :
+          serializable ) : Registry.Register.Witness.t =
+      { scan =
+          Registry.Scan_inst.make ?proof ~proof_source ~proof_target init excess
+      ; append_path
+      ; registry_vk_hash
+      }
+  end
+
   module Finalize_deposit = struct
     module Ase_inst = Ase.Make_serializable_ase (struct
       module Ase_system = Ase.With_length
@@ -1137,6 +1208,7 @@ module Bridge = struct
           serializable ) ~vk_hash : t =
       { public_key
       ; vk_hash
+      ; asset = ()
       ; may_use_token
       ; inner_authorization_kind
       ; ase = Ase_inst.of_serializable ase
@@ -1161,6 +1233,7 @@ module Bridge = struct
 
     type serializable =
       { public_key : Public_key.Compressed.t
+      ; asset : Bridge_inst_ethereum_token.Registry.Membership_witness.t
       ; may_use_token :
           Bridge_inst_ethereum_token.Rule_bridge_finalize_deposit.May_use_token
           .t
@@ -1175,6 +1248,7 @@ module Bridge = struct
 
     let of_serializable ~proof_cache_db
         ({ public_key
+         ; asset
          ; may_use_token
          ; inner_authorization_kind
          ; ase
@@ -1186,6 +1260,7 @@ module Bridge = struct
           serializable ) ~vk_hash : t =
       { public_key
       ; vk_hash
+      ; asset
       ; may_use_token
       ; inner_authorization_kind
       ; ase = Ase_inst.of_serializable ase
@@ -1304,18 +1379,22 @@ module Bridge = struct
     [@@deriving yojson]
 
     let of_serializable ({ public_key; amount } : serializable) ~vk_hash : t =
-      { public_key; vk_hash; amount }
+      { public_key; vk_hash; asset = (); amount }
   end
 
   module Inner_receive_ethereum_token = struct
     type t = Bridge_inst_ethereum_token.Rule_bridge_inner_receive.Witness.t
 
     type serializable =
-      { public_key : Public_key.Compressed.t; amount : Currency.Amount.t }
+      { public_key : Public_key.Compressed.t
+      ; asset : Bridge_inst_ethereum_token.Registry.Membership_witness.t
+      ; amount : Currency.Amount.t
+      }
     [@@deriving yojson]
 
-    let of_serializable ({ public_key; amount } : serializable) ~vk_hash : t =
-      { public_key; vk_hash; amount }
+    let of_serializable ({ public_key; asset; amount } : serializable) ~vk_hash :
+        t =
+      { public_key; vk_hash; asset; amount }
   end
 
   module Withdrawal_params_ethereum_token = struct

--- a/src/app/zeko/zeko_types/zeko_types.ml
+++ b/src/app/zeko/zeko_types/zeko_types.ml
@@ -749,6 +749,27 @@ module Outer_commit = struct
     end
   end)
 
+  module Registry_path = Make_serializable_path (struct
+    module PathStep = struct
+      type t = Outer_rules_inst.Rule_commit_inst.Registry_path.Step.t
+
+      let to_yojson ({ hash_other; is_right } : t) =
+        `Assoc
+          [ ("hash_other", Field.to_yojson hash_other)
+          ; ("is_right", `Bool is_right)
+          ]
+
+      let of_yojson json : t Ppx_deriving_yojson_runtime.error_or =
+        let open Yojson.Safe.Util in
+        try
+          Ok
+            { hash_other = member "hash_other" json |> Field.of_yojson |> ok_exn
+            ; is_right = member "is_right" json |> to_bool
+            }
+        with e -> Error (Exn.to_string e)
+    end
+  end)
+
   module Ase_outer_inst = Ase.Make_serializable_ase (struct
     module Ase_system = Ase.Without_length
     module Action_state = Outer_action_state
@@ -782,9 +803,12 @@ module Outer_commit = struct
       ; new_inner_acc_path : Path.t
       ; da_multisig : Multisig.Witness.t
       ; slot_range : Slot_range.t
-      ; ethereum_asset_registry_root : F.t
-      ; ethereum_asset_registry_count : F.t
-      ; ethereum_asset_registry_schema : F.t
+      ; old_ethereum_asset_registry_acc : Account.t
+      ; old_ethereum_asset_registry_path : Registry_path.t
+      ; new_ethereum_asset_registry_acc : Account.t
+      ; new_ethereum_asset_registry_path : Registry_path.t
+      ; ethereum_asset_registration :
+          Outer_rules_inst.Rule_commit_inst.Registration_witness.t
       ; verify_both_ases : Verify_both_ases.serializable
       }
     [@@deriving yojson]
@@ -800,9 +824,11 @@ module Outer_commit = struct
          ; new_inner_acc_path
          ; da_multisig
          ; slot_range
-         ; ethereum_asset_registry_root
-         ; ethereum_asset_registry_count
-         ; ethereum_asset_registry_schema
+         ; old_ethereum_asset_registry_acc
+         ; old_ethereum_asset_registry_path
+         ; new_ethereum_asset_registry_acc
+         ; new_ethereum_asset_registry_path
+         ; ethereum_asset_registration
          } :
           serializable ) ~vk_hash : t =
       { base_witness =
@@ -815,9 +841,11 @@ module Outer_commit = struct
           ; new_inner_acc_path
           ; da_multisig
           ; slot_range
-          ; ethereum_asset_registry_root
-          ; ethereum_asset_registry_count
-          ; ethereum_asset_registry_schema
+          ; old_ethereum_asset_registry_acc
+          ; old_ethereum_asset_registry_path
+          ; new_ethereum_asset_registry_acc
+          ; new_ethereum_asset_registry_path
+          ; ethereum_asset_registration
           }
       ; txn_snark = Txn_snark.of_serializable txn_snark
       ; verify_both_ases = Verify_both_ases.of_serializable verify_both_ases
@@ -955,21 +983,45 @@ module Bridge = struct
     type t = Bridge_state.Deposit_params_ethereum_token.t
 
     type serializable =
-      { asset_id_high : F.t
+      { encoding_version : Checked32.t
+      ; registry_index : Checked32.t
+      ; record_commitment : F.t
+      ; asset_id_high : F.t
       ; asset_id_low : F.t
       ; base : Deposit_params_base.serializable
       }
     [@@deriving yojson]
 
     let of_serializable ~proof_cache_db
-        ({ asset_id_high; asset_id_low; base } : serializable) : t =
-      { asset_id_high
+        ({ encoding_version
+         ; registry_index
+         ; record_commitment
+         ; asset_id_high
+         ; asset_id_low
+         ; base
+         } :
+          serializable ) : t =
+      { encoding_version
+      ; registry_index
+      ; record_commitment
+      ; asset_id_high
       ; asset_id_low
       ; base = Deposit_params_base.of_serializable ~proof_cache_db base
       }
 
-    let to_serializable ({ asset_id_high; asset_id_low; base } : t) =
-      { asset_id_high
+    let to_serializable
+        ({ encoding_version
+         ; registry_index
+         ; record_commitment
+         ; asset_id_high
+         ; asset_id_low
+         ; base
+         } :
+          t ) =
+      { encoding_version
+      ; registry_index
+      ; record_commitment
+      ; asset_id_high
       ; asset_id_low
       ; base = Deposit_params_base.to_serializable base
       }
@@ -1157,13 +1209,7 @@ module Bridge = struct
     [@@deriving yojson]
 
     let of_serializable ~registry_vk_hash
-        ({ proof
-         ; proof_source
-         ; proof_target
-         ; init
-         ; excess
-         ; append_path
-         } :
+        ({ proof; proof_source; proof_target; init; excess; append_path } :
           serializable ) : Registry.Register.Witness.t =
       { scan =
           Registry.Scan_inst.make ?proof ~proof_source ~proof_target init excess
@@ -1392,8 +1438,8 @@ module Bridge = struct
       }
     [@@deriving yojson]
 
-    let of_serializable ({ public_key; asset; amount } : serializable) ~vk_hash :
-        t =
+    let of_serializable ({ public_key; asset; amount } : serializable) ~vk_hash
+        : t =
       { public_key; vk_hash; asset; amount }
   end
 
@@ -1401,7 +1447,10 @@ module Bridge = struct
     type t = Bridge_state.Withdrawal_params_ethereum_token.t
 
     type serializable =
-      { asset_id_high : F.t
+      { encoding_version : Checked32.t
+      ; registry_index : Checked32.t
+      ; record_commitment : F.t
+      ; asset_id_high : F.t
       ; asset_id_low : F.t
       ; token_owner_body : Account_update.Body.Stable.Latest.t
       ; nested_children :
@@ -1420,7 +1469,10 @@ module Bridge = struct
     [@@deriving yojson]
 
     let of_serializable ~proof_cache_db
-        ({ asset_id_high
+        ({ encoding_version
+         ; registry_index
+         ; record_commitment
+         ; asset_id_high
          ; asset_id_low
          ; token_owner_body
          ; nested_children
@@ -1433,7 +1485,10 @@ module Bridge = struct
         Zkapp_command.Call_forest.With_hashes.write_all_proofs_to_disk
           ~proof_cache_db
       in
-      { asset_id_high
+      { encoding_version
+      ; registry_index
+      ; record_commitment
+      ; asset_id_high
       ; asset_id_low
       ; custom =
           { token_owner_body
@@ -1443,7 +1498,10 @@ module Bridge = struct
       }
 
     let to_serializable
-        ({ asset_id_high
+        ({ encoding_version
+         ; registry_index
+         ; record_commitment
+         ; asset_id_high
          ; asset_id_low
          ; custom =
              { token_owner_body
@@ -1455,7 +1513,10 @@ module Bridge = struct
       let read =
         Zkapp_command.Call_forest.With_hashes.read_all_proofs_from_disk
       in
-      { asset_id_high
+      { encoding_version
+      ; registry_index
+      ; record_commitment
+      ; asset_id_high
       ; asset_id_low
       ; token_owner_body
       ; nested_children = read nested_children

--- a/src/app/zeko/zeko_types/zeko_types.ml
+++ b/src/app/zeko/zeko_types/zeko_types.ml
@@ -56,6 +56,14 @@ module Outer_rules_inst = Outer_rules.Make (Zeko_circuits_config.Inputs) ()
 module Bridge_inst_mina =
   Bridge_rules.Make_mina (Zeko_circuits_config.Inputs) ()
 
+module Bridge_inst_ethereum_token =
+  Bridge_rules.Make_ethereum_token
+    (struct
+      include Zeko_circuits_config.Inputs
+      include Zeko_circuits_config.Inputs.Ethereum_token
+    end)
+    ()
+
 module F = struct
   include F
 
@@ -934,6 +942,38 @@ module Bridge = struct
               ~proof_cache_db:(Proof_cache_tag.create_identity_db ()))
   end
 
+  module Deposit_params_ethereum_token = struct
+    type t = Bridge_state.Deposit_params_ethereum_token.t
+
+    type serializable =
+      { asset_id_high : F.t
+      ; asset_id_low : F.t
+      ; base : Deposit_params_base.serializable
+      }
+    [@@deriving yojson]
+
+    let of_serializable ~proof_cache_db
+        ({ asset_id_high; asset_id_low; base } : serializable) : t =
+      { asset_id_high
+      ; asset_id_low
+      ; base = Deposit_params_base.of_serializable ~proof_cache_db base
+      }
+
+    let to_serializable ({ asset_id_high; asset_id_low; base } : t) =
+      { asset_id_high
+      ; asset_id_low
+      ; base = Deposit_params_base.to_serializable base
+      }
+
+    let to_yojson = Fn.compose serializable_to_yojson to_serializable
+
+    let of_yojson json =
+      Ppx_deriving_yojson_runtime.(
+        serializable_of_yojson json
+        >|= of_serializable
+              ~proof_cache_db:(Proof_cache_tag.create_identity_db ()))
+  end
+
   module Check_accepted_mina = struct
     include Bridge_inst_mina.Check_accepted
     include Bridge_inst_mina.Check_accepted.Definition
@@ -988,6 +1028,79 @@ module Bridge = struct
       .make ?proof ~proof_source ~proof_target init excess
   end
 
+  module Check_accepted_ethereum_token = struct
+    include Bridge_inst_ethereum_token.Check_accepted
+    include Bridge_inst_ethereum_token.Check_accepted.Definition
+
+    module Stmt = struct
+      type t = Bridge_inst_ethereum_token.Check_accepted.Definition.Stmt.t =
+        { params : Deposit_params_ethereum_token.t
+        ; action_state : Outer_action_state.t
+        ; deposit_index : Checked32.t
+        ; n_steps : Checked32.t
+        ; is_rejected : bool
+        ; is_accepted : bool
+        }
+      [@@deriving yojson]
+    end
+
+    module Elem = struct
+      type t = Bridge_inst_ethereum_token.Check_accepted.Definition.Elem.t
+
+      include
+        Snarky_serializable_unsafe
+          (Bridge_inst_ethereum_token.Check_accepted.Definition.Elem)
+    end
+
+    module Init = struct
+      type t = Bridge_inst_ethereum_token.Check_accepted.Definition.Init.t =
+        { params : Deposit_params_ethereum_token.t
+        ; original_action_state : Outer_action_state.t
+        ; deposit_index : Checked32.t
+        }
+
+      type serializable =
+        { params : Deposit_params_ethereum_token.serializable
+        ; original_action_state : Outer_action_state.t
+        ; deposit_index : Checked32.t
+        }
+      [@@deriving yojson]
+
+      let of_serializable ~proof_cache_db
+          ({ params; original_action_state; deposit_index } : serializable) : t
+          =
+        { params =
+            Deposit_params_ethereum_token.of_serializable ~proof_cache_db params
+        ; original_action_state
+        ; deposit_index
+        }
+
+      let to_serializable ({ params; original_action_state; deposit_index } : t)
+          =
+        { params = Deposit_params_ethereum_token.to_serializable params
+        ; original_action_state
+        ; deposit_index
+        }
+    end
+
+    type serializable =
+      { proof : Compile_simple.Proof.t option
+      ; proof_source : Stmt.t
+      ; proof_target : Stmt.t
+      ; init : Init.serializable
+      ; excess : Elem.t list
+      }
+    [@@deriving yojson]
+
+    let of_serializable ~proof_cache_db
+        ({ proof; proof_source; proof_target; init; excess } : serializable) =
+      Bridge_inst_ethereum_token.Rule_bridge_finalize_deposit
+      .Check_accepted_inst
+      .make ?proof ~proof_source ~proof_target
+        (Init.of_serializable ~proof_cache_db init)
+        excess
+  end
+
   module Finalize_deposit = struct
     module Ase_inst = Ase.Make_serializable_ase (struct
       module Ase_system = Ase.With_length
@@ -1028,6 +1141,57 @@ module Bridge = struct
       ; inner_authorization_kind
       ; ase = Ase_inst.of_serializable ase
       ; check_accepted = Check_accepted_mina.of_serializable check_accepted
+      ; prev_next_deposit
+      ; prev_nonce =
+          Mina_numbers.Account_nonce.of_string (Checked32.to_string prev_nonce)
+      ; helper_account_new
+      }
+  end
+
+  module Finalize_ethereum_token_deposit = struct
+    module Ase_inst = Ase.Make_serializable_ase (struct
+      module Ase_system = Ase.With_length
+      module Action_state = Outer_action_state.With_length
+
+      module Ase_inst =
+        Bridge_inst_ethereum_token.Rule_bridge_finalize_deposit.Ase_inst
+    end)
+
+    type t = Bridge_inst_ethereum_token.Rule_bridge_finalize_deposit.Witness.t
+
+    type serializable =
+      { public_key : Public_key.Compressed.t
+      ; may_use_token :
+          Bridge_inst_ethereum_token.Rule_bridge_finalize_deposit.May_use_token
+          .t
+      ; inner_authorization_kind : Rule_bridge_finalize_deposit.A.t
+      ; ase : Ase_inst.serializable
+      ; check_accepted : Check_accepted_ethereum_token.serializable
+      ; prev_next_deposit : Checked32.t
+      ; prev_nonce : Checked32.t
+      ; helper_account_new : bool
+      }
+    [@@deriving yojson]
+
+    let of_serializable ~proof_cache_db
+        ({ public_key
+         ; may_use_token
+         ; inner_authorization_kind
+         ; ase
+         ; check_accepted
+         ; prev_next_deposit
+         ; prev_nonce
+         ; helper_account_new
+         } :
+          serializable ) ~vk_hash : t =
+      { public_key
+      ; vk_hash
+      ; may_use_token
+      ; inner_authorization_kind
+      ; ase = Ase_inst.of_serializable ase
+      ; check_accepted =
+          Check_accepted_ethereum_token.of_serializable ~proof_cache_db
+            check_accepted
       ; prev_next_deposit
       ; prev_nonce =
           Mina_numbers.Account_nonce.of_string (Checked32.to_string prev_nonce)
@@ -1141,6 +1305,93 @@ module Bridge = struct
 
     let of_serializable ({ public_key; amount } : serializable) ~vk_hash : t =
       { public_key; vk_hash; amount }
+  end
+
+  module Inner_receive_ethereum_token = struct
+    type t = Bridge_inst_ethereum_token.Rule_bridge_inner_receive.Witness.t
+
+    type serializable =
+      { public_key : Public_key.Compressed.t; amount : Currency.Amount.t }
+    [@@deriving yojson]
+
+    let of_serializable ({ public_key; amount } : serializable) ~vk_hash : t =
+      { public_key; vk_hash; amount }
+  end
+
+  module Withdrawal_params_ethereum_token = struct
+    type t = Bridge_state.Withdrawal_params_ethereum_token.t
+
+    type serializable =
+      { asset_id_high : F.t
+      ; asset_id_low : F.t
+      ; token_owner_body : Account_update.Body.Stable.Latest.t
+      ; nested_children :
+          ( Account_update.Stable.Latest.t
+          , Zkapp_command.Digest.Account_update.t
+          , Zkapp_command.Digest.Forest.t )
+          Zkapp_command.Call_forest.t
+      ; children :
+          ( Account_update.Stable.Latest.t
+          , Zkapp_command.Digest.Account_update.t
+          , Zkapp_command.Digest.Forest.t )
+          Zkapp_command.Call_forest.t
+      ; amount : Currency.Amount.t
+      ; recipient : Public_key.Compressed.t
+      }
+    [@@deriving yojson]
+
+    let of_serializable ~proof_cache_db
+        ({ asset_id_high
+         ; asset_id_low
+         ; token_owner_body
+         ; nested_children
+         ; children
+         ; amount
+         ; recipient
+         } :
+          serializable ) : t =
+      let write =
+        Zkapp_command.Call_forest.With_hashes.write_all_proofs_to_disk
+          ~proof_cache_db
+      in
+      { asset_id_high
+      ; asset_id_low
+      ; custom =
+          { token_owner_body
+          ; nested_children = write nested_children
+          ; base = { children = write children; amount; recipient }
+          }
+      }
+
+    let to_serializable
+        ({ asset_id_high
+         ; asset_id_low
+         ; custom =
+             { token_owner_body
+             ; nested_children
+             ; base = { children; amount; recipient }
+             }
+         } :
+          t ) =
+      let read =
+        Zkapp_command.Call_forest.With_hashes.read_all_proofs_from_disk
+      in
+      { asset_id_high
+      ; asset_id_low
+      ; token_owner_body
+      ; nested_children = read nested_children
+      ; children = read children
+      ; amount
+      ; recipient
+      }
+
+    let to_yojson = Fn.compose serializable_to_yojson to_serializable
+
+    let of_yojson json =
+      Ppx_deriving_yojson_runtime.(
+        serializable_of_yojson json
+        >|= of_serializable
+              ~proof_cache_db:(Proof_cache_tag.create_identity_db ()))
   end
 
   module Finalize_withdrawal = struct

--- a/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
+++ b/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
@@ -20,10 +20,10 @@ module Test_module = struct
 
   let account_id = Account_id.create pk_compressed Token_id.default
 
-  (* This fixture is also linked into the Zeko sequencer integration test. Keep
-     its independent Pickles compilation lazy so an executable can establish
-     the dependency order of its own recursive circuits before the fixture is
-     first used. *)
+  (* ZEKO NOTE: This fixture is also linked into the Zeko sequencer integration
+     test. Keep its independent Pickles compilation lazy so an executable can
+     establish the dependency order of its own recursive circuits before the
+     fixture is first used. *)
   let compiled =
     lazy
       (let tag, _, _, Pickles.Provers.[ initialize_prover; update_state_prover ]

--- a/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
+++ b/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
@@ -20,78 +20,86 @@ module Test_module = struct
 
   let account_id = Account_id.create pk_compressed Token_id.default
 
-  let ( tag
-      , _
-      , p_module
-      , Pickles.Provers.[ initialize_prover; update_state_prover ] ) =
-    Zkapps_examples.compile () ~cache:Cache_dir.cache
-      ~auxiliary_typ:Impl.Typ.unit
-      ~max_proofs_verified:(module Nat.N0)
-      ~name:"empty_update"
-      ~choices:(fun ~self:_ ->
-        [ Zkapps_initialize_state.initialize_rule pk_compressed
-        ; Zkapps_initialize_state.update_state_rule pk_compressed
-        ] )
-
-  module P = (val p_module)
-
-  let vk =
-    Async.Thread_safe.block_on_async_exn (fun () ->
-        Pickles.Side_loaded.Verification_key.of_compiled tag )
+  (* This fixture is also linked into the Zeko sequencer integration test. Keep
+     its independent Pickles compilation lazy so an executable can establish
+     the dependency order of its own recursive circuits before the fixture is
+     first used. *)
+  let compiled =
+    lazy
+      (let tag, _, _, Pickles.Provers.[ initialize_prover; update_state_prover ]
+           =
+         Zkapps_examples.compile () ~cache:Cache_dir.cache
+           ~auxiliary_typ:Impl.Typ.unit
+           ~max_proofs_verified:(module Nat.N0)
+           ~name:"empty_update"
+           ~choices:(fun ~self:_ ->
+             [ Zkapps_initialize_state.initialize_rule pk_compressed
+             ; Zkapps_initialize_state.update_state_rule pk_compressed
+             ] )
+       in
+       let vk =
+         Async.Thread_safe.block_on_async_exn (fun () ->
+             Pickles.Side_loaded.Verification_key.of_compiled tag )
+       in
+       (vk, initialize_prover, update_state_prover) )
 
   module Deploy_account_update = struct
-    let account_update_body : Account_update.Body.t =
-      { Account_update.Body.dummy with
-        public_key = pk_compressed
-      ; update =
-          { Account_update.Update.dummy with
-            verification_key =
-              Set
-                { data = vk
-                ; hash =
-                    (* TODO: This function should live in
-                       [Side_loaded_verification_key].
-                    *)
-                    Zkapp_account.digest_vk vk
-                }
-          ; permissions =
-              Set
-                { edit_state = Proof
-                ; send = Proof
-                ; receive = Proof
-                ; access = None
-                ; set_delegate = Proof
-                ; set_permissions = Proof
-                ; set_verification_key =
-                    (Proof, Mina_numbers.Txn_version.current)
-                ; set_zkapp_uri = Proof
-                ; edit_action_state = Proof
-                ; set_token_symbol = Proof
-                ; increment_nonce = Proof
-                ; set_voting_for = Proof
-                ; set_timing = Proof
-                }
-          }
-      ; use_full_commitment = true
-      ; preconditions =
-          { Account_update.Preconditions.network =
-              Zkapp_precondition.Protocol_state.accept
-          ; account = Zkapp_precondition.Account.accept
-          ; valid_while = Ignore
-          }
-      ; authorization_kind = Signature
-      ; implicit_account_creation_fee = false
-      }
-
-    let account_update : Account_update.t =
-      (* TODO: This is a pain. *)
-      Account_update.with_aux ~body:account_update_body
-        ~authorization:(Control.Poly.Signature Signature.dummy)
+    let account_update : Account_update.t Lazy.t =
+      lazy
+        (let vk, _, _ = Lazy.force compiled in
+         let account_update_body : Account_update.Body.t =
+           { Account_update.Body.dummy with
+             public_key = pk_compressed
+           ; update =
+               { Account_update.Update.dummy with
+                 verification_key =
+                   Set
+                     { data = vk
+                     ; hash =
+                         (* TODO: This function should live in
+                            [Side_loaded_verification_key].
+                         *)
+                         Zkapp_account.digest_vk vk
+                     }
+               ; permissions =
+                   Set
+                     { edit_state = Proof
+                     ; send = Proof
+                     ; receive = Proof
+                     ; access = None
+                     ; set_delegate = Proof
+                     ; set_permissions = Proof
+                     ; set_verification_key =
+                         (Proof, Mina_numbers.Txn_version.current)
+                     ; set_zkapp_uri = Proof
+                     ; edit_action_state = Proof
+                     ; set_token_symbol = Proof
+                     ; increment_nonce = Proof
+                     ; set_voting_for = Proof
+                     ; set_timing = Proof
+                     }
+               }
+           ; use_full_commitment = true
+           ; preconditions =
+               { Account_update.Preconditions.network =
+                   Zkapp_precondition.Protocol_state.accept
+               ; account = Zkapp_precondition.Account.accept
+               ; valid_while = Ignore
+               }
+           ; authorization_kind = Signature
+           ; implicit_account_creation_fee = false
+           }
+         in
+         (* TODO: This is a pain. *)
+         Account_update.with_aux ~body:account_update_body
+           ~authorization:(Control.Poly.Signature Signature.dummy) )
   end
 
   module Initialize_account_update = struct
-    let account_update, () =
-      Async.Thread_safe.block_on_async_exn initialize_prover
+    let account_update =
+      lazy
+        (let _, initialize_prover, _ = Lazy.force compiled in
+         Async.Thread_safe.block_on_async_exn initialize_prover |> fst )
   end
 
   module Update_state_account_update = struct
@@ -99,10 +107,13 @@ module Test_module = struct
       List.init Zkapp_state.max_size_int ~f:(fun _ ->
           Snark_params.Tick.Field.one )
 
-    let account_update, () =
-      Async.Thread_safe.block_on_async_exn
-        (update_state_prover
-           ~handler:(Zkapps_initialize_state.update_state_handler new_state) )
+    let account_update =
+      lazy
+        (let _, _, update_state_prover = Lazy.force compiled in
+         Async.Thread_safe.block_on_async_exn
+           (update_state_prover
+              ~handler:(Zkapps_initialize_state.update_state_handler new_state) )
+         |> fst )
   end
 
   let test_zkapp_command ?expected_failure zkapp_command =
@@ -190,9 +201,9 @@ module Test_module = struct
     let account =
       []
       |> Zkapp_command.Call_forest.cons_tree
-           Initialize_account_update.account_update
+           (Lazy.force Initialize_account_update.account_update)
       |> Zkapp_command.Call_forest.cons ~signature_kind
-           Deploy_account_update.account_update
+           (Lazy.force Deploy_account_update.account_update)
       |> test_zkapp_command
     in
     let zkapp_state =
@@ -206,11 +217,11 @@ module Test_module = struct
     let account =
       []
       |> Zkapp_command.Call_forest.cons_tree
-           Update_state_account_update.account_update
+           (Lazy.force Update_state_account_update.account_update)
       |> Zkapp_command.Call_forest.cons_tree
-           Initialize_account_update.account_update
+           (Lazy.force Initialize_account_update.account_update)
       |> Zkapp_command.Call_forest.cons ~signature_kind
-           Deploy_account_update.account_update
+           (Lazy.force Deploy_account_update.account_update)
       |> test_zkapp_command
     in
     let zkapp_state =
@@ -224,13 +235,13 @@ module Test_module = struct
     let account =
       []
       |> Zkapp_command.Call_forest.cons_tree
-           Update_state_account_update.account_update
+           (Lazy.force Update_state_account_update.account_update)
       |> Zkapp_command.Call_forest.cons_tree
-           Update_state_account_update.account_update
+           (Lazy.force Update_state_account_update.account_update)
       |> Zkapp_command.Call_forest.cons_tree
-           Initialize_account_update.account_update
+           (Lazy.force Initialize_account_update.account_update)
       |> Zkapp_command.Call_forest.cons ~signature_kind
-           Deploy_account_update.account_update
+           (Lazy.force Deploy_account_update.account_update)
       |> test_zkapp_command
     in
     let zkapp_state =
@@ -244,9 +255,9 @@ module Test_module = struct
     let account =
       []
       |> Zkapp_command.Call_forest.cons_tree
-           Update_state_account_update.account_update
+           (Lazy.force Update_state_account_update.account_update)
       |> Zkapp_command.Call_forest.cons ~signature_kind
-           Deploy_account_update.account_update
+           (Lazy.force Deploy_account_update.account_update)
       |> test_zkapp_command
            ~expected_failure:
              (Account_proved_state_precondition_unsatisfied, Pass_2)
@@ -257,11 +268,11 @@ module Test_module = struct
     let account =
       []
       |> Zkapp_command.Call_forest.cons_tree
-           Initialize_account_update.account_update
+           (Lazy.force Initialize_account_update.account_update)
       |> Zkapp_command.Call_forest.cons_tree
-           Initialize_account_update.account_update
+           (Lazy.force Initialize_account_update.account_update)
       |> Zkapp_command.Call_forest.cons ~signature_kind
-           Deploy_account_update.account_update
+           (Lazy.force Deploy_account_update.account_update)
       |> test_zkapp_command
            ~expected_failure:
              (Account_proved_state_precondition_unsatisfied, Pass_2)
@@ -272,13 +283,13 @@ module Test_module = struct
     let account =
       []
       |> Zkapp_command.Call_forest.cons_tree
-           Initialize_account_update.account_update
+           (Lazy.force Initialize_account_update.account_update)
       |> Zkapp_command.Call_forest.cons_tree
-           Update_state_account_update.account_update
+           (Lazy.force Update_state_account_update.account_update)
       |> Zkapp_command.Call_forest.cons_tree
-           Initialize_account_update.account_update
+           (Lazy.force Initialize_account_update.account_update)
       |> Zkapp_command.Call_forest.cons ~signature_kind
-           Deploy_account_update.account_update
+           (Lazy.force Deploy_account_update.account_update)
       |> test_zkapp_command
            ~expected_failure:
              (Account_proved_state_precondition_unsatisfied, Pass_2)
@@ -293,9 +304,9 @@ module Test_module = struct
           *)
           []
           |> Zkapp_command.Call_forest.cons_tree
-               Update_state_account_update.account_update
+               (Lazy.force Update_state_account_update.account_update)
           |> Zkapp_command.Call_forest.cons_tree
-               Initialize_account_update.account_update
+               (Lazy.force Initialize_account_update.account_update)
           |> test_zkapp_command )
     in
     assert (Or_error.is_error account)


### PR DESCRIPTION
## Intent

Fix the actionable review findings for the universal ERC20 registry PoC on feature/universal-erc20-registry, preserving explicit legacy V1 behavior and the existing stacked PR #428 targeting feature/erc20-token-bridge. Validate that the Pickles commit circuit binds old/new registry accounts to source/target ledger roots, governed registration authorization, real owner/admin/vault/circulation account constraints, V2 action version/index/record commitment binding, odd Mina public-key transport, and public runtime root/count/config values. Use focused builds and fake/vector proofs only; do not run paid Succinct jobs, --prove, Groth16, PLONK generation, or the CPU-heavy real proving path. Preserve unrelated work and update the existing branch/PR rather than creating a new independent PR.

## What Changed

- Add a governed, append-only Ethereum asset registry with commit-circuit bindings for ledger roots, registry checkpoints, registration authority, and bounded Mina fungible-token inventory.
- Add registry-backed V2 ERC20 deposit and withdrawal proving across the sequencer, GraphQL, archive, deployment, and settlement export paths while preserving explicit legacy V1 behavior.
- Add registry and bridge design documentation plus vector, fake-proof, integration, and configuration coverage for multi-asset flows and settlement metadata.

## Risk Assessment

⚠️ Medium: No material source defects were found, but the broad, security-sensitive circuit, settlement, and admission changes retain meaningful integration risk despite focused regression coverage.

## Testing

After baseline inspection and repairing the clean checkout’s missing toolchain inputs, the focused registry, bridge, and CLI builds; authenticated registry fake proofs; commit/bridge adversarial vectors; legacy V1 compatibility; V2 bindings; odd-key transport; and public config/state evidence checks all passed. No paid, real, Succinct, Groth16, PLONK-generation, or `--prove` path ran, and all generated build/submodule setup was removed.

<details>
<summary>Evidence: Authenticated registry fake-proof transcript and witness</summary>

```text
compile_simple.fake: called for circuit folder(Ethereum asset registry exhaustive scan) from src/app/zeko/circuits/folder.ml:265
compile_simple.fake: hashed folder(Ethereum asset registry exhaustive scan)
compile_simple.fake: called for circuit Ethereum asset registry from src/app/zeko/circuits/asset_registry.ml:712
compile_simple.fake: hashed Ethereum asset registry
compile_simple.fake: proving folder(Ethereum asset registry exhaustive scan).Rule_leaf_option
compile_simple.fake: folder(Ethereum asset registry exhaustive scan).Rule_leaf_option done
compile_simple.fake: proving Ethereum asset registry.register Ethereum asset
compile_simple.fake: Ethereum asset registry.register Ethereum asset done
compile_simple.fake: proving folder(Ethereum asset registry exhaustive scan).Rule_leaf
compile_simple.fake: folder(Ethereum asset registry exhaustive scan).Rule_leaf done
compile_simple.fake: proving Ethereum asset registry.register Ethereum asset
compile_simple.fake: Ethereum asset registry.register Ethereum asset done
compile_simple.fake: proving folder(Ethereum asset registry exhaustive scan).Rule_leaf
compile_simple.fake: folder(Ethereum asset registry exhaustive scan).Rule_leaf done
compile_simple.fake: proving Ethereum asset registry.register Ethereum asset
compile_simple.fake: proving folder(Ethereum asset registry exhaustive scan).Rule_leaf
compile_simple.fake: proving folder(Ethereum asset registry exhaustive scan).Rule_leaf
compile_simple.fake: proving folder(Ethereum asset registry exhaustive scan).Rule_leaf
compile_simple.fake: proving folder(Ethereum asset registry exhaustive scan).Rule_leaf
compile_simple.fake: proving folder(Ethereum asset registry exhaustive scan).Rule_leaf
compile_simple.fake: folder(Ethereum asset registry exhaustive scan).Rule_leaf done
compile_simple.fake: proving Ethereum asset registry.register Ethereum asset
compile_simple.fake: proving folder(Ethereum asset registry exhaustive scan).Rule_leaf
compile_simple.fake: proving folder(Ethereum asset registry exhaustive scan).Rule_leaf
compile_simple.fake: proving folder(Ethereum asset registry exhaustive scan).Rule_leaf_option
compile_simple.fake: folder(Ethereum asset registry exhaustive scan).Rule_leaf_option done
compile_simple.fake: proving Ethereum asset registry.register Ethereum asset
{"state":{"root":"0x2575E732DE673A9B2CA46A2FCC133EDAD73EFD7A1CD7EB215312758A58101AAD","leaf_count":"1","schema_version":"1"},"record":{"schema_version":"1","registry_index":"0","asset_id_high":"0x00000000000000000000000000000000000000000000000000000000000003E8","asset_id_low":"0x00000000000000000000000000000000000000000000000000000000000007D0","ethereum_token_address":"0x0000000000000000000000000000000000000000000000000000000000000BB8","token_owner_l2":"B62qmgieGFaJnMccdywGmkfULtzsnrGF6jTfVGv349BK6j92BfPLAYM","token_id_l2":"xWRD8BEokgsvhrztRi3U9Vf9KqUvMC6YdGUoMebEFNMySP4RnX","decimals":"6","inventory_cap":"0.001","mft_standard_vk_id":"0x000000000000000000000000000000000000000000000000000000000001637B","vault_public_key":"B62qnZEEg9nT2zLxDimgEZmyxQGLqV978cGEH7mgEkcd3CzyQxUKAyg","universal_bridge_vk_id":"0x000000000000000000000000000000000000000000000000000000000001637C"},"path":["0x0000000000000000000000000000000000000000000000000000000000000000","0x0C2685EEB6FE3D201D2FBB109AB0E06A938BAB086DAA22064D26515ACC6EE3E5","0x02EB0B3212398F6A0593222084E18EEB4AA30C385304A5CFE91F86B0FBE6ED74","0x213A1B03B5031B037AC8DC5C09C00DF82889B687BB7A231A7B38D147969B234F","0x06136862C819821EE5432BDA5A7504C25263FA410F4B5989507DA0429B52F4CA","0x371D18FEF6708D6B7A8EEB051C10B84F19A967DBB5B252F7E37BF5AB5F8108FD","0x2C56993DA3307D3EA98295DD5FB9CB7F26FA243E81BE22F21AA4DEE610A14ABF","0x3A816C9E13089667861AD93244B317DAAF9D2FE5B17B4E1C7AB316D292D89E78"]}
asset registry vectors: ok
```
</details>
<details>
<summary>Evidence: Commit and universal bridge fake-proof transcript</summary>

```text
compile_simple.fake: called for circuit zeko-transaction-snark from src/app/zeko/circuits/txn_rules.ml:2
compile_simple.fake: hashed zeko-transaction-snark
compile_simple.fake: called for circuit folder(action state extension without length) from src/app/zeko/circuits/folder.ml:265
compile_simple.fake: hashed folder(action state extension without length)
compile_simple.fake: called for circuit folder(action state extension with length) from src/app/zeko/circuits/folder.ml:265
compile_simple.fake: hashed folder(action state extension with length)
compile_simple.fake: called for circuit folder(count_commits) from src/app/zeko/circuits/folder.ml:265
compile_simple.fake: hashed folder(count_commits)
compile_simple.fake: called for circuit folder(emergency da action fold) from src/app/zeko/circuits/folder.ml:265
compile_simple.fake: hashed folder(emergency da action fold)
compile_simple.fake: called for circuit Verify_both_ases from src/app/zeko/circuits/rule_commit.ml:44
compile_simple.fake: hashed Verify_both_ases
compile_simple.fake: called for circuit Verify_emergency_folders from src/app/zeko/circuits/rule_commit.ml:87
compile_simple.fake: hashed Verify_emergency_folders
compile_simple.fake: called for circuit Verify_base_wrappers from src/app/zeko/circuits/rule_commit.ml:117
compile_simple.fake: hashed Verify_base_wrappers
compile_simple.fake: called for circuit Inner_rules from src/app/zeko/circuits/inner_rules.ml:18
compile_simple.fake: hashed Inner_rules
compile_simple.fake: called for circuit Outer_rules from src/app/zeko/circuits/outer_rules.ml:46
compile_simple.fake: hashed Outer_rules
compile_simple.fake: called for circuit folder(check_accepted) from src/app/zeko/circuits/folder.ml:265
compile_simple.fake: hashed folder(check_accepted)
compile_simple.fake: called for circuit Verify_both_ases from src/app/zeko/circuits/rule_bridge_finalize_cancelled_deposit.ml:120
compile_simple.fake: hashed Verify_both_ases
compile_simple.fake: called for circuit Verify_check_accepted_and_ase from src/app/zeko/circuits/rule_bridge_finalize_cancelled_deposit.ml:165
compile_simple.fake: hashed Verify_check_accepted_and_ase
compile_simple.fake: called for circuit bridge rules for mina l1 from src/app/zeko/circuits/bridge_rules.ml:163
compile_simple.fake: hashed bridge rules for mina l1
compile_simple.fake: called for circuit bridge rules for mina l1 from src/app/zeko/circuits/bridge_rules.ml:174
compile_simple.fake: hashed bridge rules for mina l1
compile_simple.fake: called for circuit bridge rules for mina l2 from src/app/zeko/circuits/bridge_rules.ml:180
compile_simple.fake: hashed bridge rules for mina l2
compile_simple.fake: called for circuit bridge rules for mina l1 token owner from src/app/zeko/circuits/bridge_rules.ml:190
compile_simple.fake: hashed bridge rules for mina l1 token owner
compile_simple.fake: called for circuit folder(Ethereum asset registry exhaustive scan) from src/app/zeko/circuits/folder.ml:265
compile_simple.fake: hashed folder(Ethereum asset registry exhaustive scan)
compile_simple.fake: called for circuit Ethereum asset registry from src/app/zeko/circuits/asset_registry.ml:712
compile_simple.fake: hashed Ethereum asset registry
compile_simple.fake: called for circuit folder(check_accepted) from src/app/zeko/circuits/folder.ml:265
compile_simple.fake: hashed folder(check_accepted)
compile_simple.fake: called for circuit universal registry-backed Ethereum asset bridge on l2 from src/app/zeko/circuits/bridge_rules.ml:432
compile_simple.fake: hashed universal registry-backed Ethereum asset bridge on l2
compile_simple.fake: called for circuit Rule_change_permissions from src/app/zeko/circuits/rule_change_permissions.ml:47
compile_simple.fake: hashed Rule_change_permissions
compile_simple.fake: called for circuit folder(Ethereum asset registry exhaustive scan) from src/app/zeko/circuits/folder.ml:265
compile_simple.fake: hashed folder(Ethereum asset registry exhaustive scan)
compile_simple.fake: called for circuit Ethereum asset registry from src/app/zeko/circuits/asset_registry.ml:712
compile_simple.fake: hashed Ethereum asset registry
compile_simple.fake: called for circuit folder(check_accepted) from src/app/zeko/circuits/folder.ml:265
compile_simple.fake: hashed folder(check_accepted)
compile_simple.fake: called for circuit universal registry-backed Ethereum asset bridge on l2 from src/app/zeko/circuits/bridge_rules.ml:432
compile_simple.fake: hashed universal registry-backed Ethereum asset bridge on l2
compile_simple.fake: proving folder(check_accepted).Rule_leaf_option
compile_simple.fake: folder(check_accepted).Rule_leaf_option done
compile_simple.fake: proving universal registry-backed Ethereum asset bridge on l2.finalize deposit
compile_simple.fake: universal registry-backed Ethereum asset bridge on l2.finalize deposit done
compile_simple.fake: proving folder(check_accepted).Rule_leaf_option
compile_simple.fake: folder(check_accepted).Rule_leaf_option done
compile_simple.fake: proving universal registry-backed Ethereum asset bridge on l2.finalize deposit
compile_simple.fake: universal registry-backed Ethereum asset bridge on l2.finalize deposit done
compile_simple.fake: proving universal registry-backed Ethereum asset bridge on l2.inner receive
compile_simple.fake: universal registry-backed Ethereum asset bridge on l2.inner receive done
with_label: failed in registry count advances by at most one
with_label: failed in registry append root transition
with_label: failed in test source registry opening
with_label: failed in test target registry opening
with_label: failed in registry count advances by at most one
with_label: failed in registry append root transition
with_label: failed in registered token owner ledger opening
with_label: failed in registered token owner public key
with_label: failed in registered token owner VK
with_label: failed in registered token owner permissions
with_label: failed in registered token admin public key
with_label: failed in registered token admin VK
with_label: failed in registered token admin permissions
with_label: failed in registered token admin authority revoked
with_label: failed in registered vault public key
with_label: failed in registered vault VK
with_label: failed in registered vault permissions
with_label: failed in registered vault inventory
with_label: failed in registered circulation public key
with_label: failed in registered circulation permissions
with_label: failed in registered circulation supply
with_label: failed in registered vault inventory
with_label: failed in File "src/app/zeko/circuits/bridge_state.ml", line 462, characters 28-35
```
</details>
<details>
<summary>Evidence: Public registry state and circuits configuration</summary>

```text
{
  "publicCircuitsConfig": {
    "chain_l1": [
      "Testnet"
    ],
    "chain_l2": [
      "Testnet"
    ],
    "max_valid_while_size": "4294967295",
    "multisig_key": {
      "public_keys": [
        "B62qpNQZtmrMfJgPn9JLZYrPbH2GBBYhBui6pxVkmDCz9C9LSjX64ko"
      ],
      "quorum": "0x0000000000000000000000000000000000000000000000000000000000000001"
    },
    "holder_accounts_l1": [
      "B62qpNQZtmrMfJgPn9JLZYrPbH2GBBYhBui6pxVkmDCz9C9LSjX64ko"
    ],
    "ethereum_holder_account_l1": "B62qj2VzB9f1fdZZm9sB3ZEqqBhGA9n9tFuLoDezXBiKkNWwak9aBCc",
    "ethereum_assets": {
      "registry_public_key": "B62qrrytZmo8SraqYfJMZ8E3QcK77uAGZhsGJGKmVF5E598E8KX9j6a",
      "registration_authority": "B62qmgieGFaJnMccdywGmkfULtzsnrGF6jTfVGv349BK6j92BfPLAYM",
      "vault_public_key": "B62qnZEEg9nT2zLxDimgEZmyxQGLqV978cGEH7mgEkcd3CzyQxUKAyg",
      "approved_mft_standard_vk_id": "91003",
      "approved_mft_token_vk_hash": "91007",
      "approved_mft_admin_vk_hash": "91008",
      "universal_bridge_vk_id": "91004",
      "universal_bridge_vk_hash": "91009"
    },
    "helper_token_owner_l1": "B62qnJPxfjRRJfyfXDbkxFojRGeQyFwHPRcTkyL7TBr5yK3VuSB4EjZ",
    "zeko_l1": "B62qpcJZn4StWgBc7okd3ZJEhVsNUS2mVhbfHdb5i3K2K4meoE9SSUE",
    "emergency_da_public_key": "B62qjL49JH2qS3t6Zri5QUBpiFmP55Ltcuk6vgY5cH51NGudNm4X4Zx",
    "withdrawal_delay": "5",
    "bridge_fee_recipient_l1": "B62qrpwPbZufvjV197akqXDimoXYoNxp7FD4uFQVpguTwVZggywLNE1",
    "bridge_fee_recipient_l2": "B62qprZnWSFPvz2jGuWo69FZMzvbAR2PdUHUriFg6VSjtCCyZvPZydV",
    "outer_account_creation_fee": "1"
  },
  "authenticatedRegistry": {
    "state": {
      "root": "0x2575E732DE673A9B2CA46A2FCC133EDAD73EFD7A1CD7EB215312758A58101AAD",
      "leaf_count": "1",
      "schema_version": "1"
    },
    "record": {
      "schema_version": "1",
      "registry_index": "0",
      "asset_id_high": "0x00000000000000000000000000000000000000000000000000000000000003E8",
      "asset_id_low": "0x00000000000000000000000000000000000000000000000000000000000007D0",
      "ethereum_token_address": "0x0000000000000000000000000000000000000000000000000000000000000BB8",
      "token_owner_l2": "B62qmgieGFaJnMccdywGmkfULtzsnrGF6jTfVGv349BK6j92BfPLAYM",
      "token_id_l2": "xWRD8BEokgsvhrztRi3U9Vf9KqUvMC6YdGUoMebEFNMySP4RnX",
      "decimals": "6",
      "inventory_cap": "0.001",
      "mft_standard_vk_id": "0x000000000000000000000000000000000000000000000000000000000001637B",
      "vault_public_key": "B62qnZEEg9nT2zLxDimgEZmyxQGLqV978cGEH7mgEkcd3CzyQxUKAyg",
      "universal_bridge_vk_id": "0x000000000000000000000000000000000000000000000000000000000001637C"
    },
    "path": [
      "0x0000000000000000000000000000000000000000000000000000000000000000",
      "0x0C2685EEB6FE3D201D2FBB109AB0E06A938BAB086DAA22064D26515ACC6EE3E5",
      "0x02EB0B3212398F6A0593222084E18EEB4AA30C385304A5CFE91F86B0FBE6ED74",
      "0x213A1B03B5031B037AC8DC5C09C00DF82889B687BB7A231A7B38D147969B234F",
      "0x06136862C819821EE5432BDA5A7504C25263FA410F4B5989507DA0429B52F4CA",
      "0x371D18FEF6708D6B7A8EEB051C10B84F19A967DBB5B252F7E37BF5AB5F8108FD",
      "0x2C56993DA3307D3EA98295DD5FB9CB7F26FA243E81BE22F21AA4DEE610A14ABF",
      "0x3A816C9E13089667861AD93244B317DAAF9D2FE5B17B4E1C7AB316D292D89E78"
    ]
  }
}
```
</details>
- Outcome: 🔧 3 issues found → auto-fixed ✅ across 2 runs (1h54m1s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed (5) ✅</summary>

- 🚨 `src/app/zeko/circuits/rule_commit.ml:582` - The required “real owner/admin/vault/circulation account constraints” are not sufficient for the bounded-inventory model: registration requires the standard admin’s live controller to equal the registration signer, but that admin’s `canMint` authorizes unrestricted minting after a signature ([reference implementation](https://github.com/MinaFoundation/mina-fungible-token/blob/main/FungibleTokenAdmin.ts#L62-L65)). This contradicts the design requirement that routine mint authority be revoked or capped after deployment. Require a capped/revoked admin policy or prove rotation away from the live signer.
- 🚨 `src/app/zeko/sequencer/lib/gql.ml:2933` - The required “V2 action version/index/record commitment binding” is broken in settlement plumbing: the V2 withdrawal parameters are archived using the legacy V1 salt, while `withdrawal_action` emits an auxiliary hash using `ethereum_erc20_withdrawal_v2_salt`. Settlement export looks up metadata by the emitted hash, so it cannot recover the token withdrawal preimage. Use the V2 salt here.
- ⚠️ `src/app/zeko/circuits/asset_registry.ml:288` - Registration restricts decimals to values below 10, although the documented contract requires equality with the token’s UInt8 decimals. This rejects valid values 10–255. Remove the narrower bound in favor of an UInt8 bound, or explicitly approve and document the single-digit product restriction.
- ⚠️ `src/app/zeko/sequencer/tests/sequencer_test.ml:413` - The ERC20 integration scenario constructs V2 deposit parameters but hashes them with the V1 salt before submitting synthetic outer actions. The finalization circuit recomputes the V2 hash, so this scenario cannot exercise the required V2 deposit flow. Use `ethereum_erc20_deposit_v2_salt`.

🔧 Fix: Enforce bounded ERC20 registration and V2 bindings
3 issues (2 warnings, 1 info) still open:
- ⚠️ `src/app/zeko/circuits/rule_commit.ml:588` - The approved final `Public_key.Compressed.empty` controller permanently disables the standard admin’s `pause`, `resume`, `setAdmin`, and authorized upgrade paths. This conflicts with the design claims that the token admin provides pause/resume/upgrades and that emergency pause covers L2 token transfers. Confirm that rollup commit freezing alone is intended and update those claims, or retain post-registration token administration, which is incompatible with the empty controller.
- ⚠️ `src/app/zkapps_examples/test/initialize_state/initialize_state.ml:23` - AGENTS.md requires fork-specific changes to upstream Mina code to be `zeko_`-prefixed or marked with `ZEKO NOTE`. This Zeko-specific lazy-compilation change is outside `src/app/zeko`, but its explanatory comment lacks the required marker. Add `ZEKO NOTE` for upstream-sync traceability.
- ℹ️ `src/app/zeko/circuits/rule_commit.ml:142` - After separating registry authorization from final MFT control, `ethereum_asset_registration_authority` is unused by `Rule_commit` but remains threaded through its interface, `Outer_rules`, and test configurations. Remove this obsolete commit-circuit input; registration authorization remains enforced by `Asset_registry.Register`.

🔧 Fix: Align revoked-admin docs and remove stale authority plumbing
2 warnings still open:
- ⚠️ `src/app/zeko/circuits/design/ethereum-erc20-bridge.md:370` - The approved policy preserves the unmodified standard contracts, but this sequence instructs operators to mint and then rotate the same admin’s controller. [`FungibleTokenAdmin`](https://github.com/MinaFoundation/mina-fungible-token/blob/main/FungibleTokenAdmin.ts#L33-L50) writes its controller only during deployment and exposes no rotation method; [`FungibleToken.setAdmin`](https://github.com/MinaFoundation/mina-fungible-token/blob/main/FungibleToken.ts#L122-L128) instead replaces the token owner’s admin contract. Document the reachable flow: mint under a live provisioning admin, deploy a separate empty-controller admin, and install that final admin before registration.
- ⚠️ `src/app/zeko/circuits/design/ethereum-erc20-bridge.md:418` - The active gate runs `test_all_real.exe` and then `run-sequencer-test.sh real`; these invoke real Pickles provers and the non-fake prover service. This contradicts the authoritative criterion “Use focused builds and fake/vector proofs only; do not run … the CPU-heavy real proving path.” Replace them with focused fake/vector gates or explicitly mark them as future release gates outside this PoC validation.

🔧 Fix: Document reachable admin handoff and fake-only PoC gates
4 errors still open:
- 🚨 `src/app/zeko/circuits/rule_commit.ml:1031` - The required “odd Mina public-key transport” remains incomplete: this checkpoint hashes only `registry_public_key.x`, and settlement export likewise serializes only x, so opposite-parity registry keys collide in the public checkpoint representation. Bind `is_odd` in the checkpoint and use the parity-preserving key encoding in `registryPublicKey`.
- 🚨 `src/app/zeko/sequencer/lib/gql.ml:1716` - ERC20 withdrawal recipients accept any compressed Mina key, but settlement export only supports even keys whose x-coordinate fits 160 bits and silently omits metadata otherwise. Such a proof can return tokens to the vault while producing no claimable Ethereum withdrawal. Enforce the Ethereum-address domain in the circuit/API and make missing preimages an export error.
- 🚨 `src/app/zeko/sequencer/lib/gql.ml:2929` - Withdrawal metadata is stored before `Bridge_prover.Ethereum_token_withdrawal_request.f` validates registry membership and record commitment. A rejected request can reuse a valid parameters hash with forged asset data and overwrite the archive entry later consumed by settlement export. Persist only after synchronous precomputation succeeds.
- 🚨 `src/app/zeko/sequencer/lib/zeko_sequencer.ml:904` - The one-registration limit is checked only during commit construction, after valid registration transactions have already advanced the persistent ledger. If two registrations arrive before a commit, this exception terminates the commit attempt and every retry observes the same delta. Either reject/serialize a second pending registration, force an intervening commit, or support multiple appends.

🔧 Fix: Secure ERC20 checkpoint, withdrawal, and registry admission
2 errors still open:
- 🚨 `src/app/zeko/sequencer/lib/zeko_sequencer.ml:345` - The approved requirement to reject a second uncommitted append “at the common transaction-admission boundary … covering every submission path” is still bypassable: `List.exists` reduces all registry updates in one zkApp command to one boolean. A command containing two valid registration updates passes when current equals committed, persists both, and recreates the uncommittable delta of 2. Count matching updates and reject commands containing more than one.
- 🚨 `src/app/zeko/circuits/bridge_state.ml:554` - The approved “Enforce in-circuit and at the API boundary that Ethereum withdrawal recipients are even compressed keys with x fitting exactly the 160-bit Ethereum-address domain” rule is applied only to the V2 registry-binding branch; `None, None` remains unchecked and the native `WithdrawalParamsInput` still accepts arbitrary keys. In Ethereum-settlement mode such a withdrawal can move funds before the new exporter hard-fails on its recipient. Extend validation to every Ethereum-settlement path, or explicitly confirm that the requirement is V2-only to preserve legacy behavior.

🔧 Fix: Enforce registration cardinality and settlement recipient domains
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 3 issues found → auto-fixed ✅</summary>

- 🚨 `src/app/zeko/tests/ethereum_bridge_vectors.ml:1439` - The vector test does not compile: the result of `ethereum_withdrawal_preimage_json` is ignored without the type annotation required by the Jane Street PPX style check.
- 🚨 `src/app/zeko/circuits/asset_registry.mli:55` - `asset_registry.ml` defines `Checkpoint`, but `asset_registry.mli` does not expose it. The definitions are rejected as unused and `rule_commit.ml` cannot resolve `Asset_registry.Checkpoint`.
- 🚨 `src/app/zeko/circuits/bridge_state.ml:23` - The bridge and sequencer builds fail because Ethereum recipient validation calls unavailable `Snark_params.Tick.Field.to_bits`.
- <code>`no-mistakes axi` (read-only preflight; gate metadata was not initialized in this isolated worktree)</code>
- <code>`git status --short --branch`, `git rev-parse HEAD`, and `git diff --stat a8741e461853cbec731762e8ee013ca87786dab5..ba28a09b0c88b7163e385a99fc21043f69f08c5f`</code>
- <code>`dune build ./src/app/zeko/tests/asset_registry_vectors.exe ./src/app/zeko/tests/ethereum_bridge_vectors.exe ./src/app/zeko/tests/test_all_fake.exe` (initial PATH setup failure)</code>
- <code>`git submodule status --recursive` and `nix develop . --command bash -c &#39;command -v dune; dune --version&#39;` (identified missing pinned submodules)</code>
- `nix develop '.?submodules=1' --command bash -c 'command -v dune; dune --version'`
- `nix develop '.?submodules=1' --command dune build ./src/app/zeko/tests/asset_registry_vectors.exe ./src/app/zeko/tests/ethereum_bridge_vectors.exe ./src/app/zeko/tests/test_all_fake.exe`
- `nix develop '.?submodules=1' --command dune build ./src/app/zeko/sequencer`
- <code>Read-only GitHub metadata check for `zeko-labs/zeko#428`</code>
- <code>`nix develop &#39;.?submodules=1&#39; --command dune clean` followed by clean-worktree and submodule-state verification</code>

🔧 Fix: Fix registry bridge compilation and legacy fake proofs
✅ Re-checked - no issues remain.
- <code>Baseline inspection: `git status --short`; `git rev-parse HEAD`; `git diff --stat --name-status a8741e461853cbec731762e8ee013ca87786dab5..8ae22303b2d8353081d0fb5580a3e0d9e2fc92eb`; `git log --oneline a8741e4..8ae2230`</code>
- <code>Toolchain probes: `nix develop .#default --no-write-lock-file -c dune --version` followed by `nix develop &#39;path:.#default&#39; --no-write-lock-file -c dune --version` after populating the exact submodule revisions</code>
- `nix develop 'path:.#default' --no-write-lock-file -c dune build src/app/zeko/tests/asset_registry_vectors.exe src/app/zeko/tests/ethereum_bridge_vectors.exe`
- `nix develop 'path:.#default' --no-write-lock-file -c bash -lc 'dune exec src/app/zeko/tests/asset_registry_vectors.exe -- --json | tee /tmp/no-mistakes-evidence/01KYMKG1J3EA1MXZC24AQ7ERJT/asset-registry-membership.jsonl'`
- `bash -o pipefail -c '_build/default/src/app/zeko/tests/ethereum_bridge_vectors.exe 2>&1 | tee /tmp/no-mistakes-evidence/01KYMKG1J3EA1MXZC24AQ7ERJT/ethereum-bridge-vectors.log'`
- `nix develop 'path:.#default' --no-write-lock-file -c dune build src/app/zeko/sequencer/cli.exe`
- `_build/default/src/app/zeko/sequencer/cli.exe generate-circuits-config --circuits-config-output …/public-circuits-config.json --deploy-config-output /dev/null [universal ERC20 registry flags]`
- <code>`jq` integrity checks over `registry-public-state-and-config.json`, including root/count/schema, vault identity, and universal bridge configuration</code>
- <code>Final `git status --short`, submodule-state, evidence-integrity, and transient-build cleanup checks</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
