### PR TITLE
Make fixture DA topology configurable

### DIFF
--- a/src/app/zeko/sequencer/tests/run-sequencer-test.sh
+++ b/src/app/zeko/sequencer/tests/run-sequencer-test.sh
@@ -14,6 +14,7 @@ MODE="$1"
 NUM_PROVERS="$2"
 PROVER_PIDS=()
 SIGNER_PIDS=()
+DA_PIDS=()
 PROVERS=()
 
 AGENT="$3"
@@ -37,14 +38,35 @@ if ! [[ "$NUM_PROVERS" =~ ^[1-9][0-9]*$ ]]; then
   usage
 fi
 
+EXPORT_ONLY=false
+if [[ ${ZEKO_ETHEREUM_BRIDGE_EXPORT_ONLY:-false} == true || \
+      ${ZEKO_ETHEREUM_SEQUENTIAL_EXPORT_ONLY:-false} == true ]]; then
+  EXPORT_ONLY=true
+fi
+if [[ $EXPORT_ONLY == true ]]; then
+  ZEKO_TEST_DA_NODE_COUNT=${ZEKO_TEST_DA_NODE_COUNT:-3}
+  ZEKO_TEST_DA_QUORUM=${ZEKO_TEST_DA_QUORUM:-2}
+else
+  ZEKO_TEST_DA_NODE_COUNT=3
+  ZEKO_TEST_DA_QUORUM=2
+fi
+[[ $ZEKO_TEST_DA_NODE_COUNT =~ ^[1-3]$ ]] || {
+  echo "ZEKO_TEST_DA_NODE_COUNT must be between 1 and 3" >&2
+  exit 1
+}
+[[ $ZEKO_TEST_DA_QUORUM =~ ^[1-3]$ && \
+   $ZEKO_TEST_DA_QUORUM -le $ZEKO_TEST_DA_NODE_COUNT ]] || {
+  echo "ZEKO_TEST_DA_QUORUM must be between 1 and ZEKO_TEST_DA_NODE_COUNT" >&2
+  exit 1
+}
+export ZEKO_TEST_DA_NODE_COUNT ZEKO_TEST_DA_QUORUM
+
 cleanup() {
   local exit_status=$1
   echo "Cleaning up..."
   local -a service_pids=(
     "${l1_pid:-}"
-    "${da1_pid:-}"
-    "${da2_pid:-}"
-    "${da3_pid:-}"
+    "${DA_PIDS[@]}"
     "${PROVER_PIDS[@]}"
     "${SIGNER_PIDS[@]}"
   )
@@ -176,9 +198,15 @@ SEQUENCER_SIGNER_BIN="$SIGNER_BUILD_ROOT/cli.exe"
 DA_SIGNER_BIN="$SIGNER_BUILD_ROOT/cli.exe"
 
 ZEKO_TEST_SEQUENCER_SIGNER_PRIVATE_KEY="${ZEKO_TEST_SEQUENCER_SIGNER_PRIVATE_KEY:-$(generate_even_key)}"
-DA1_SIGNER_PRIVATE_KEY="${DA1_SIGNER_PRIVATE_KEY:-$(generate_even_key)}"
-DA2_SIGNER_PRIVATE_KEY="${DA2_SIGNER_PRIVATE_KEY:-$(generate_even_key)}"
-DA3_SIGNER_PRIVATE_KEY="${DA3_SIGNER_PRIVATE_KEY:-$(generate_even_key)}"
+DA_SIGNER_PRIVATE_KEYS=()
+for ((index = 1; index <= ZEKO_TEST_DA_NODE_COUNT; index++)); do
+  private_key_variable="DA${index}_SIGNER_PRIVATE_KEY"
+  private_key=${!private_key_variable:-}
+  if [[ -z $private_key ]]; then
+    private_key=$(generate_even_key)
+  fi
+  DA_SIGNER_PRIVATE_KEYS+=("$private_key")
+done
 ZEKO_SIGNER_AUTH_TOKEN="sequencer-test-signer-token"
 SIGNER_TLS_CERT="$TMP_DIR/signer-tls-cert.pem"
 SIGNER_TLS_KEY="$TMP_DIR/signer-tls-key.pem"
@@ -217,43 +245,36 @@ run "sequencer-signer" \
 signer_seq_pid=$!
 SIGNER_PIDS+=("$signer_seq_pid")
 
-run "da1-signer" \
-  env MINA_PRIVATE_KEY="$DA1_SIGNER_PRIVATE_KEY" \
-  "$DA_SIGNER_BIN" run --port 8601 --allow-field-signing \
-    --tls-cert-file "$SIGNER_TLS_CERT" --tls-key-file "$SIGNER_TLS_KEY" &
-signer_da1_pid=$!
-SIGNER_PIDS+=("$signer_da1_pid")
-
-run "da2-signer" \
-  env MINA_PRIVATE_KEY="$DA2_SIGNER_PRIVATE_KEY" \
-  "$DA_SIGNER_BIN" run --port 8602 --allow-field-signing \
-    --tls-cert-file "$SIGNER_TLS_CERT" --tls-key-file "$SIGNER_TLS_KEY" &
-signer_da2_pid=$!
-SIGNER_PIDS+=("$signer_da2_pid")
-
-run "da3-signer" \
-  env MINA_PRIVATE_KEY="$DA3_SIGNER_PRIVATE_KEY" \
-  "$DA_SIGNER_BIN" run --port 8603 --allow-field-signing \
-    --tls-cert-file "$SIGNER_TLS_CERT" --tls-key-file "$SIGNER_TLS_KEY" &
-signer_da3_pid=$!
-SIGNER_PIDS+=("$signer_da3_pid")
+DA_SIGNER_PIDS=()
+for ((index = 1; index <= ZEKO_TEST_DA_NODE_COUNT; index++)); do
+  signer_port=$((8600 + index))
+  run "da${index}-signer" \
+    env MINA_PRIVATE_KEY="${DA_SIGNER_PRIVATE_KEYS[index - 1]}" \
+    "$DA_SIGNER_BIN" run --port "$signer_port" --allow-field-signing \
+      --tls-cert-file "$SIGNER_TLS_CERT" --tls-key-file "$SIGNER_TLS_KEY" &
+  signer_pid=$!
+  SIGNER_PIDS+=("$signer_pid")
+  DA_SIGNER_PIDS+=("$signer_pid")
+done
 
 wait_for_port 8600 $signer_seq_pid
-wait_for_port 8601 $signer_da1_pid
-wait_for_port 8602 $signer_da2_pid
-wait_for_port 8603 $signer_da3_pid
+for ((index = 1; index <= ZEKO_TEST_DA_NODE_COUNT; index++)); do
+  wait_for_port "$((8600 + index))" "${DA_SIGNER_PIDS[index - 1]}"
+done
 
 run "l1" $SEQUENCER_BUILD_ROOT/tests/testing_ledger/run.exe -p 8080 --db-dir "$TMP_DIR/l1_db" --network-id "$ZEKO_TEST_L1_NETWORK_ID" --block-period 9999999 &
 l1_pid=$!
 
-run "da1" $SEQUENCER_BUILD_ROOT/../da_layer/cli.exe run-node --bind-localhost --port 8555 --healthcheck-port 8558 --network-id "$SIGNING_NETWORK_ID" --db-dir "$TMP_DIR/da1_db" --signer localhost:8601 &
-da1_pid=$!
-
-run "da2" $SEQUENCER_BUILD_ROOT/../da_layer/cli.exe run-node --bind-localhost --port 8556 --healthcheck-port 8559 --network-id "$SIGNING_NETWORK_ID" --db-dir "$TMP_DIR/da2_db" --signer localhost:8602 &
-da2_pid=$!
-
-run "da3" $SEQUENCER_BUILD_ROOT/../da_layer/cli.exe run-node --bind-localhost --port 8557 --healthcheck-port 8560 --network-id "$SIGNING_NETWORK_ID" --db-dir "$TMP_DIR/da3_db" --signer localhost:8603 &
-da3_pid=$!
+for ((index = 1; index <= ZEKO_TEST_DA_NODE_COUNT; index++)); do
+  da_port=$((8554 + index))
+  healthcheck_port=$((8557 + index))
+  signer_port=$((8600 + index))
+  run "da${index}" $SEQUENCER_BUILD_ROOT/../da_layer/cli.exe run-node \
+    --bind-localhost --port "$da_port" --healthcheck-port "$healthcheck_port" \
+    --network-id "$SIGNING_NETWORK_ID" --db-dir "$TMP_DIR/da${index}_db" \
+    --signer "localhost:$signer_port" &
+  DA_PIDS+=("$!")
+done
 
 # Launch provers
 if [ "$MODE" = "fake" ]; then
@@ -277,9 +298,9 @@ done
 echo "Waiting for services to start..."
 
 wait_for_port 8080 $l1_pid
-wait_for_port 8555 $da1_pid
-wait_for_port 8556 $da2_pid
-wait_for_port 8557 $da3_pid
+for ((index = 1; index <= ZEKO_TEST_DA_NODE_COUNT; index++)); do
+  wait_for_port "$((8554 + index))" "${DA_PIDS[index - 1]}"
+done
 wait_for_provers "$NUM_PROVERS"
 
 echo "All services started successfully"

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -24,22 +24,62 @@ let logger =
 
 let gql_uri = Uri.of_string "http://localhost:8080/graphql"
 
-let da_config_with2 =
-  Da_layer.Client.Config.of_string_list [ "127.0.0.1:8555"; "127.0.0.1:8556" ]
+let env_flag name =
+  Option.value_map
+    (Stdlib.Sys.getenv_opt name)
+    ~default:false
+    ~f:(String.Caseless.equal "true")
 
-let da_config_with3 =
+let sequential_export_only = env_flag "ZEKO_ETHEREUM_SEQUENTIAL_EXPORT_ONLY"
+
+let bridge_export_only = env_flag "ZEKO_ETHEREUM_BRIDGE_EXPORT_ONLY"
+
+let export_only = sequential_export_only || bridge_export_only
+
+let int_env name ~default =
+  Option.value_map (Stdlib.Sys.getenv_opt name) ~default ~f:(fun value ->
+      try Int.of_string value
+      with _ -> failwithf "%s must be an integer, got %S" name value () )
+
+let export_da_node_count =
+  if export_only then int_env "ZEKO_TEST_DA_NODE_COUNT" ~default:3 else 3
+
+let export_da_quorum =
+  if export_only then int_env "ZEKO_TEST_DA_QUORUM" ~default:2 else 2
+
+let da_node_locations = [ "127.0.0.1:8555"; "127.0.0.1:8556"; "127.0.0.1:8557" ]
+
+let () =
+  if export_only then (
+    if not (Int.between export_da_node_count ~low:1 ~high:3) then
+      failwithf "ZEKO_TEST_DA_NODE_COUNT must be between 1 and 3, got %d"
+        export_da_node_count () ;
+    if not (Int.between export_da_quorum ~low:1 ~high:export_da_node_count) then
+      failwithf
+        "ZEKO_TEST_DA_QUORUM must be between 1 and the DA node count %d, got %d"
+        export_da_node_count export_da_quorum () )
+
+let da_config_with2 =
+  Da_layer.Client.Config.of_string_list (List.take da_node_locations 2)
+
+let da_config_with3 = Da_layer.Client.Config.of_string_list da_node_locations
+
+let export_da_config =
   Da_layer.Client.Config.of_string_list
-    [ "127.0.0.1:8555"; "127.0.0.1:8556"; "127.0.0.1:8557" ]
+    (List.take da_node_locations export_da_node_count)
+
+let active_da_config = if export_only then export_da_config else da_config_with2
+
+let run = Thread_safe.block_on_async_exn
 
 let da_keys =
   run (fun () ->
-      Da_layer.Client.Config.fetch_public_keys ~logger da_config_with3 )
+      Da_layer.Client.Config.fetch_public_keys ~logger
+        (if export_only then export_da_config else da_config_with3) )
 
