### PR TITLE
Scale Ethereum-backed fees to Mina-equivalent value

### DIFF
--- a/src/app/zeko/circuits/txn_state.ml
+++ b/src/app/zeko/circuits/txn_state.ml
@@ -65,17 +65,7 @@ module Zeko_stmt = struct
 end
 
 let constraint_constants : Genesis_constants.Constraint_constants.t =
-  { sub_windows_per_window = 1
-  ; ledger_depth = Account_set.height
-  ; work_delay = 1
-  ; block_window_duration_ms = 1
-  ; transaction_capacity_log_2 = 1
-  ; pending_coinbase_depth = 1
-  ; coinbase_amount = Currency.Amount.zero
-  ; supercharged_coinbase_factor = 1
-  ; account_creation_fee = Currency.Fee.of_mina_string_exn "0.1"
-  ; fork = None
-  }
+  { Zeko_constants.constraint_constants with ledger_depth = Account_set.height }
 
 type update_acc_set_witness =
   { get_account_set_x : unit -> Token_id.t

--- a/src/app/zeko/sequencer/README.md
+++ b/src/app/zeko/sequencer/README.md
@@ -70,7 +70,7 @@ export ZEKO_SIGNER_AUTH_TOKEN="long random signer token"
 dune exec ../signer/cli.exe -- run \
     --port 9000 \
     --allow-zkapp-signing \
-    --max-fee 10 \
+    --max-fee 0.00025 \
     --max-balance-change 1000000
 ```
 
@@ -92,7 +92,7 @@ dune exec ../signer/cli.exe -- run \
     --host 0.0.0.0 \
     --port 9000 \
     --allow-zkapp-signing \
-    --max-fee 10 \
+    --max-fee 0.00025 \
     --max-balance-change 1000000 \
     --tls-cert-file /path/to/signer-cert.pem \
     --tls-key-file /path/to/signer-key.pem

--- a/src/app/zeko/sequencer/cli.ml
+++ b/src/app/zeko/sequencer/cli.ml
@@ -78,7 +78,7 @@ let send_direct ~logger ~l1_uri ~(signers : Keypair.t list)
     { fee_payer =
         { Account_update.Fee_payer.body =
             { public_key = Public_key.compress fee_signer.public_key
-            ; fee = Currency.Fee.of_mina_string_exn "0.1"
+            ; fee = Zeko_constants.transaction_fee
             ; valid_until = None
             ; nonce
             }
@@ -251,7 +251,8 @@ let generate_circuits_config =
            ; withdrawal_delay = Mina_numbers.Global_slot_span.of_int 5
            ; bridge_fee_recipient_l1 = fst bridge_fee_recipient_l1
            ; bridge_fee_recipient_l2 = fst bridge_fee_recipient_l2
-           ; outer_account_creation_fee = Currency.Fee.of_mina_string_exn "1"
+           ; outer_account_creation_fee =
+               Zeko_constants.outer_account_creation_fee
            }
          in
          let deploy_config : Zeko_circuits_config.Deploy.t =
@@ -1046,8 +1047,8 @@ let multisig_submit =
                in
                let%bind command =
                  Deploy.submit_multisig_update ~kind:first.kind ~signer:sender
-                   ~fee:(Currency.Fee.of_mina_string_exn "0.1")
-                   ~nonce ~payload ~signatures
+                   ~fee:Zeko_constants.transaction_fee ~nonce ~payload
+                   ~signatures
                  >>| Zkapp_command.read_all_proofs_from_disk
                in
                match%map Gql_client.send_zkapp l1_uri command with

--- a/src/app/zeko/sequencer/deploy.ml
+++ b/src/app/zeko/sequencer/deploy.ml
@@ -199,8 +199,8 @@ let generate ~l1_uri ~sender_pk ~ledger_input ~faucet_aid ~pause_key
         Sequencer_lib.Deploy.deploy_command_exn
           ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
           ~signer_pk:sender_pk ~outer_pk ~holder_pk ~token_holder_pk
-          ~fee:(Currency.Fee.of_mina_int_exn 1)
-          ~nonce ~account_creation_fee ~initial_ledger:new_ledger
+          ~fee:Zeko_constants.outer_account_creation_fee ~nonce
+          ~account_creation_fee ~initial_ledger:new_ledger
           ~account_set_hash:imt_hash ~pause_key ~sequencer:sequencer_key
           ~da_key:
             (Multisig.commit
@@ -556,8 +556,8 @@ let deploy_token_owner =
                Sequencer_lib.Deploy.deploy_token_owner_exn
                  ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
                  ~signer:sender_keypair ~token_owner_kp
-                 ~fee:(Currency.Fee.of_mina_int_exn 1)
-                 ~nonce ~account_creation_fee ()
+                 ~fee:Zeko_constants.outer_account_creation_fee ~nonce
+                 ~account_creation_fee ()
              in
              match%bind
                Gql_client.send_zkapp l1_uri

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -1417,7 +1417,7 @@ module Sequencer = struct
       { fee_payer =
           { body =
               { public_key = fee_payer_pk
-              ; fee = Currency.Fee.of_mina_string_exn "0.1"
+              ; fee = bridge_txn_fee
               ; valid_until = None
               ; nonce
               }

--- a/src/app/zeko/sequencer/run.ml
+++ b/src/app/zeko/sequencer/run.ml
@@ -135,7 +135,7 @@ let () =
          ~doc:"float Fee modifier for the sequencer"
      and minimum_fee =
        flag "--minimum-fee"
-         (optional_with_default 0.01 float)
+         (optional_with_default Zeko_constants.minimum_fee float)
          ~doc:"float Minimum fee for the sequencer"
      and slot_acceptance_m =
        flag "--slot-acceptance"
@@ -153,12 +153,12 @@ let () =
        flag "--signer" (required string) ~doc:"string Signer service host:port"
      and commit_fee =
        flag "--commit-fee"
-         (optional_with_default 0.1 float)
-         ~doc:"string Commit fee in mina"
+         (optional_with_default Zeko_constants.transaction_fee_string string)
+         ~doc:"string Commit fee in native units"
      and bridge_txn_fee =
        flag "--bridge-txn-fee"
-         (optional_with_default 0.1 float)
-         ~doc:"string Bridge transaction fee in mina"
+         (optional_with_default Zeko_constants.transaction_fee_string string)
+         ~doc:"string Bridge transaction fee in native units"
      in
      let slot_acceptance = Time.Span.of_min slot_acceptance_m in
      if slot_duration_sec <= 0 then
@@ -176,12 +176,8 @@ let () =
      let commit_validity_period =
        Mina_numbers.Global_slot_span.of_int commit_validity_period
      in
-     let commit_fee =
-       Currency.Fee.of_mina_string_exn (Float.to_string commit_fee)
-     in
-     let bridge_txn_fee =
-       Currency.Fee.of_mina_string_exn (Float.to_string bridge_txn_fee)
-     in
+     let commit_fee = Currency.Fee.of_mina_string_exn commit_fee in
+     let bridge_txn_fee = Currency.Fee.of_mina_string_exn bridge_txn_fee in
      Stdout_log.setup log_json log_level ;
      run ~logger ~port ~max_pool_size ~commitment_period ~da_config ~da_keys
        ~da_quorum ~db_dir ~checkpoints_dir ~postgres_uri ~l1_uri ~archive_uri

--- a/src/app/zeko/tests/test_all_real.ml
+++ b/src/app/zeko/tests/test_all_real.ml
@@ -309,7 +309,7 @@ open struct
         ; pending_coinbase_depth = 1
         ; coinbase_amount = Currency.Amount.zero
         ; supercharged_coinbase_factor = 1
-        ; account_creation_fee = Currency.Fee.of_mina_string_exn "0.1"
+        ; account_creation_fee = Zeko_constants.account_creation_fee
         ; fork = None
         }
 

--- a/src/app/zeko/tests/test_zkapp_real.ml
+++ b/src/app/zeko/tests/test_zkapp_real.ml
@@ -50,7 +50,7 @@ let constraint_constants : Genesis_constants.Constraint_constants.t =
   ; pending_coinbase_depth = 1
   ; coinbase_amount = Currency.Amount.zero
   ; supercharged_coinbase_factor = 1
-  ; account_creation_fee = Currency.Fee.of_mina_string_exn "0.1"
+  ; account_creation_fee = Zeko_constants.account_creation_fee
   ; fork = None
   }
 

--- a/src/app/zeko/zeko_constants.ml
+++ b/src/app/zeko/zeko_constants.ml
@@ -3,6 +3,19 @@ open Mina_base
 open Signature_lib
 module Field = Snark_params.Tick.Run.Field
 
+(* Preserve the approximate fiat value and relative scale of the former
+   Mina-denominated defaults when the native asset is ETH. The conversion uses
+   25,000 native nanounits per former MINA and keeps every fee divisible by 10. *)
+let account_creation_fee = Currency.Fee.of_mina_string_exn "0.0000025"
+
+let minimum_fee = 0.00000025
+
+let transaction_fee_string = "0.0000025"
+
+let transaction_fee = Currency.Fee.of_mina_string_exn transaction_fee_string
+
+let outer_account_creation_fee = Currency.Fee.of_mina_string_exn "0.000025"
+
 let constraint_constants : Genesis_constants.Constraint_constants.t =
   { sub_windows_per_window = 1
   ; ledger_depth = 35
@@ -12,7 +25,7 @@ let constraint_constants : Genesis_constants.Constraint_constants.t =
   ; pending_coinbase_depth = 1
   ; coinbase_amount = Currency.Amount.zero
   ; supercharged_coinbase_factor = 1
-  ; account_creation_fee = Currency.Fee.of_mina_string_exn "0.1"
+  ; account_creation_fee
   ; fork = None
   }
 


### PR DESCRIPTION
## Summary

- centralize the Ethereum-value fee scale at 25,000 native nanounits per former MINA
- lower the L2 account-creation/operation fee to 2,500 and the minimum fee to 250, preserving the existing relative ratios
- parse commit and bridge fee CLI values as exact decimal strings so the smaller defaults are not rendered in scientific notation

## Why

The Ethereum-backed deployment inherited Mina-denominated numeric defaults. Values such as the former 0.1 MINA account-creation fee therefore became 0.1 ETH, even though the intended economic cost was only a few cents. This maps the old Mina fee schedule to approximately equivalent Ethereum value and rounds every amount to a multiple of 10.

## Impact

This changes circuit-bound fee values, including account creation and the derived bridge-proof fee. Deployment requires rebuilt Zeko artifacts and coordinated settlement configuration. Non-Ethereum deployment profiles are intentionally unchanged.

## Validation

- `dune build ./src/app/zeko/sequencer ./src/app/zeko/da_layer ./src/app/zeko/signer`
- scoped `ocamlformat --check` for all changed OCaml files
- `dune exec ./src/app/zeko/sequencer/run.exe -- --help`

A broader build of `test_zkapp_real.exe` remains blocked by the base branch's pre-existing missing `global_slot` witness field; the failure is unrelated to this diff.