-let da_quorum = 2
+let da_quorum = if export_only then export_da_quorum else 2
 
 let mq_host = Host_and_port.of_string "localhost:5672"
-
-let run = Thread_safe.block_on_async_exn
 
 let get_test_signer () =
   run (fun () ->
@@ -55,18 +95,6 @@ let free_sequencer (sequencer : Sequencer.t Handle.valid_t) =
   Handle.invalidate sequencer
 
 let slot_acceptance = Time.Span.of_min 60.
-
-let sequential_export_only =
-  Option.value_map
-    (Stdlib.Sys.getenv_opt "ZEKO_ETHEREUM_SEQUENTIAL_EXPORT_ONLY")
-    ~default:false
-    ~f:(String.Caseless.equal "true")
-
-let bridge_export_only =
-  Option.value_map
-    (Stdlib.Sys.getenv_opt "ZEKO_ETHEREUM_BRIDGE_EXPORT_ONLY")
-    ~default:false
-    ~f:(String.Caseless.equal "true")
 
 let bridge_live_sdk =
   Option.value_map
@@ -130,7 +158,7 @@ let () =
     let open Mina_numbers in
     Quickcheck.test ~trials:1
       (Sequencer_spec.gen ~logger ~number_of_transactions:0 ~postgres_uri
-         ~gql_uri ~da_config:da_config_with3 ~da_keys ~da_quorum ~mq_host
+         ~gql_uri ~da_config:export_da_config ~da_keys ~da_quorum ~mq_host
          ~slot_acceptance:(Time.Span.of_min 10.)
          ~include_bridge_fee_recipient:true
          ~commit_validity_period:
@@ -505,7 +533,7 @@ let () =
               in
               let json =
                 `Assoc
-                  ( [ ("schemaVersion", `Int 3)
+                  ( [ ("schemaVersion", `Int 4)
                     ; ( "commitValidityPeriod"
                       , `Int bridge_commit_validity_period )
                     ; ( "zekoRecipient"
@@ -553,6 +581,15 @@ let () =
                                `String
                                  (Public_key.Compressed.to_base58_check
                                     public_key ) ) ) )
+                    ; ("daNodeCount", `Int (List.length da_keys))
+                    ; ("daQuorum", `Int da_quorum)
+                    ; ( "daCommitment"
+                      , `String
+                          (Ethereum_settlement_export.field_to_hex
+                             (Multisig.commit
+                                { public_keys = da_keys
+                                ; quorum = Field.of_int da_quorum
+                                } ) ) )
                     ; ( "sequencerPublicKey"
                       , `String
                           (Public_key.Compressed.to_base58_check signer_pk) )
@@ -1207,7 +1244,7 @@ let () =
 
     Quickcheck.test ~trials:1
       (Sequencer_spec.gen ~logger ~number_of_transactions:5
-         ~postgres_uri:postgres_uri1 ~gql_uri ~da_config:da_config_with2
+         ~postgres_uri:postgres_uri1 ~gql_uri ~da_config:active_da_config
          ~da_keys ~da_quorum ~mq_host ~slot_acceptance () )
       ~f:(fun
            { outer_kp
@@ -1370,7 +1407,7 @@ let () =
           run (fun () ->
               let%map new_sequencer =
                 Sequencer.create ~logger ~max_pool_size:10
-                  ~commitment_period_sec:0. ~da_config:da_config_with2 ~da_keys
+                  ~commitment_period_sec:0. ~da_config:active_da_config ~da_keys
                   ~da_quorum ~db_dir:None ~checkpoints_dir:None
                   ~postgres_uri:postgres_uri2 ~l1_uri:gql_uri
                   ~archive_uri:gql_uri ~signer:(get_test_signer ())


### PR DESCRIPTION
## Summary

- make the bridge and sequential fixture-only tests honor an explicit DA node count and quorum
- start only the selected DA signers/nodes while preserving the existing 3-node, quorum-2 default
- export bridge-scenario schema v4 with the node count, quorum, and exact multisig commitment

This lets the Sepolia 1-node, quorum-1 profile generate a fixture whose outer-state DA commitment matches its runtime configuration instead of inheriting the reference Docker topology.

## Validation

- `bash -n src/app/zeko/sequencer/tests/run-sequencer-test.sh`
- invalid 1-node/quorum-2 configuration is rejected before services start
- `ocamlformat` on the changed OCaml source
- `dune build ./src/app/zeko/sequencer/tests/sequencer_test_fake.exe`
- `dune build ./src/app/zeko/sequencer/tests/sequencer_test.exe`
- `dune build ./src/app/zeko/sequencer ./src/app/zeko/da_layer ./src/app/zeko/signer`

No proof request or proving run was performed.
