### PR TITLE
Fix unaddressed medium-severity DA audit findings

### DIFF
--- a/src/app/zeko/da_layer/lib/acc_set_transition.ml
+++ b/src/app/zeko/da_layer/lib/acc_set_transition.ml
@@ -1,0 +1,146 @@
+open Core_kernel
+open Mina_base
+module Field = Snark_params.Tick.Field
+module Entry = Indexed_merkle_tree.Entry.Stable.Latest
+module Sparse = Indexed_merkle_tree.Sparse
+module Sparse_tree = Sparse_ledger_lib.Sparse_ledger.Tree
+module Sparse_t = Sparse_ledger_lib.Sparse_ledger.T
+
+let new_account_keys ~changed_accounts ~ledger_openings =
+  List.filter changed_accounts ~f:(fun (index, _) ->
+      Account.equal
+        (Mina_ledger.Sparse_ledger.get_exn ledger_openings index)
+        Account.empty )
+  |> List.sort ~compare:(fun (a, _) (b, _) -> Int.compare a b)
+  |> List.map ~f:(fun (_, account) ->
+         Account_id.derive_token_id ~owner:(Account.identifier account) )
+
+(** Return the keys whose target-tree paths are needed to reverse [new_keys]
+    in insertion order. A later insertion can sit between an earlier key and
+    its original predecessor, so skip such later keys when recovering that
+    predecessor from the target tree. *)
+let opening_keys ~find_lower new_keys =
+  let find_predecessor index key =
+    let later_keys = List.drop new_keys (index + 1) in
+    let rec go key =
+      match find_lower key with
+      | None ->
+          Or_error.errorf "No account-set predecessor for %s"
+            (Token_id.to_string key)
+      | Some predecessor
+        when List.mem later_keys predecessor ~equal:Token_id.equal ->
+          go predecessor
+      | Some predecessor ->
+          Ok predecessor
+    in
+    go key
+  in
+  let%map.Or_error predecessors =
+    List.mapi new_keys ~f:find_predecessor |> Or_error.combine_errors
+  in
+  List.dedup_and_sort (new_keys @ predecessors) ~compare:Token_id.compare
+
+let set_empty_leaf_exn (t : Sparse.t) index =
+  let hash = Sparse.hash in
+  let rec go height tree =
+    match (height < 0, tree) with
+    | true, Sparse_tree.Account _ ->
+        Sparse_tree.Hash Field.zero
+    | false, Sparse_tree.Node (_, left, right) ->
+        let left, right =
+          if index land (1 lsl height) <> 0 then (left, go (height - 1) right)
+          else (go (height - 1) left, right)
+        in
+        Sparse_tree.Node
+          ( Indexed_merkle_tree.Hash.merge ~height (hash left) (hash right)
+          , left
+          , right )
+    | _ ->
+        failwithf "Account-set opening has no leaf at index %d" index ()
+  in
+  { t with Sparse_t.tree = go (Sparse.depth t - 1) t.tree }
+
+let find_predecessor_exn openings key =
+  let predecessor = ref None in
+  Sparse.iteri openings ~f:(fun index entry ->
+      if
+        (not (Entry.equal entry Entry.empty))
+        && Token_id.compare entry.value key < 0
+      then
+        match !predecessor with
+        | None ->
+            predecessor := Some (index, entry)
+        | Some (_, current) when Token_id.compare current.value entry.value < 0
+          ->
+            predecessor := Some (index, entry)
+        | Some _ ->
+            () ) ;
+  Option.value_exn !predecessor
+    ~message:
+      (sprintf "No opened predecessor for account-set key %s"
+         (Token_id.to_string key) )
+
+(** Validate that [target_openings] is rooted at a tree obtained by inserting
+    exactly [new_keys], in order, into [source_root]. Returns the independently
+    recomputed target root. *)
+let validate ~source_root ~new_keys target_openings =
+  Or_error.try_with (fun () ->
+      let target_root = Sparse.merkle_root_without_cache_exn target_openings in
+      let source_openings =
+        List.fold_right new_keys ~init:target_openings ~f:(fun key openings ->
+            let key_index =
+              Sparse.find_index_exn openings
+                (Indexed_merkle_tree.Account_id.with_empty_key key)
+            in
+            let key_entry = Sparse.get_exn openings key_index in
+            if not (Token_id.equal key_entry.value key) then
+              failwithf "Account-set key opening mismatch for %s"
+                (Token_id.to_string key) () ;
+            let predecessor_index, predecessor =
+              find_predecessor_exn openings key
+            in
+            if not (Token_id.equal predecessor.value_next key) then
+              failwithf "Account-set predecessor does not point to %s"
+                (Token_id.to_string key) () ;
+            if Token_id.compare key key_entry.value_next >= 0 then
+              failwithf "Account-set key %s is not below its successor"
+                (Token_id.to_string key) () ;
+            let openings = set_empty_leaf_exn openings key_index in
+            Sparse.set_exn openings predecessor_index
+              { predecessor with value_next = key_entry.value_next } )
+      in
+      let computed_source_root =
+        Sparse.merkle_root_without_cache_exn source_openings
+      in
+      if not (Field.equal computed_source_root source_root) then
+        failwith "Source account-set root mismatch" ;
+      target_root )
+
+let%test_unit "account-set transition is bound to its source root" =
+  let depth = 8 in
+  let tree = Indexed_merkle_tree.In_memory.create ~depth () in
+  let source_key = Token_id.of_field (Field.of_int 10) in
+  Indexed_merkle_tree.In_memory.insert_exn tree source_key ;
+  let source_root = Indexed_merkle_tree.In_memory.merkle_root tree in
+  (* Insert 20 before 15 so the final predecessor of 20 is not its source
+     predecessor. This exercises the lineage reconstruction, not only a
+     single insertion. *)
+  let new_keys =
+    [ Token_id.of_field (Field.of_int 20); Token_id.of_field (Field.of_int 15) ]
+  in
+  Indexed_merkle_tree.In_memory.insert_batch_exn tree new_keys ;
+  let keys =
+    opening_keys new_keys
+      ~find_lower:(Indexed_merkle_tree.In_memory.find_lower_entry_tid tree)
+    |> Or_error.ok_exn
+  in
+  let openings =
+    Indexed_merkle_tree.Sparse.of_in_memory_subset ~logger:(Logger.create ())
+      ~db:tree ~keys
+  in
+  let target_root =
+    validate ~source_root ~new_keys openings |> Or_error.ok_exn
+  in
+  assert (
+    Field.equal target_root (Indexed_merkle_tree.In_memory.merkle_root tree) ) ;
+  assert (Result.is_error (validate ~source_root:Field.one ~new_keys openings))

--- a/src/app/zeko/da_layer/lib/client.ml
+++ b/src/app/zeko/da_layer/lib/client.ml
@@ -26,26 +26,37 @@ module Diff_table = struct
     ; ledger_openings : Sparse_ledger.t
     ; acc_set_openings : Indexed_merkle_tree.Sparse.t
     ; genesis : bool
-    ; target_ledger_hash : Ledger_hash.t
+    ; source_state : Da_state.t
+    ; target_state : Da_state.t
     }
   [@@deriving hlist, fields, sexp]
 
-  let make ~diff ~ledger_openings ~acc_set_openings ~target_ledger_hash ~genesis
-      =
-    { diff; ledger_openings; acc_set_openings; target_ledger_hash; genesis }
+  let make ~diff ~ledger_openings ~acc_set_openings ~source_state ~target_state
+      ~genesis =
+    { diff
+    ; ledger_openings
+    ; acc_set_openings
+    ; source_state
+    ; target_state
+    ; genesis
+    }
 
   let typ =
     Mina_caqti.Type_spec.custom_type
       ~to_hlist:(fun { diff
                      ; ledger_openings
                      ; acc_set_openings
-                     ; target_ledger_hash
+                     ; source_state
+                     ; target_state
                      ; genesis
                      } ->
         H_list.
-          [ Ledger_hash.to_decimal_string target_ledger_hash
+          [ Ledger_hash.to_decimal_string target_state.ledger_hash
+          ; Field.to_string target_state.acc_set
           ; ( if genesis then None
-            else Some (Ledger_hash.to_decimal_string diff.source_ledger_hash) )
+            else Some (Ledger_hash.to_decimal_string source_state.ledger_hash)
+            )
+          ; Field.to_string source_state.acc_set
           ; Binable.to_bigstring
               (module Diff.Pending.Stable.V1.With_top_version_tag)
               diff
@@ -56,7 +67,9 @@ module Diff_table = struct
           ] )
       ~of_hlist:(fun H_list.
                        [ target_ledger_hash
+                       ; target_acc_set
                        ; source_ledger_hash
+                       ; source_acc_set
                        ; diff
                        ; ledger_openings
                        ; acc_set_openings
@@ -67,10 +80,20 @@ module Diff_table = struct
           | Ppx_deriving_yojson_runtime.Result.Error e ->
               failwithf "Error parsing ledger openings: %s" e ()
         in
-        { diff =
-            Binable.of_bigstring
-              (module Diff.Pending.Stable.V1.With_top_version_tag)
-              (Bigstring.of_string diff)
+        let diff =
+          Binable.of_bigstring
+            (module Diff.Pending.Stable.V1.With_top_version_tag)
+            (Bigstring.of_string diff)
+        in
+        let source_state =
+          Da_state.create
+            ~ledger_hash:
+              (Option.value_map source_ledger_hash
+                 ~default:diff.source_ledger_hash
+                 ~f:Ledger_hash.of_decimal_string )
+            ~acc_set:(Field.of_string source_acc_set)
+        in
+        { diff
         ; ledger_openings =
             Sparse_ledger.of_yojson (Yojson.Safe.from_string ledger_openings)
             |> ok_exn
@@ -79,49 +102,64 @@ module Diff_table = struct
               (Yojson.Safe.from_string acc_set_openings)
             |> ok_exn
         ; genesis = Option.is_none source_ledger_hash
-        ; target_ledger_hash = Ledger_hash.of_decimal_string target_ledger_hash
+        ; source_state
+        ; target_state =
+            Da_state.create
+              ~ledger_hash:(Ledger_hash.of_decimal_string target_ledger_hash)
+              ~acc_set:(Field.of_string target_acc_set)
         } )
-      Caqti_type.[ string; option string; octets; octets; octets ]
+      Caqti_type.
+        [ string; string; option string; string; octets; octets; octets ]
 
   let insert (module Conn : CONNECTION) t =
     Conn.exec
       (Caqti_request.exec typ
-         {sql| INSERT INTO da_diff (target_ledger_hash, source_ledger_hash, diff, ledger_openings, acc_set_openings)
-                VALUES (?, ?, ?, ?, ?) |sql} )
+         {sql| INSERT INTO da_diff (target_ledger_hash, target_acc_set, source_ledger_hash, source_acc_set, diff, ledger_openings, acc_set_openings)
+                VALUES (?, ?, ?, ?, ?, ?, ?) |sql} )
       t
 
-  let get_diff_by_source (module Conn : CONNECTION) ledger_hash =
-    match ledger_hash with
-    | Some ledger_hash ->
+  let get_diff_by_source (module Conn : CONNECTION) state =
+    match state with
+    | Some (state : Da_state.t) ->
         Conn.find_opt
-          (Caqti_request.find_opt Caqti_type.string typ
-             {sql| SELECT target_ledger_hash, source_ledger_hash, diff, ledger_openings, acc_set_openings FROM da_diff WHERE source_ledger_hash = ? |sql} )
-          (Ledger_hash.to_decimal_string ledger_hash)
+          (Caqti_request.find_opt
+             Caqti_type.(tup2 string string)
+             typ
+             {sql| SELECT target_ledger_hash, target_acc_set, source_ledger_hash, source_acc_set, diff, ledger_openings, acc_set_openings FROM da_diff WHERE source_ledger_hash = ? AND source_acc_set = ? |sql} )
+          ( Ledger_hash.to_decimal_string state.ledger_hash
+          , Field.to_string state.acc_set )
     | None ->
         Conn.find_opt
           (Caqti_request.find_opt Caqti_type.unit typ
-             {sql| SELECT target_ledger_hash, source_ledger_hash, diff, ledger_openings, acc_set_openings FROM da_diff WHERE source_ledger_hash IS NULL |sql} )
+             {sql| SELECT target_ledger_hash, target_acc_set, source_ledger_hash, source_acc_set, diff, ledger_openings, acc_set_openings FROM da_diff WHERE source_ledger_hash IS NULL |sql} )
           ()
 
-  let get_id_by_target (module Conn : CONNECTION) ledger_hash =
+  let get_id_by_target (module Conn : CONNECTION) (state : Da_state.t) =
     Conn.find_opt
-      (Caqti_request.find_opt Caqti_type.string Caqti_type.int
-         {sql| SELECT id FROM da_diff WHERE target_ledger_hash = ? |sql} )
-      (Ledger_hash.to_decimal_string ledger_hash)
+      (Caqti_request.find_opt
+         Caqti_type.(tup2 string string)
+         Caqti_type.int
+         {sql| SELECT id FROM da_diff WHERE target_ledger_hash = ? AND target_acc_set = ? |sql} )
+      ( Ledger_hash.to_decimal_string state.ledger_hash
+      , Field.to_string state.acc_set )
 
   let get_target_by_id (module Conn : CONNECTION) id =
     let%map.Deferred.Result result =
       Conn.find_opt
-        (Caqti_request.find_opt Caqti_type.int Caqti_type.string
-           {sql| SELECT target_ledger_hash FROM da_diff WHERE id = ? |sql} )
+        (Caqti_request.find_opt Caqti_type.int
+           Caqti_type.(tup2 string string)
+           {sql| SELECT target_ledger_hash, target_acc_set FROM da_diff WHERE id = ? |sql} )
         id
     in
-    Option.map ~f:Ledger_hash.of_decimal_string result
+    Option.map result ~f:(fun (ledger_hash, acc_set) ->
+        Da_state.create
+          ~ledger_hash:(Ledger_hash.of_decimal_string ledger_hash)
+          ~acc_set:(Field.of_string acc_set) )
 end
 
 module Signature_table = struct
   type t =
-    { target_ledger_hash : Ledger_hash.t
+    { target_state : Da_state.t
     ; public_key : Public_key.Compressed.t
     ; signature : Signature.t
     }
@@ -129,39 +167,53 @@ module Signature_table = struct
 
   let typ =
     Mina_caqti.Type_spec.custom_type
-      ~to_hlist:(fun { target_ledger_hash; public_key; signature } ->
+      ~to_hlist:(fun { target_state; public_key; signature } ->
         H_list.
-          [ Ledger_hash.to_decimal_string target_ledger_hash
+          [ Ledger_hash.to_decimal_string target_state.ledger_hash
+          ; Field.to_string target_state.acc_set
           ; Public_key.Compressed.to_base58_check public_key
           ; Signature.to_base58_check signature
           ] )
-      ~of_hlist:(fun H_list.[ target_ledger_hash; public_key; signature ] ->
-        { target_ledger_hash = Ledger_hash.of_decimal_string target_ledger_hash
+      ~of_hlist:(fun H_list.
+                       [ target_ledger_hash
+                       ; target_acc_set
+                       ; public_key
+                       ; signature
+                       ] ->
+        { target_state =
+            Da_state.create
+              ~ledger_hash:(Ledger_hash.of_decimal_string target_ledger_hash)
+              ~acc_set:(Field.of_string target_acc_set)
         ; public_key = Public_key.Compressed.of_base58_check_exn public_key
         ; signature = Signature.of_base58_check_exn signature
         } )
-      Caqti_type.[ string; string; octets ]
+      Caqti_type.[ string; string; string; octets ]
 
   let insert (module Conn : CONNECTION) t =
     Conn.exec
       (Caqti_request.exec typ
-         {sql| INSERT INTO da_signature (target_ledger_hash, public_key, signature) VALUES (?, ?, ?) |sql} )
+         {sql| INSERT INTO da_signature (target_ledger_hash, target_acc_set, public_key, signature) VALUES (?, ?, ?, ?) |sql} )
       t
 
-  let get_signature_opt (module Conn : CONNECTION) ledger_hash public_key =
+  let get_signature_opt (module Conn : CONNECTION) (state : Da_state.t)
+      public_key =
     Conn.find_opt
       (Caqti_request.find_opt
-         Caqti_type.(tup2 string string)
+         Caqti_type.(tup3 string string string)
          typ
-         {sql| SELECT target_ledger_hash, public_key, signature FROM da_signature WHERE target_ledger_hash = ? AND public_key = ? |sql} )
-      ( Ledger_hash.to_decimal_string ledger_hash
+         {sql| SELECT target_ledger_hash, target_acc_set, public_key, signature FROM da_signature WHERE target_ledger_hash = ? AND target_acc_set = ? AND public_key = ? |sql} )
+      ( Ledger_hash.to_decimal_string state.ledger_hash
+      , Field.to_string state.acc_set
       , Public_key.Compressed.to_base58_check public_key )
 
-  let get_signatures (module Conn : CONNECTION) ledger_hash =
+  let get_signatures (module Conn : CONNECTION) (state : Da_state.t) =
     Conn.collect_list
-      (Caqti_request.collect Caqti_type.string typ
-         {sql| SELECT target_ledger_hash, public_key, signature FROM da_signature WHERE target_ledger_hash = ? |sql} )
-      (Ledger_hash.to_decimal_string ledger_hash)
+      (Caqti_request.collect
+         Caqti_type.(tup2 string string)
+         typ
+         {sql| SELECT target_ledger_hash, target_acc_set, public_key, signature FROM da_signature WHERE target_ledger_hash = ? AND target_acc_set = ? |sql} )
+      ( Ledger_hash.to_decimal_string state.ledger_hash
+      , Field.to_string state.acc_set )
 end
 
 module Rpc = struct
@@ -265,36 +317,23 @@ module Rpc = struct
 
   let post_diff ~logger
       ~(node_location : Host_and_port.t Cli_lib.Flag.Types.with_name)
-      ~ledger_openings ~acc_set_openings ~diff =
+      ~source_state ~ledger_openings ~acc_set_openings ~diff =
     [%log debug] "Posting diff to da node %s"
       (Host_and_port.to_string node_location.value) ;
-    dispatch ~max_tries:5 ~logger node_location Rpc.Post_diff.V1.t
-      { ledger_openings; diff; acc_set_openings }
+    dispatch ~max_tries:5 ~logger node_location Rpc.Post_diff.V2.t
+      { source_state; ledger_openings; diff; acc_set_openings }
 
   let get_diff ~logger
-      ~(node_location : Host_and_port.t Cli_lib.Flag.Types.with_name)
-      ~ledger_hash =
+      ~(node_location : Host_and_port.t Cli_lib.Flag.Types.with_name) ~state =
     [%log debug] "Getting diff from da node %s"
       (Host_and_port.to_string node_location.value) ;
-    dispatch_with_fallback_same_query ~max_tries:1 ~logger node_location
-      ledger_hash
-      ~versions:
-        [ Versioned_rpc_same_query.V (Rpc.Get_diff.V4.t, Fn.id)
-        ; Versioned_rpc_same_query.V
-            (Rpc.Get_diff.V3.t, Option.map ~f:Diff.Stable.V3.to_latest)
-        ; Versioned_rpc_same_query.V
-            (Rpc.Get_diff.V2.t, Option.map ~f:Diff.Stable.V2.to_latest)
-        ; Versioned_rpc_same_query.V
-            (Rpc.Get_diff.V1.t, Option.map ~f:Diff.Stable.V1.to_latest)
-        ]
+    dispatch ~max_tries:1 ~logger node_location Rpc.Get_diff.V5.t state
 
   let get_diff_source ~logger
-      ~(node_location : Host_and_port.t Cli_lib.Flag.Types.with_name)
-      ~ledger_hash =
+      ~(node_location : Host_and_port.t Cli_lib.Flag.Types.with_name) ~state =
     [%log debug] "Getting diff source from da node %s"
       (Host_and_port.to_string node_location.value) ;
-    dispatch ~max_tries:1 ~logger node_location Rpc.Get_diff_source.V1.t
-      ledger_hash
+    dispatch ~max_tries:1 ~logger node_location Rpc.Get_diff_source.V2.t state
 
   let get_node_public_key ~logger
       ~(node_location : Host_and_port.t Cli_lib.Flag.Types.with_name) () =
@@ -304,19 +343,17 @@ module Rpc = struct
       ()
 
   let get_signature ~logger
-      ~(node_location : Host_and_port.t Cli_lib.Flag.Types.with_name)
-      ~ledger_hash =
+      ~(node_location : Host_and_port.t Cli_lib.Flag.Types.with_name) ~state =
     [%log debug] "Getting signature from da node %s"
       (Host_and_port.to_string node_location.value) ;
-    dispatch ~max_tries:1 ~logger node_location Rpc.Get_signature.V1.t
-      ledger_hash
+    dispatch ~max_tries:1 ~logger node_location Rpc.Get_signature.V2.t state
 
-  let get_ledger_hashes_chain ~logger
+  let get_states_chain ~logger
       ~(node_location : Host_and_port.t Cli_lib.Flag.Types.with_name)
       ?max_length ~source ~target () =
     [%log debug] "Getting ledger hashes chain from da node %s"
       (Host_and_port.to_string node_location.value) ;
-    dispatch ~max_tries:1 ~logger node_location Rpc.Get_ledger_hashes_chain.V1.t
+    dispatch ~max_tries:1 ~logger node_location Rpc.Get_ledger_hashes_chain.V2.t
       { source; target; max_length }
 
   let get_diffs_chain ~logger
@@ -324,15 +361,14 @@ module Rpc = struct
       ?max_length ~source ~target () =
     [%log debug] "Getting diffs chain from da node %s"
       (Host_and_port.to_string node_location.value) ;
-    dispatch ~max_tries:1 ~logger node_location Rpc.Get_diffs_chain.V2.t
+    dispatch ~max_tries:1 ~logger node_location Rpc.Get_diffs_chain.V3.t
       { source; target; max_length }
 
   let has_diff ~logger
-      ~(node_location : Host_and_port.t Cli_lib.Flag.Types.with_name)
-      ~ledger_hash =
+      ~(node_location : Host_and_port.t Cli_lib.Flag.Types.with_name) ~state =
     [%log debug] "Checking if diff exists in da node %s"
       (Host_and_port.to_string node_location.value) ;
-    dispatch ~max_tries:1 ~logger node_location Rpc.Has_diff.V1.t ledger_hash
+    dispatch ~max_tries:1 ~logger node_location Rpc.Has_diff.V2.t state
 
   let pipe_dispatch rpc query (host_and_port : Host_and_port.t) =
     let open Async in
@@ -386,7 +422,7 @@ module Rpc = struct
       ~target () =
     [%log debug] "Getting diffs stream from da node %s"
       (Host_and_port.to_string node_location.value) ;
-    pipe_dispatch Rpc.Diffs_stream.V3.t { source; target } node_location.value
+    pipe_dispatch Rpc.Diffs_stream.V4.t { source; target } node_location.value
 end
 
 module Config = struct
@@ -456,8 +492,8 @@ let create ~logger ~(config : Config.t) ~quorum ~da_keys ~db_pool =
 
 let stop t = Ivar.fill t.stop ()
 
-let enqueue_diff t ~target_ledger_hash ~ledger_openings ~acc_set_openings ~diff
-    ~genesis =
+let enqueue_diff t ~source_state ~target_state ~ledger_openings
+    ~acc_set_openings ~diff ~genesis =
   let%map () =
     Pool.use
       (fun conn ->
@@ -465,7 +501,8 @@ let enqueue_diff t ~target_ledger_hash ~ledger_openings ~acc_set_openings ~diff
           { diff
           ; ledger_openings
           ; acc_set_openings
-          ; target_ledger_hash
+          ; source_state
+          ; target_state
           ; genesis
           } )
       t.db_pool
@@ -475,7 +512,7 @@ let enqueue_diff t ~target_ledger_hash ~ledger_openings ~acc_set_openings ~diff
 
 let rec start_posting_diffs_from ?timeout_on_failure ?pushed_diff t
     ~(node_location : Host_and_port.t Cli_lib.Flag.Types.with_name)
-    ~source_ledger_hash () =
+    ~source_state () =
   if Ivar.is_full t.stop then return ()
   else
     let logger = t.logger in
@@ -483,26 +520,31 @@ let rec start_posting_diffs_from ?timeout_on_failure ?pushed_diff t
       Option.value pushed_diff ~default:(Condition.wait t.pushed_diff)
     in
     match%bind
-      Pool.use
-        (fun c -> Diff_table.get_diff_by_source c source_ledger_hash)
-        t.db_pool
+      Pool.use (fun c -> Diff_table.get_diff_by_source c source_state) t.db_pool
       >>| caqti_ok_exn ~msg:"Failed to get diff from db: %s"
     with
     | None ->
         [%log info]
-          !"No diff found for source ledger hash: %{sexp: Ledger_hash.t \
-            option} for node %s, waiting"
-          source_ledger_hash
+          !"No diff found for source DA state: %{sexp: Da_state.t option} for \
+            node %s, waiting"
+          source_state
           (Host_and_port.to_string node_location.value) ;
         let%bind () = Deferred.any [ pushed_diff; Ivar.read t.stop ] in
         start_posting_diffs_from ?timeout_on_failure
           ~pushed_diff:(Condition.wait t.pushed_diff)
-          t ~node_location ~source_ledger_hash ()
-    | Some { diff; ledger_openings; acc_set_openings; target_ledger_hash; _ }
-      -> (
+          t ~node_location ~source_state ()
+    | Some
+        { diff
+        ; ledger_openings
+        ; acc_set_openings
+        ; source_state = diff_source_state
+        ; target_state
+        ; _
+        } -> (
         match%bind
-          Rpc.post_diff ~logger:t.logger ~node_location ~ledger_openings
-            ~acc_set_openings ~diff
+          Rpc.post_diff ~logger:t.logger ~node_location
+            ~source_state:diff_source_state ~ledger_openings ~acc_set_openings
+            ~diff
         with
         | Error err ->
             [%log error] "Failed to post diff to da node: %s"
@@ -524,17 +566,17 @@ let rec start_posting_diffs_from ?timeout_on_failure ?pushed_diff t
                   after timeout
             in
             start_posting_diffs_from ?timeout_on_failure t ~node_location
-              ~source_ledger_hash ()
+              ~source_state ()
         | Ok (public_key, signature) ->
             [%log info]
-              !"Posted diff to da node %s with hash: %{sexp: Ledger_hash.t}"
+              !"Posted diff to da node %s for state: %{sexp: Da_state.t}"
               (Host_and_port.to_string node_location.value)
-              target_ledger_hash ;
+              target_state ;
             let%bind () =
               Pool.use
                 (fun c ->
                   Signature_table.insert c
-                    { target_ledger_hash; public_key; signature } )
+                    { target_state; public_key; signature } )
                 t.db_pool
               >>| fun r ->
               if Ivar.is_full t.stop then ()
@@ -542,7 +584,7 @@ let rec start_posting_diffs_from ?timeout_on_failure ?pushed_diff t
             in
             Condition.broadcast t.pushed_signature () ;
             start_posting_diffs_from ?timeout_on_failure t ~node_location
-              ~source_ledger_hash:(Some target_ledger_hash) () )
+              ~source_state:(Some target_state) () )
 
 let wait_for_successful_healthcheck ~timeout ~logger ~node_location () =
   keep_retrying ~delay:timeout ~logger
@@ -560,16 +602,14 @@ let wait_for_successful_healthcheck ~timeout ~logger ~node_location () =
           Error err )
     ()
 
-let binary_search_last_ledger_hash t ~node_location ~target_ledger_hash =
+let binary_search_last_state t ~node_location ~target_state =
   let return = Deferred.Result.return in
   if%bind.Deferred.Result
-    Rpc.has_diff ~logger:t.logger ~node_location ~ledger_hash:target_ledger_hash
-  then return (Some target_ledger_hash)
+    Rpc.has_diff ~logger:t.logger ~node_location ~state:target_state
+  then return (Some target_state)
   else
     let%bind.Deferred.Result target_id =
-      Pool.use
-        (fun c -> Diff_table.get_id_by_target c target_ledger_hash)
-        t.db_pool
+      Pool.use (fun c -> Diff_table.get_id_by_target c target_state) t.db_pool
       >>| caqti_ok_exn ~msg:"Failed to get id from target ledger hash: %s"
       >>| (fun opt -> Option.value_exn ~message:"No diff found" opt)
       >>| Result.return
@@ -578,7 +618,7 @@ let binary_search_last_ledger_hash t ~node_location ~target_ledger_hash =
       if left > right then return None
       else
         let mid = (left + right) / 2 in
-        let%bind.Deferred.Result mid_ledger_hash =
+        let%bind.Deferred.Result mid_state =
           Pool.use (fun c -> Diff_table.get_target_by_id c mid) t.db_pool
           >>| caqti_ok_exn ~msg:"Failed to find mid ledger hash: %s"
           >>| (fun opt ->
@@ -587,25 +627,23 @@ let binary_search_last_ledger_hash t ~node_location ~target_ledger_hash =
           >>| Result.return
         in
         let%bind.Deferred.Result mid_found =
-          Rpc.has_diff ~logger:t.logger ~node_location
-            ~ledger_hash:mid_ledger_hash
+          Rpc.has_diff ~logger:t.logger ~node_location ~state:mid_state
         in
-        let%bind.Deferred.Result next_ledger_hash =
+        let%bind.Deferred.Result next_state =
           Pool.use (fun c -> Diff_table.get_target_by_id c (mid + 1)) t.db_pool
           >>| caqti_ok_exn ~msg:"Failed to find next ledger hash: %s"
           >>| Result.return
         in
         let%bind.Deferred.Result next_found =
-          match next_ledger_hash with
-          | Some next_ledger_hash ->
-              Rpc.has_diff ~logger:t.logger ~node_location
-                ~ledger_hash:next_ledger_hash
+          match next_state with
+          | Some next_state ->
+              Rpc.has_diff ~logger:t.logger ~node_location ~state:next_state
           | None ->
               return false
         in
-        if mid_found && not next_found then return (Some mid_ledger_hash)
-        else if mid_found && mid = target_id then return (Some mid_ledger_hash)
-        else if next_found && mid + 1 = target_id then return next_ledger_hash
+        if mid_found && not next_found then return (Some mid_state)
+        else if mid_found && mid = target_id then return (Some mid_state)
+        else if next_found && mid + 1 = target_id then return next_state
         else if (not mid_found) && mid = 1 then return None
         else if mid_found && next_found then go ~left:mid ~right
         else go ~left ~right:mid
@@ -613,27 +651,26 @@ let binary_search_last_ledger_hash t ~node_location ~target_ledger_hash =
     go ~left:1 ~right:target_id
 
 let catch_up t ~(node_location : Host_and_port.t Cli_lib.Flag.Types.with_name)
-    ~target_ledger_hash =
+    ~target_state =
   let logger = t.logger in
   let%bind.Deferred () =
     wait_for_successful_healthcheck ~timeout:(Time_ns.Span.of_sec 30.) ~logger
       ~node_location ()
   in
-  let%bind last_ledger_hash =
+  let%bind last_state =
     keep_retrying ~logger
-      ~f:(fun () ->
-        binary_search_last_ledger_hash t ~node_location ~target_ledger_hash )
+      ~f:(fun () -> binary_search_last_state t ~node_location ~target_state)
       ()
   in
   [%log info]
-    !"Found last ledger hash: %{sexp: Ledger_hash.t option} for node %s"
-    last_ledger_hash
+    !"Found last DA state: %{sexp: Da_state.t option} for node %s"
+    last_state
     (Host_and_port.to_string node_location.value) ;
   let%bind () =
-    match (last_ledger_hash, Ivar.is_full t.stop) with
+    match (last_state, Ivar.is_full t.stop) with
     | None, _ | _, true ->
         return ()
-    | Some last_ledger_hash, false ->
+    | Some last_state, false ->
         (* In case we've started from checkpoint, we need to refetch the signature *)
         let%bind public_key =
           keep_retrying ~logger:t.logger
@@ -644,7 +681,7 @@ let catch_up t ~(node_location : Host_and_port.t Cli_lib.Flag.Types.with_name)
         Pool.use
           (with_transaction ~f:(fun c ->
                let%bind.Deferred.Result signature_opt =
-                 Signature_table.get_signature_opt c last_ledger_hash public_key
+                 Signature_table.get_signature_opt c last_state public_key
                in
                if Option.is_some signature_opt then return (Ok ())
                else (
@@ -653,16 +690,13 @@ let catch_up t ~(node_location : Host_and_port.t Cli_lib.Flag.Types.with_name)
                    (Host_and_port.to_string node_location.value) ;
                  let%bind public_key, signature =
                    Rpc.get_signature ~logger:t.logger ~node_location
-                     ~ledger_hash:last_ledger_hash
+                     ~state:last_state
                    >>| Or_error.ok_exn
                    >>| fun x ->
                    Option.value_exn ~message:"Signature not found" x
                  in
                  Signature_table.insert c
-                   { target_ledger_hash = last_ledger_hash
-                   ; public_key
-                   ; signature
-                   } ) ) )
+                   { target_state = last_state; public_key; signature } ) ) )
           t.db_pool
         >>| fun res ->
         if Ivar.is_full t.stop then ()
@@ -671,20 +705,20 @@ let catch_up t ~(node_location : Host_and_port.t Cli_lib.Flag.Types.with_name)
   if Ivar.is_full t.stop then return ()
   else
     start_posting_diffs_from t ~timeout_on_failure:(Time_ns.Span.of_sec 10.)
-      ~node_location ~source_ledger_hash:last_ledger_hash ()
+      ~node_location ~source_state:last_state ()
 
-let start_client t ~target_ledger_hash =
+let start_client t ~target_state =
   List.iter t.config.nodes ~f:(fun node_location ->
       don't_wait_for
         (within' ~monitor:Monitor.main (fun () ->
-             catch_up t ~node_location ~target_ledger_hash ) ) )
+             catch_up t ~node_location ~target_state ) ) )
 
-let rec get_multisig ?pushed_signature t ~ledger_hash =
+let rec get_multisig ?pushed_signature t ~state =
   let pushed_signature =
     Option.value pushed_signature ~default:(Condition.wait t.pushed_signature)
   in
   let%bind signatures =
-    Pool.use (fun c -> Signature_table.get_signatures c ledger_hash) t.db_pool
+    Pool.use (fun c -> Signature_table.get_signatures c state) t.db_pool
     >>| caqti_ok_exn ~msg:"Failed to get signatures from db: %s"
   in
   if List.length signatures >= t.quorum then
@@ -704,7 +738,7 @@ let rec get_multisig ?pushed_signature t ~ledger_hash =
     else
       get_multisig
         ~pushed_signature:(Condition.wait t.pushed_signature)
-        t ~ledger_hash
+        t ~state
 
 (** Useful for querying data, will fallback to the next node in list in case the first one fails *)
 let try_all_nodes ~config ~f =
@@ -720,29 +754,28 @@ let try_all_nodes ~config ~f =
   in
   try_first ~accum_errors:[] (Config.nodes config)
 
-(** Get the chain of ledger hashes from [source_ledger_hash] hash to [target_ledger_hash] *)
-let get_ledger_hashes_chain ~logger ~config ?max_length ~source_ledger_hash
-    ~target_ledger_hash () =
+(** Get the chain of exact DA states from [source_state] to [target_state]. *)
+let get_states_chain ~logger ~config ?max_length ~source_state ~target_state ()
+    =
   try_all_nodes ~config ~f:(fun ~node_location () ->
-      Rpc.get_ledger_hashes_chain ~logger ~node_location ?max_length
-        ~source:source_ledger_hash ~target:target_ledger_hash () )
+      Rpc.get_states_chain ~logger ~node_location ?max_length
+        ~source:source_state ~target:target_state () )
 
-(** Get the chain of diffs from [source_ledger_hash] hash to [target_ledger_hash] *)
-let get_diffs_chain ~logger ~config ?max_length ~source_ledger_hash
-    ~target_ledger_hash () =
+(** Get the chain of stored diffs from [source_state] to [target_state]. *)
+let get_diffs_chain ~logger ~config ?max_length ~source_state ~target_state () =
   try_all_nodes ~config ~f:(fun ~node_location () ->
       Rpc.get_diffs_chain ~logger ~node_location ?max_length
-        ~source:source_ledger_hash ~target:target_ledger_hash () )
+        ~source:source_state ~target:target_state () )
 
-let diff_exists ~logger ~config ~ledger_hash () =
+let diff_exists ~logger ~config ~state () =
   try_all_nodes ~config ~f:(fun ~node_location () ->
-      Rpc.has_diff ~logger ~node_location ~ledger_hash )
+      Rpc.has_diff ~logger ~node_location ~state )
 
-let stream_diffs ~logger ~config ~source_ledger_hash ~target_ledger_hash () =
+let stream_diffs ~logger ~config ~source_state ~target_state () =
   try_all_nodes ~config ~f:(fun ~node_location () ->
       match%bind
-        Rpc.diffs_stream ~logger ~node_location ~source:source_ledger_hash
-          ~target:target_ledger_hash ()
+        Rpc.diffs_stream ~logger ~node_location ~source:source_state
+          ~target:target_state ()
       with
       | Ok (Ok stream) ->
           return (Ok stream)
@@ -750,28 +783,23 @@ let stream_diffs ~logger ~config ~source_ledger_hash ~target_ledger_hash () =
           return (Error err) )
 
 (** Lazily fetch chunks of diffs, used to minimize memory usage *)
-let get_lazy_diffs_chunks ~logger ~depth ~config ?(n = 1000) ~source_ledger_hash
-    ~target_ledger_hash
+let get_lazy_diffs_chunks ~logger ~config ?(n = 1000) ~source_state
+    ~target_state
     (rpc :
          logger:Logger.t
       -> config:Config.t
-      -> source_ledger_hash:[ `Genesis | `Specific of Field.t ]
-      -> target_ledger_hash:Field.t
+      -> source_state:[ `Genesis | `Specific of Da_state.t ]
+      -> target_state:Da_state.t
       -> unit
       -> ('a, Error.t) result Deferred.t ) () =
-  let source_ledger_hash =
-    match source_ledger_hash with
-    | `Genesis ->
-        Diff.empty_ledger_hash ~depth
-    | `Specific h ->
-        h
+  let specific_source_state =
+    match source_state with `Genesis -> None | `Specific state -> Some state
   in
   let counter = ref 0 in
   (* Get ledger hashes intervals of size [n] *)
-  let rec get_intervals ~target_ledger_hash =
+  let rec get_intervals ~target_state =
     let%bind.Deferred.Result chain =
-      get_ledger_hashes_chain ~logger ~config ~max_length:n
-        ~source_ledger_hash:(`Specific source_ledger_hash) ~target_ledger_hash
+      get_states_chain ~logger ~config ~max_length:n ~source_state ~target_state
         ()
     in
     counter := !counter + List.length chain ;
@@ -780,21 +808,28 @@ let get_lazy_diffs_chunks ~logger ~depth ~config ?(n = 1000) ~source_ledger_hash
     | [] ->
         return (Ok [])
     | [ last ] ->
-        let interval = (source_ledger_hash, last) in
+        let interval_source =
+          match specific_source_state with
+          | Some state ->
+              `Specific state
+          | None ->
+              `Genesis
+        in
+        let interval = (interval_source, last) in
         return (Ok [ interval ])
     | chain ->
         let hd = List.hd_exn chain in
         let tl = List.last_exn chain in
-        let interval = (hd, tl) in
+        let interval = (`Specific hd, tl) in
         let%bind.Deferred.Result next_intervals =
-          get_intervals ~target_ledger_hash:hd
+          get_intervals ~target_state:hd
         in
         return (Ok (interval :: next_intervals))
   in
   let%bind.Deferred.Result intervals =
     [%log info] "Fetching intervals from da layer of size %s"
       (Int.to_string_hum n) ;
-    get_intervals ~target_ledger_hash >>| Result.map ~f:List.rev
+    get_intervals ~target_state >>| Result.map ~f:List.rev
   in
   [%log debug] "Fetched %s intervals"
     (Int.to_string_hum (List.length intervals)) ;
@@ -802,35 +837,41 @@ let get_lazy_diffs_chunks ~logger ~depth ~config ?(n = 1000) ~source_ledger_hash
   @@ Ok
        (List.map intervals ~f:(fun (source, target) ->
             [%log debug] "Creating lazy chunk from %s to %s"
-              (Ledger_hash.to_decimal_string source)
-              (Ledger_hash.to_decimal_string target) ;
+              ( match source with
+              | `Genesis ->
+                  "genesis"
+              | `Specific state ->
+                  Da_state.to_string state )
+              (Da_state.to_string target) ;
             lazy
               ( [%log debug] "Forcing diffs chunk from %s to %s"
-                  (Ledger_hash.to_decimal_string source)
-                  (Ledger_hash.to_decimal_string target) ;
-                rpc ~logger ~config ~source_ledger_hash:(`Specific source)
-                  ~target_ledger_hash:target () ) ) )
+                  ( match source with
+                  | `Genesis ->
+                      "genesis"
+                  | `Specific state ->
+                      Da_state.to_string state )
+                  (Da_state.to_string target) ;
+                rpc ~logger ~config ~source_state:source ~target_state:target ()
+              ) ) )
 
 let map_diffs :
        ?interval_size:int
     -> logger:Logger.t
-    -> depth:int
     -> config:Config.t
-    -> source_ledger_hash:[< `Genesis | `Specific of Field.t ]
-    -> target_ledger_hash:Field.t
+    -> source_state:[< `Genesis | `Specific of Da_state.t ]
+    -> target_state:Da_state.t
     -> f:
          (   current_chunk:int
           -> current_diff:int
           -> chunks_length:int
-          -> Diff.Stable.V4.t
+          -> Stored_diff.t
           -> 'a Deferred.t )
     -> unit
     -> ('a list, Error.t) Deferred.Result.t =
- fun ?interval_size ~logger ~depth ~config ~source_ledger_hash
-     ~target_ledger_hash ~f () ->
+ fun ?interval_size ~logger ~config ~source_state ~target_state ~f () ->
   let%bind.Deferred.Result lazy_chunks =
-    get_lazy_diffs_chunks ?n:interval_size ~logger ~depth ~config
-      ~source_ledger_hash ~target_ledger_hash
+    get_lazy_diffs_chunks ?n:interval_size ~logger ~config ~source_state
+      ~target_state
       (get_diffs_chain ?max_length:None)
       ()
   in
@@ -858,23 +899,21 @@ let map_diffs :
 let iter_diffs :
        ?interval_size:int
     -> logger:Logger.t
-    -> depth:int
     -> config:Config.t
-    -> source_ledger_hash:[< `Genesis | `Specific of Field.t ]
-    -> target_ledger_hash:Field.t
+    -> source_state:[< `Genesis | `Specific of Da_state.t ]
+    -> target_state:Da_state.t
     -> f:
          (   current_chunk:int
           -> current_diff:int
           -> chunks_length:int
-          -> Diff.Stable.V4.t
+          -> Stored_diff.t
           -> unit Deferred.t )
     -> unit
     -> (unit, Error.t) Deferred.Result.t =
- fun ?interval_size ~logger ~depth ~config ~source_ledger_hash
-     ~target_ledger_hash ~f () ->
+ fun ?interval_size ~logger ~config ~source_state ~target_state ~f () ->
   let%bind.Deferred.Result lazy_chunks =
-    get_lazy_diffs_chunks ?n:interval_size ~logger ~depth ~config
-      ~source_ledger_hash ~target_ledger_hash stream_diffs ()
+    get_lazy_diffs_chunks ?n:interval_size ~logger ~config ~source_state
+      ~target_state stream_diffs ()
   in
   [%log debug] "Fetched %s lazy chunks"
     (Int.to_string_hum (List.length lazy_chunks)) ;
@@ -899,9 +938,9 @@ let iter_diffs :
               return (Error err) ) )
 
 (** Try to get the diff from the first node in the list, if it fails, try the next one *)
-let get_diff ~logger ~config ~ledger_hash =
+let get_diff ~logger ~config ~state =
   try_all_nodes ~config ~f:(fun ~node_location () ->
-      match%bind Rpc.get_diff ~logger ~node_location ~ledger_hash with
+      match%bind Rpc.get_diff ~logger ~node_location ~state with
       | Ok (Some diff) ->
           return (Ok diff)
       | Ok None ->
@@ -909,12 +948,13 @@ let get_diff ~logger ~config ~ledger_hash =
       | Error e ->
           return (Error e) )
 
-let distribute_diff ~logger ~config ~ledger_openings ~acc_set_openings ~diff =
+let distribute_diff ~logger ~config ~source_state ~ledger_openings
+    ~acc_set_openings ~diff =
   Deferred.List.iter ~how:`Parallel
     Config.(config.nodes)
     ~f:(fun n ->
       match%map
-        Rpc.post_diff ~logger ~node_location:n ~ledger_openings
+        Rpc.post_diff ~logger ~node_location:n ~source_state ~ledger_openings
           ~acc_set_openings ~diff
       with
       | Ok _ ->
@@ -945,6 +985,11 @@ let create_genesis_diffs ?(max_size = 50) ~logger ledger ~get_actions_for_aid =
     (Int.to_string_hum (List.length account_chunks)) ;
   let%map result =
     Deferred.List.map ~how:`Sequential account_chunks ~f:(fun chunk ->
+        let source_state =
+          Da_state.create
+            ~ledger_hash:(Ledger.merkle_root ephemeral)
+            ~acc_set:(Indexed_merkle_tree.In_memory.merkle_root acc_set)
+        in
         let ledger_openings =
           Sparse_ledger.of_ledger_subset_exn ephemeral
             (List.map chunk ~f:snd |> List.map ~f:Account.identifier)
@@ -976,11 +1021,17 @@ let create_genesis_diffs ?(max_size = 50) ~logger ledger ~get_actions_for_aid =
                        Account_id.derive_token_id
                          ~owner:(Account.identifier acc) ) )
         in
+        let target_state =
+          Da_state.create
+            ~ledger_hash:(Ledger.merkle_root ephemeral)
+            ~acc_set:(Indexed_merkle_tree.In_memory.merkle_root acc_set)
+        in
         return
           ( diff
           , ledger_openings
           , acc_set_openings
-          , `Target (Ledger.merkle_root ephemeral) ) )
+          , `Source source_state
+          , `Target target_state ) )
   in
   let (_ : Ledger.unattached_mask) =
     Ledger.Maskable.unregister_mask_exn ~loc:__LOC__ ~grandchildren:`Recursive
@@ -992,8 +1043,15 @@ let create_genesis_diffs ?(max_size = 50) ~logger ledger ~get_actions_for_aid =
 let distribute_genesis_diff ~logger ~config ~ledger ~get_actions_for_aid =
   let%bind diffs = create_genesis_diffs ~logger ledger ~get_actions_for_aid in
   Deferred.List.iter ~how:`Sequential diffs
-    ~f:(fun (diff, ledger_openings, acc_set_openings, `Target _) ->
-      distribute_diff ~logger ~config ~ledger_openings ~acc_set_openings ~diff )
+    ~f:(fun
+         ( diff
+         , ledger_openings
+         , acc_set_openings
+         , `Source source_state
+         , `Target _ )
+       ->
+      distribute_diff ~logger ~config ~source_state ~ledger_openings
+        ~acc_set_openings ~diff )
 
 let get_ledger_openings ~diff ~ledger =
   let changed_accounts =

--- a/src/app/zeko/da_layer/lib/client.ml
+++ b/src/app/zeko/da_layer/lib/client.ml
@@ -5,6 +5,7 @@ open Mina_ledger
 open Signature_lib
 open Relational_db
 module Field = Snark_params.Tick.Field
+module Rpc_def = Rpc
 
 let rec keep_retrying ~logger ?(delay = Time_ns.Span.of_sec 5.) ~f () =
   match%bind
@@ -216,6 +217,70 @@ module Signature_table = struct
       , Field.to_string state.acc_set )
 end
 
+let verify_da_signature ~signature_kind ~state ~public_key ~signature =
+  match Public_key.decompress public_key with
+  | None ->
+      Or_error.error_string "DA response contains an invalid signer public key"
+  | Some public_key ->
+      let verifies =
+        Schnorr.Chunked.verify ~signature_kind signature
+          (Snark_params.Tick.Inner_curve.of_affine public_key)
+          (Random_oracle.Input.Chunked.field (Da_state.signing_message state))
+      in
+      if verifies then Ok ()
+      else Or_error.error_string "DA signature does not verify for target state"
+
+let validate_post_diff_response ~signature_kind ~expected_state
+    (response : Rpc_def.Post_diff.V2.Response.t) =
+  if not (Da_state.equal response.state_id expected_state) then
+    Or_error.error_s
+      [%message
+        "DA node returned a signature for an unexpected state"
+          (expected_state : Da_state.t)
+          (response.state_id : Da_state.t)]
+  else
+    let%map.Or_error () =
+      verify_da_signature ~signature_kind ~state:response.state_id
+        ~public_key:response.signer ~signature:response.signature
+    in
+    (response.signer, response.signature)
+
+let%test_unit "post-diff responses are bound to the expected state" =
+  let signature_kind = Mina_signature_kind.Other_network "da-response-test" in
+  let keypair = Keypair.create () in
+  let expected_state =
+    Da_state.create ~ledger_hash:Ledger_hash.empty_hash ~acc_set:Field.zero
+  in
+  let signature =
+    Schnorr.Chunked.sign ~signature_kind keypair.private_key
+      (Random_oracle.Input.Chunked.field
+         (Da_state.signing_message expected_state) )
+  in
+  let response =
+    Rpc_def.Post_diff.V2.Response.
+      { state_id = expected_state
+      ; signer = Public_key.compress keypair.public_key
+      ; signature
+      }
+  in
+  assert (
+    Result.is_ok
+      (validate_post_diff_response ~signature_kind ~expected_state response) ) ;
+  let unexpected_state = { expected_state with acc_set = Field.one } in
+  assert (
+    Result.is_error
+      (validate_post_diff_response ~signature_kind
+         ~expected_state:unexpected_state response ) ) ;
+  let bad_signature =
+    Schnorr.Chunked.sign ~signature_kind (Keypair.create ()).private_key
+      (Random_oracle.Input.Chunked.field
+         (Da_state.signing_message expected_state) )
+  in
+  assert (
+    Result.is_error
+      (validate_post_diff_response ~signature_kind ~expected_state
+         { response with signature = bad_signature } ) )
+
 module Rpc = struct
   let dispatch ?(max_tries = 5) ?(timeout = 5.) ~logger
       (node_location : Host_and_port.t Cli_lib.Flag.Types.with_name) rpc data =
@@ -317,11 +382,17 @@ module Rpc = struct
 
   let post_diff ~logger
       ~(node_location : Host_and_port.t Cli_lib.Flag.Types.with_name)
-      ~source_state ~ledger_openings ~acc_set_openings ~diff =
+      ~signature_kind ~source_state ~target_state ~ledger_openings
+      ~acc_set_openings ~diff =
     [%log debug] "Posting diff to da node %s"
       (Host_and_port.to_string node_location.value) ;
-    dispatch ~max_tries:5 ~logger node_location Rpc.Post_diff.V2.t
-      { source_state; ledger_openings; diff; acc_set_openings }
+    let%map result =
+      dispatch ~max_tries:5 ~logger node_location Rpc_def.Post_diff.V2.t
+        { source_state; ledger_openings; diff; acc_set_openings }
+    in
+    Result.bind result ~f:(fun response ->
+        validate_post_diff_response ~signature_kind ~expected_state:target_state
+          response )
 
   let get_diff ~logger
       ~(node_location : Host_and_port.t Cli_lib.Flag.Types.with_name) ~state =
@@ -460,6 +531,7 @@ end
 type t =
   { logger : Logger.t
   ; config : Config.t
+  ; signature_kind : Mina_signature_kind.t
   ; quorum : int  (** The amount of signatures needed when distributing diff *)
   ; db_pool : Db.pool
   ; pushed_diff : unit Condition.t
@@ -468,7 +540,8 @@ type t =
   ; da_keys : Public_key.Compressed.t list
   }
 
-let create ~logger ~(config : Config.t) ~quorum ~da_keys ~db_pool =
+let create ~logger ~(config : Config.t) ~signature_kind ~quorum ~da_keys
+    ~db_pool =
   let%map.Deferred fetched_da_keys = Config.fetch_public_keys ~logger config in
   let sorted_da_keys =
     List.sort da_keys ~compare:Public_key.Compressed.compare
@@ -482,6 +555,7 @@ let create ~logger ~(config : Config.t) ~quorum ~da_keys ~db_pool =
       fetched_da_keys sorted_da_keys ;
   { logger
   ; config
+  ; signature_kind
   ; quorum
   ; db_pool
   ; pushed_diff = Condition.create ()
@@ -543,8 +617,8 @@ let rec start_posting_diffs_from ?timeout_on_failure ?pushed_diff t
         } -> (
         match%bind
           Rpc.post_diff ~logger:t.logger ~node_location
-            ~source_state:diff_source_state ~ledger_openings ~acc_set_openings
-            ~diff
+            ~signature_kind:t.signature_kind ~source_state:diff_source_state
+            ~target_state ~ledger_openings ~acc_set_openings ~diff
         with
         | Error err ->
             [%log error] "Failed to post diff to da node: %s"
@@ -948,20 +1022,34 @@ let get_diff ~logger ~config ~state =
       | Error e ->
           return (Error e) )
 
-let distribute_diff ~logger ~config ~source_state ~ledger_openings
-    ~acc_set_openings ~diff =
+let distribute_diff ~logger ~config ~signature_kind ~source_state ~target_state
+    ~ledger_openings ~acc_set_openings ~diff =
   Deferred.List.iter ~how:`Parallel
     Config.(config.nodes)
     ~f:(fun n ->
       match%map
-        Rpc.post_diff ~logger ~node_location:n ~source_state ~ledger_openings
-          ~acc_set_openings ~diff
+        Rpc.post_diff ~logger ~node_location:n ~signature_kind ~source_state
+          ~target_state ~ledger_openings ~acc_set_openings ~diff
       with
       | Ok _ ->
           ()
       | Error e ->
           [%log error] "Failed to post diff to da node: %s"
             (Error.to_string_hum e) )
+
+let acc_set_opening_keys ~new_keys ~find_lower =
+  Acc_set_transition.opening_keys ~find_lower new_keys |> Or_error.ok_exn
+
+let get_in_memory_acc_set_openings ~logger ~changed_accounts ~ledger_openings
+    ~imt =
+  let new_keys =
+    Acc_set_transition.new_account_keys ~changed_accounts ~ledger_openings
+  in
+  let keys =
+    acc_set_opening_keys ~new_keys
+      ~find_lower:(Indexed_merkle_tree.In_memory.find_lower_entry_tid imt)
+  in
+  Indexed_merkle_tree.Sparse.of_in_memory_subset ~logger ~db:imt ~keys
 
 (** One diff can be too big, split it into multiple smaller ones
     To have only one diff set [max_size] to [Int.max_value]
@@ -1007,19 +1095,16 @@ let create_genesis_diffs ?(max_size = 50) ~logger ledger ~get_actions_for_aid =
             ~changed_accounts:chunk ~actions:(`Actions actions)
         in
         [%log debug] "Adding accounts to acc set db" ;
-        Indexed_merkle_tree.In_memory.insert_batch_exn acc_set
-          (List.map chunk ~f:(fun (_, account) ->
-               Account_id.derive_token_id ~owner:(Account.identifier account) )
-          ) ;
+        let new_account_keys =
+          List.map chunk ~f:(fun (_, account) ->
+              Account_id.derive_token_id ~owner:(Account.identifier account) )
+        in
+        Indexed_merkle_tree.In_memory.insert_batch_exn acc_set new_account_keys ;
         [%log debug] "Creating acc set openings" ;
         let acc_set_openings =
-          Indexed_merkle_tree.Sparse.of_in_memory_subset ~logger ~db:acc_set
-            ~keys:
-              ( [%log debug] "Getting accounts from chunk" ;
-                List.map chunk ~f:snd
-                |> List.map ~f:(fun acc ->
-                       Account_id.derive_token_id
-                         ~owner:(Account.identifier acc) ) )
+          get_in_memory_acc_set_openings ~logger
+            ~changed_accounts:diff.changed_accounts ~ledger_openings
+            ~imt:acc_set
         in
         let target_state =
           Da_state.create
@@ -1040,7 +1125,8 @@ let create_genesis_diffs ?(max_size = 50) ~logger ledger ~get_actions_for_aid =
   result
 
 (** Distribute diff of initial accounts *)
-let distribute_genesis_diff ~logger ~config ~ledger ~get_actions_for_aid =
+let distribute_genesis_diff ~logger ~config ~signature_kind ~ledger
+    ~get_actions_for_aid =
   let%bind diffs = create_genesis_diffs ~logger ledger ~get_actions_for_aid in
   Deferred.List.iter ~how:`Sequential diffs
     ~f:(fun
@@ -1048,10 +1134,10 @@ let distribute_genesis_diff ~logger ~config ~ledger ~get_actions_for_aid =
          , ledger_openings
          , acc_set_openings
          , `Source source_state
-         , `Target _ )
+         , `Target target_state )
        ->
-      distribute_diff ~logger ~config ~source_state ~ledger_openings
-        ~acc_set_openings ~diff )
+      distribute_diff ~logger ~config ~signature_kind ~source_state
+        ~target_state ~ledger_openings ~acc_set_openings ~diff )
 
 let get_ledger_openings ~diff ~ledger =
   let changed_accounts =
@@ -1067,17 +1153,12 @@ let get_ledger_openings ~diff ~ledger =
 let attach_ledger_openings ~diffs ~ledger =
   List.map diffs ~f:(fun diff -> (diff, get_ledger_openings ~diff ~ledger))
 
-let get_acc_set_openings ~diff ~ledger_openings ~imt =
-  let new_accounts_keys =
-    List.filter (Diff.changed_accounts diff) ~f:(fun (index, _) ->
-        Account.equal
-          (Sparse_ledger.get_exn ledger_openings index)
-          Account.empty )
-    |> List.sort ~compare:(fun (a, _) (b, _) -> Int.compare a b)
-    |> List.map ~f:(fun (_, account) ->
-           Account_id.derive_token_id ~owner:(Account.identifier account) )
+let get_acc_set_openings ~logger ~changed_accounts ~ledger_openings ~imt =
+  let new_keys =
+    Acc_set_transition.new_account_keys ~changed_accounts ~ledger_openings
   in
-  let acc_set_openings =
-    Indexed_merkle_tree.Sparse.of_db_subset ~db:imt ~keys:new_accounts_keys
+  let keys =
+    acc_set_opening_keys ~new_keys
+      ~find_lower:(Indexed_merkle_tree.Db.find_lower_entry_tid imt)
   in
-  acc_set_openings
+  Indexed_merkle_tree.Sparse.of_db_subset ~logger ~db:imt ~keys

--- a/src/app/zeko/da_layer/lib/core.ml
+++ b/src/app/zeko/da_layer/lib/core.ml
@@ -10,10 +10,11 @@ module Field = Snark_params.Tick.Field
     4. Set each account in [diff.diff] to the [ledger_openings] and call the resulting ledger hash [target_ledger_hash].
     5. Apply all the actions in [diff.diff] to the [ledger_openings] and check it matches the target ledger..
     6. Check that after applying all the receipts of the command, the receipt chain hashes match the target ledger.
-    7. Check that new accounts in ledger openings are in same order as in acc set openings.
+    7. Check that the account-set openings transform [source_state.acc_set]
+       by inserting exactly the new accounts in ledger order.
     8. Attach timestamp and acc set root.
-    9. Store the diff under the [target_ledger_hash]. 
-    10. Sign [target_ledger_hash]. *)
+    9. Store the diff under the target DA state.
+    10. Sign and return the target DA state. *)
 let post_diff ~logger ~proof_cache_db ~kvdb ~network_id
     ~(signer : Signer_service.Signer.t) ~(source_state : Da_state.t)
     ~ledger_openings ~acc_set_openings ~(diff : Diff.Pending.t) =
@@ -284,15 +285,25 @@ let post_diff ~logger ~proof_cache_db ~kvdb ~network_id
   in
 
   (* 7 *)
+  let new_accounts =
+    List.filter diff.changed_accounts ~f:(fun (index, _) ->
+        Account.equal
+          (Sparse_ledger.get_exn ledger_openings index)
+          Account.empty )
+    |> List.sort ~compare:(fun (a, _) (b, _) -> Int.compare a b)
+  in
+  let new_account_keys =
+    List.map new_accounts ~f:(fun (_, account) ->
+        Account_id.derive_token_id ~owner:(Account.identifier account) )
+  in
+  let%bind.Result target_acc_set =
+    Acc_set_transition.validate ~source_root:source_state.acc_set
+      ~new_keys:new_account_keys acc_set_openings
+    |> Result.map_error ~f:(fun error ->
+           Error.tag error ~tag:"Invalid account-set transition" )
+  in
   let%bind.Result () =
     try
-      let new_accounts =
-        List.filter diff.changed_accounts ~f:(fun (index, _) ->
-            Account.equal
-              (Sparse_ledger.get_exn ledger_openings index)
-              Account.empty )
-        |> List.sort ~compare:(fun (a, _) (b, _) -> Int.compare a b)
-      in
       let acc_set_entries =
         List.map new_accounts ~f:(fun (_, account) ->
             let key =
@@ -326,9 +337,6 @@ let post_diff ~logger ~proof_cache_db ~kvdb ~network_id
 
   (* 8 *)
   (* V2 was added time *)
-  let target_acc_set =
-    Indexed_merkle_tree.Sparse.merkle_root_without_cache_exn acc_set_openings
-  in
   let diff : Diff.Stable.V4.t =
     Diff.add_time_and_acc_set ~logger diff ~acc_set:target_acc_set
   in
@@ -366,7 +374,9 @@ let post_diff ~logger ~proof_cache_db ~kvdb ~network_id
     Signer_service.Signer.sign_field ~signature_kind:network_id signer message
     (* Schnorr.Chunked.sign ~signature_kind:network_id signer.private_key message *)
   in
-  Ok signature
+  Ok
+    (Async.Deferred.map signature ~f:(fun result ->
+         Result.map result ~f:(fun signature -> (target_state, signature)) ) )
 
 let%test_unit "actions-only diffs cannot change receipt-chain hashes" =
   let depth = 8 in
@@ -432,6 +442,36 @@ let%test_unit "actions-only diffs cannot change receipt-chain hashes" =
           let source_state =
             Da_state.create ~ledger_hash:source_ledger_hash ~acc_set
           in
+          let mismatched_acc_set =
+            if Field.equal acc_set Field.one then Field.of_int 2 else Field.one
+          in
+          let mismatched_source_state =
+            Da_state.create ~ledger_hash:source_ledger_hash
+              ~acc_set:mismatched_acc_set
+          in
+          let mismatched_source_diff =
+            { source_diff with Diff.Stable.V4.acc_set = mismatched_acc_set }
+          in
+          ignore
+            ( Db.add_diff kvdb
+                ~diff:
+                  { Stored_diff.source_state
+                  ; target_state = mismatched_source_state
+                  ; diff = mismatched_source_diff
+                  }
+              : [ `Added
+                | `Already_existed
+                | `Conflicting_diff of Stored_diff.t ] ) ;
+          let no_op_diff =
+            Diff.create_pending ~source_ledger_hash ~changed_accounts:[]
+              ~actions:(`Actions [])
+          in
+          let mismatched_source_result =
+            post_diff ~logger ~proof_cache_db ~kvdb ~network_id:Mainnet ~signer
+              ~source_state:mismatched_source_state ~ledger_openings
+              ~acc_set_openings ~diff:no_op_diff
+          in
+          assert (Result.is_error mismatched_source_result) ;
           let changed_receipt_chain_hash =
             Receipt.Chain_hash.cons_zkapp_command_commitment
               Unsigned.UInt32.zero
@@ -457,8 +497,9 @@ let%test_unit "actions-only diffs cannot change receipt-chain hashes" =
             with
             | Error error ->
                 Error error
-            | Ok signature ->
-                Async.Thread_safe.block_on_async_exn (fun () -> signature)
+            | Ok state_and_signature ->
+                Async.Thread_safe.block_on_async_exn (fun () ->
+                    state_and_signature )
           in
           assert (Result.is_error result) ;
           let receipt_preserving_account =
@@ -480,8 +521,9 @@ let%test_unit "actions-only diffs cannot change receipt-chain hashes" =
             with
             | Error error ->
                 Error error
-            | Ok signature ->
-                Async.Thread_safe.block_on_async_exn (fun () -> signature)
+            | Ok state_and_signature ->
+                Async.Thread_safe.block_on_async_exn (fun () ->
+                    state_and_signature )
           in
           assert (Result.is_ok receipt_preserving_result) ;
           let conflicting_diff =
@@ -500,7 +542,8 @@ let%test_unit "actions-only diffs cannot change receipt-chain hashes" =
             with
             | Error error ->
                 Error error
-            | Ok signature ->
-                Async.Thread_safe.block_on_async_exn (fun () -> signature)
+            | Ok state_and_signature ->
+                Async.Thread_safe.block_on_async_exn (fun () ->
+                    state_and_signature )
           in
           assert (Result.is_error conflicting_result) ) )

--- a/src/app/zeko/da_layer/lib/core.ml
+++ b/src/app/zeko/da_layer/lib/core.ml
@@ -15,13 +15,23 @@ module Field = Snark_params.Tick.Field
     9. Store the diff under the [target_ledger_hash]. 
     10. Sign [target_ledger_hash]. *)
 let post_diff ~logger ~proof_cache_db ~kvdb ~network_id
-    ~(signer : Signer_service.Signer.t) ~ledger_openings ~acc_set_openings
-    ~(diff : Diff.Pending.t) =
+    ~(signer : Signer_service.Signer.t) ~(source_state : Da_state.t)
+    ~ledger_openings ~acc_set_openings ~(diff : Diff.Pending.t) =
   let get_account ledger account_id =
     try
       let index = Sparse_ledger.find_index_exn ledger account_id in
       Ok (Sparse_ledger.get_exn ledger index)
     with e -> Error (Error.of_exn e)
+  in
+
+  let%bind.Result () =
+    if Ledger_hash.equal source_state.ledger_hash diff.source_ledger_hash then
+      Ok ()
+    else
+      Error
+        (Error.create "Source DA state does not match diff source ledger hash"
+           (source_state, diff.source_ledger_hash)
+           [%sexp_of: Da_state.t * Ledger_hash.t] )
   in
 
   (* 1 *)
@@ -43,19 +53,18 @@ let post_diff ~logger ~proof_cache_db ~kvdb ~network_id
 
   (* 2 *)
   let%bind.Result () =
-    match Db.get_diff kvdb ~ledger_hash:diff.source_ledger_hash with
+    match Db.get_diff kvdb ~state:source_state with
     | Some _ ->
         Ok ()
     | None ->
         if
-          Ledger_hash.equal diff.source_ledger_hash
-            (Diff.empty_ledger_hash
-               ~depth:(Sparse_ledger.depth ledger_openings) )
+          Da_state.equal source_state
+            (Da_state.empty ~depth:(Sparse_ledger.depth ledger_openings))
         then Ok ()
         else
           Error
-            (Error.create "Source ledger not found in the database"
-               diff.source_ledger_hash Ledger_hash.sexp_of_t )
+            (Error.create "Source ledger not found in the database" source_state
+               Da_state.sexp_of_t )
   in
 
   (* 3 *)
@@ -250,30 +259,28 @@ let post_diff ~logger ~proof_cache_db ~kvdb ~network_id
         Ok acc
   in
   let%bind.Result () =
-    match diff.actions with
-    | `Actions _ ->
-        Ok ()
-    | `Command_with_action_step_flags _ ->
-        List.fold_result diff.changed_accounts ~init:()
-          ~f:(fun _ (_, account) ->
-            (* account's target_receipt_chain_hash needs to be either unchanged or the same as in [applied_hashes] *)
-            let account_id = Account.identifier account in
-            let%bind.Result target_account =
-              get_account target_ledger account_id
-            in
-            let target_receipt_chain_hash = target_account.receipt_chain_hash in
-            let%bind.Result applied_receipt_chain_hash =
-              get_account's_receipt_chain_hash applied_hashes account_id
-            in
-            if
-              Receipt.Chain_hash.equal target_receipt_chain_hash
-                applied_receipt_chain_hash
-            then Ok ()
-            else
-              Error
-                (Error.create "Receipt chain hash mismatch"
-                   (target_receipt_chain_hash, applied_receipt_chain_hash)
-                   [%sexp_of: Receipt.Chain_hash.t * Receipt.Chain_hash.t] ) )
+    List.fold_result diff.changed_accounts ~init:() ~f:(fun _ (_, account) ->
+        (* For command-backed diffs, [applied_hashes] contains every receipt
+           update authorized by the command. For actions-only diffs it is
+           empty, so this requires each receipt chain hash to stay unchanged. *)
+        let account_id = Account.identifier account in
+        let%bind.Result target_account = get_account target_ledger account_id in
+        let target_receipt_chain_hash = target_account.receipt_chain_hash in
+        let%bind.Result applied_receipt_chain_hash =
+          get_account's_receipt_chain_hash applied_hashes account_id
+        in
+        if
+          Receipt.Chain_hash.equal target_receipt_chain_hash
+            applied_receipt_chain_hash
+        then Ok ()
+        else
+          Error
+            (Error.create "Receipt chain hash mismatch"
+               ( account_id
+               , target_receipt_chain_hash
+               , applied_receipt_chain_hash )
+               [%sexp_of:
+                 Account_id.t * Receipt.Chain_hash.t * Receipt.Chain_hash.t] ) )
   in
 
   (* 7 *)
@@ -319,33 +326,40 @@ let post_diff ~logger ~proof_cache_db ~kvdb ~network_id
 
   (* 8 *)
   (* V2 was added time *)
-  let diff : Diff.Stable.V4.t =
-    Diff.add_time_and_acc_set ~logger diff
-      ~acc_set:(Indexed_merkle_tree.Sparse.merkle_root acc_set_openings)
+  let target_acc_set =
+    Indexed_merkle_tree.Sparse.merkle_root_without_cache_exn acc_set_openings
   in
+  let diff : Diff.Stable.V4.t =
+    Diff.add_time_and_acc_set ~logger diff ~acc_set:target_acc_set
+  in
+  let target_state =
+    Da_state.create ~ledger_hash:target_ledger_hash ~acc_set:target_acc_set
+  in
+  let stored_diff : Stored_diff.t = { source_state; target_state; diff } in
 
   (* 9 *)
-  (* We don't care if the diff already existed *)
-  let () =
-    match Db.add_diff kvdb ~ledger_hash:target_ledger_hash ~diff with
+  let%bind.Result () =
+    match Db.add_diff kvdb ~diff:stored_diff with
     | `Already_existed ->
-        [%log warn] "Diff with target ledger hash %s already exists"
-          (Ledger_hash.to_decimal_string target_ledger_hash)
+        [%log info] "DA diff for state %s already exists"
+          (Da_state.to_string target_state) ;
+        Ok ()
     | `Added ->
-        [%log info] "Diff with target ledger hash %s added to the database"
-          (Ledger_hash.to_decimal_string target_ledger_hash)
+        [%log info] "DA diff for state %s added to the database"
+          (Da_state.to_string target_state) ;
+        Ok ()
+    | `Conflicting_diff existing ->
+        Error
+          (Error.create
+             "Refusing to sign a DA state whose stored diff has different \
+              contents"
+             (target_state, existing.diff, diff)
+             [%sexp_of: Da_state.t * Diff.Stable.V4.t * Diff.Stable.V4.t] )
   in
 
   (* 10 *)
   let%bind.Result message =
-    try
-      Random_oracle.hash
-        ~init:(Hash_prefix_create.salt Zeko_constants.da_layer_check_salt)
-        [| target_ledger_hash
-         ; Indexed_merkle_tree.Sparse.merkle_root_without_cache_exn
-             acc_set_openings
-        |]
-      |> Result.return
+    try Da_state.signing_message target_state |> Result.return
     with e -> Error (Error.of_exn e)
   in
   let signature =
@@ -353,3 +367,140 @@ let post_diff ~logger ~proof_cache_db ~kvdb ~network_id
     (* Schnorr.Chunked.sign ~signature_kind:network_id signer.private_key message *)
   in
   Ok signature
+
+let%test_unit "actions-only diffs cannot change receipt-chain hashes" =
+  let depth = 8 in
+  let logger = Logger.create () in
+  let proof_cache_db = Proof_cache_tag.create_identity_db () in
+  let signer =
+    Signer_service.Signer.of_keypair (Signature_lib.Keypair.create ())
+  in
+  let db_dir =
+    Filename.concat Filename.temp_dir_name
+      ("zeko-da-core-test-" ^ (Uuid_unix.create () |> Uuid.to_string))
+  in
+  let kvdb = Db.create db_dir in
+  Exn.protect
+    ~finally:(fun () -> Db.close kvdb)
+    ~f:(fun () ->
+      Ledger.with_ledger ~depth ~f:(fun ledger ->
+          let keypair = Signature_lib.Keypair.create () in
+          let account_id =
+            Account_id.create
+              (Public_key.compress keypair.public_key)
+              Token_id.default
+          in
+          let source_account =
+            Account.create account_id Currency.Balance.zero
+          in
+          Ledger.create_new_account_exn ledger account_id source_account ;
+          let source_ledger_hash = Ledger.merkle_root ledger in
+          let ledger_openings =
+            Sparse_ledger.of_ledger_subset_exn ledger [ account_id ]
+          in
+          let account_set = Indexed_merkle_tree.In_memory.create ~depth () in
+          Indexed_merkle_tree.In_memory.insert_exn account_set
+            (Account_id.derive_token_id ~owner:account_id) ;
+          let acc_set_openings =
+            Indexed_merkle_tree.Sparse.of_in_memory_subset ~logger
+              ~db:account_set ~keys:[]
+          in
+          let acc_set =
+            Indexed_merkle_tree.Sparse.merkle_root acc_set_openings
+          in
+          let source_diff : Diff.Stable.V4.t =
+            { source_ledger_hash
+            ; changed_accounts = []
+            ; actions = `Actions []
+            ; timestamp = Block_time.zero
+            ; acc_set
+            }
+          in
+          ignore
+            ( Db.add_diff kvdb
+                ~diff:
+                  { Stored_diff.source_state =
+                      Da_state.create
+                        ~ledger_hash:source_diff.source_ledger_hash ~acc_set
+                  ; target_state =
+                      Da_state.create ~ledger_hash:source_ledger_hash ~acc_set
+                  ; diff = source_diff
+                  }
+              : [ `Added
+                | `Already_existed
+                | `Conflicting_diff of Stored_diff.t ] ) ;
+          let source_state =
+            Da_state.create ~ledger_hash:source_ledger_hash ~acc_set
+          in
+          let changed_receipt_chain_hash =
+            Receipt.Chain_hash.cons_zkapp_command_commitment
+              Unsigned.UInt32.zero
+              (Receipt.Zkapp_command_elt.Zkapp_command_commitment Field.one)
+              source_account.receipt_chain_hash
+          in
+          let target_account =
+            { source_account with
+              receipt_chain_hash = changed_receipt_chain_hash
+            }
+          in
+          let diff =
+            Diff.create_pending ~source_ledger_hash
+              ~changed_accounts:
+                [ (Ledger.index_of_account_exn ledger account_id, target_account)
+                ]
+              ~actions:(`Actions [])
+          in
+          let result =
+            match
+              post_diff ~logger ~proof_cache_db ~kvdb ~network_id:Mainnet
+                ~signer ~source_state ~ledger_openings ~acc_set_openings ~diff
+            with
+            | Error error ->
+                Error error
+            | Ok signature ->
+                Async.Thread_safe.block_on_async_exn (fun () -> signature)
+          in
+          assert (Result.is_error result) ;
+          let receipt_preserving_account =
+            { source_account with nonce = Unsigned.UInt32.one }
+          in
+          let receipt_preserving_diff =
+            Diff.create_pending ~source_ledger_hash
+              ~changed_accounts:
+                [ ( Ledger.index_of_account_exn ledger account_id
+                  , receipt_preserving_account )
+                ]
+              ~actions:(`Actions [])
+          in
+          let receipt_preserving_result =
+            match
+              post_diff ~logger ~proof_cache_db ~kvdb ~network_id:Mainnet
+                ~signer ~source_state ~ledger_openings ~acc_set_openings
+                ~diff:receipt_preserving_diff
+            with
+            | Error error ->
+                Error error
+            | Ok signature ->
+                Async.Thread_safe.block_on_async_exn (fun () -> signature)
+          in
+          assert (Result.is_ok receipt_preserving_result) ;
+          let conflicting_diff =
+            Diff.create_pending ~source_ledger_hash
+              ~changed_accounts:
+                [ ( Ledger.index_of_account_exn ledger account_id
+                  , receipt_preserving_account )
+                ]
+              ~actions:(`Actions [ (account_id, []) ])
+          in
+          let conflicting_result =
+            match
+              post_diff ~logger ~proof_cache_db ~kvdb ~network_id:Mainnet
+                ~signer ~source_state ~ledger_openings ~acc_set_openings
+                ~diff:conflicting_diff
+            with
+            | Error error ->
+                Error error
+            | Ok signature ->
+                Async.Thread_safe.block_on_async_exn (fun () -> signature)
+          in
+          assert (Result.is_error conflicting_result) ) )

--- a/src/app/zeko/da_layer/lib/da_state.ml
+++ b/src/app/zeko/da_layer/lib/da_state.ml
@@ -1,0 +1,54 @@
+open Core_kernel
+open Mina_base
+open Mina_ledger
+module Field = Snark_params.Tick.Field
+
+[%%versioned
+module Stable = struct
+  [@@@no_toplevel_latest_type]
+
+  module V1 = struct
+    type t =
+      { ledger_hash : Ledger_hash.Stable.V1.t
+      ; acc_set : (Field.t[@version_asserted])
+      }
+    [@@deriving compare, equal, sexp, yojson]
+
+    let to_latest = Fn.id
+  end
+end]
+
+type t = Stable.V1.t = { ledger_hash : Ledger_hash.t; acc_set : Field.t }
+[@@deriving compare, equal, sexp, yojson]
+
+let create ~ledger_hash ~acc_set = { ledger_hash; acc_set }
+
+let to_string { ledger_hash; acc_set } =
+  Ledger_hash.to_decimal_string ledger_hash ^ ":" ^ Field.to_string acc_set
+
+let of_string value =
+  match String.rsplit2 value ~on:':' with
+  | Some (ledger_hash, acc_set) ->
+      Or_error.try_with (fun () ->
+          { ledger_hash = Ledger_hash.of_decimal_string ledger_hash
+          ; acc_set = Field.of_string acc_set
+          } )
+  | None ->
+      Or_error.errorf "Invalid DA state: %s" value
+
+let signing_message { ledger_hash; acc_set } =
+  Random_oracle.hash
+    ~init:(Hash_prefix_create.salt Zeko_constants.da_layer_check_salt)
+    [| ledger_hash; acc_set |]
+
+let empty ~depth =
+  let acc_set = Indexed_merkle_tree.In_memory.create ~depth () in
+  { ledger_hash = Ledger.merkle_root @@ Ledger.create_ephemeral ~depth ()
+  ; acc_set = Indexed_merkle_tree.In_memory.merkle_root acc_set
+  }
+
+let%test_unit "account-set root is part of the DA signing message" =
+  let ledger_hash = Ledger_hash.empty_hash in
+  let first = signing_message (create ~ledger_hash ~acc_set:Field.zero) in
+  let second = signing_message (create ~ledger_hash ~acc_set:Field.one) in
+  assert (not (Field.equal first second))

--- a/src/app/zeko/da_layer/lib/db.ml
+++ b/src/app/zeko/da_layer/lib/db.ml
@@ -1,15 +1,22 @@
 open Core_kernel
 open Mina_base
+module Field = Snark_params.Tick.Field
 
 module Key_value = struct
   type _ t =
-    | Diff : (Ledger_hash.t * Diff.Stable.V4.t) t
+    | Diff : (Da_state.t * Stored_diff.t) t
+    | Legacy_diff : (Ledger_hash.t * Diff.Stable.V4.t) t
     | Migration : (unit * int) t
 
   let serialize_key : type k v. (k * v) t -> k -> Bigstring.t =
    fun pair_type key ->
     match pair_type with
     | Diff ->
+        Bigstring.concat
+          [ Bigstring.of_string "state-diff:"
+          ; Bigstring.of_string @@ Da_state.to_string key
+          ]
+    | Legacy_diff ->
         Bigstring.concat
           [ Bigstring.of_string "diff"
           ; Bigstring.of_string @@ Ledger_hash.to_decimal_string key
@@ -21,6 +28,8 @@ module Key_value = struct
    fun pair_type value ->
     match pair_type with
     | Diff ->
+        Stored_diff.to_bigstring value
+    | Legacy_diff ->
         Diff.to_bigstring value
     | Migration ->
         Bigstring.of_string @@ Int.to_string value
@@ -29,6 +38,8 @@ module Key_value = struct
    fun pair_type data ->
     match pair_type with
     | Diff ->
+        Stored_diff.of_bigstring data
+    | Legacy_diff ->
         Diff.of_bigstring data |> Or_error.ok_exn
     | Migration ->
         Int.of_string @@ Bigstring.to_string data
@@ -36,29 +47,85 @@ end
 
 include Kvdb_base.Make (Key_value)
 
-let has_diff t ~ledger_hash = get t Diff ~key:ledger_hash |> Option.is_some
+let has_diff t ~state = get t Diff ~key:state |> Option.is_some
 
-let add_diff t ~ledger_hash ~diff =
-  if has_diff t ~ledger_hash then `Already_existed
-  else (
-    set t Diff ~key:ledger_hash ~data:diff ;
-    `Added )
+let add_diff t ~(diff : Stored_diff.t) =
+  match get t Diff ~key:diff.target_state with
+  | None ->
+      set t Diff ~key:diff.target_state ~data:diff ;
+      `Added
+  | Some existing when Stored_diff.same_payload existing diff ->
+      `Already_existed
+  | Some existing ->
+      `Conflicting_diff existing
 
-let get_diff t ~ledger_hash = get t Diff ~key:ledger_hash
+let get_diff t ~state = get t Diff ~key:state
+
+let get_legacy_diff t ~ledger_hash = get t Legacy_diff ~key:ledger_hash
+
+let set_legacy_diff t ~ledger_hash ~diff =
+  set t Legacy_diff ~key:ledger_hash ~data:diff
 
 let get_migration t = get t Migration ~key:() |> Option.value ~default:0
 
 let set_migration t ~migration = set t Migration ~key:() ~data:migration
 
 module Async = struct
-  let add_diff t ~ledger_hash ~diff =
-    Async.return (add_diff t ~ledger_hash ~diff)
+  let add_diff t ~diff = Async.return (add_diff t ~diff)
 
-  let get_diff t ~ledger_hash = Async.return (get_diff t ~ledger_hash)
+  let get_diff t ~state = Async.return (get_diff t ~state)
 
   let get_migration t = Async.return (get_migration t)
 
   let set_migration t ~migration = Async.return (set_migration t ~migration)
 
-  let has_diff t ~ledger_hash = Async.return (has_diff t ~ledger_hash)
+  let has_diff t ~state = Async.return (has_diff t ~state)
 end
+
+let%test_unit "stores distinct account-set roots for the same ledger hash" =
+  let db_dir =
+    Filename.concat Filename.temp_dir_name
+      ("zeko-da-db-test-" ^ (Uuid_unix.create () |> Uuid.to_string))
+  in
+  let db = create db_dir in
+  Exn.protect
+    ~finally:(fun () -> close db)
+    ~f:(fun () ->
+      let make_diff acc_set : Diff.Stable.V4.t =
+        { source_ledger_hash = Ledger_hash.empty_hash
+        ; changed_accounts = []
+        ; actions = `Actions []
+        ; timestamp = Block_time.zero
+        ; acc_set
+        }
+      in
+      let ledger_hash = Ledger_hash.empty_hash in
+      let source_state =
+        Da_state.create ~ledger_hash ~acc_set:(Field.of_int 2)
+      in
+      let make_stored_diff acc_set =
+        let target_state = Da_state.create ~ledger_hash ~acc_set in
+        { Stored_diff.source_state; target_state; diff = make_diff acc_set }
+      in
+      let first = add_diff db ~diff:(make_stored_diff Field.zero) in
+      let second = add_diff db ~diff:(make_stored_diff Field.one) in
+      let conflicting =
+        let stored = make_stored_diff Field.zero in
+        add_diff db
+          ~diff:
+            { stored with
+              source_state =
+                Da_state.create ~ledger_hash ~acc_set:(Field.of_int 3)
+            }
+      in
+      assert (Poly.equal first `Added) ;
+      assert (Poly.equal second `Added) ;
+      assert (match conflicting with `Conflicting_diff _ -> true | _ -> false) ;
+      assert (
+        Option.is_some
+          (get_diff db
+             ~state:(Da_state.create ~ledger_hash ~acc_set:Field.zero) ) ) ;
+      assert (
+        Option.is_some
+          (get_diff db
+             ~state:(Da_state.create ~ledger_hash ~acc_set:Field.one) ) ) )

--- a/src/app/zeko/da_layer/lib/migrations.ml
+++ b/src/app/zeko/da_layer/lib/migrations.ml
@@ -1,4 +1,5 @@
 open Core_kernel
+open Mina_base
 
 type migration = Db.t -> unit
 
@@ -37,7 +38,53 @@ let add_version_tag db =
           let v2 = Diff.to_bigstring @@ Diff.Stable.V1.to_latest diff in
           Db.set_raw db ~key ~data:v2 )
 
-let migrations : migration list = [ add_version_tag ]
+let migrate_composite_states db =
+  let legacy_diffs =
+    Db.to_alist db
+    |> List.filter_map ~f:(fun (key, value) ->
+           let key = Bigstring.to_string key in
+           match String.chop_prefix key ~prefix:"diff" with
+           | Some ledger_hash when not (String.is_empty ledger_hash) ->
+               let ledger_hash = Ledger_hash.of_decimal_string ledger_hash in
+               let diff = Diff.of_bigstring value |> Or_error.ok_exn in
+               Some (ledger_hash, diff)
+           | Some _ | None ->
+               None )
+  in
+  let by_ledger_hash = Map.of_alist_exn (module Ledger_hash) legacy_diffs in
+  let empty_state =
+    Da_state.empty ~depth:Zeko_constants.constraint_constants.ledger_depth
+  in
+  List.iter legacy_diffs ~f:(fun (target_ledger_hash, diff) ->
+      let target_state =
+        Da_state.create ~ledger_hash:target_ledger_hash ~acc_set:diff.acc_set
+      in
+      let source_state =
+        if Ledger_hash.equal diff.source_ledger_hash empty_state.ledger_hash
+        then empty_state
+        else
+          match Map.find by_ledger_hash diff.source_ledger_hash with
+          | Some source_diff ->
+              Da_state.create ~ledger_hash:diff.source_ledger_hash
+                ~acc_set:source_diff.acc_set
+          | None ->
+              failwithf
+                "Cannot migrate DA diff %s: source ledger %s is not present"
+                (Da_state.to_string target_state)
+                (Ledger_hash.to_decimal_string diff.source_ledger_hash)
+                ()
+      in
+      match
+        Db.add_diff db ~diff:{ Stored_diff.source_state; target_state; diff }
+      with
+      | `Added | `Already_existed ->
+          ()
+      | `Conflicting_diff _ ->
+          failwithf "Conflicting migrated DA diff for state %s"
+            (Da_state.to_string target_state)
+            () )
+
+let migrations : migration list = [ add_version_tag; migrate_composite_states ]
 
 let latest_migration = List.length migrations
 

--- a/src/app/zeko/da_layer/lib/node.ml
+++ b/src/app/zeko/da_layer/lib/node.ml
@@ -1,5 +1,4 @@
 open Core_kernel
-open Mina_base
 module Rpc_def = Rpc
 open Async
 
@@ -13,17 +12,13 @@ type t =
   ; proof_cache_db : Proof_cache_tag.cache_db
   }
 
-let get_signature t ~ledger_hash =
-  let%bind diff = Db.Async.get_diff t.db ~ledger_hash in
-  match diff with
+let get_signature t ~state =
+  let%bind stored_diff = Db.Async.get_diff t.db ~state in
+  match stored_diff with
   | None ->
       return None
-  | Some diff -> (
-      let message =
-        Random_oracle.hash
-          ~init:(Hash_prefix_create.salt Zeko_constants.da_layer_check_salt)
-          [| ledger_hash; diff.acc_set |]
-      in
+  | Some _ -> (
+      let message = Da_state.signing_message state in
       Signer_service.Signer.sign_field ~signature_kind:t.chain t.signer message
       >>| function
       | Ok signature ->
@@ -33,9 +28,9 @@ let get_signature t ~ledger_hash =
           [%log error] "Failed to sign DA receipt: %s" (Error.to_string_hum err) ;
           None )
 
-let get_ledger_hashes_chain t
+let get_states_chain t
     ({ source = source_opt; target; max_length = max_length_opt } :
-      Rpc_def.Get_ledger_hashes_chain.V1.Query.t ) =
+      Rpc_def.Get_ledger_hashes_chain.V2.Query.t ) =
   let logger = t.logger in
   let max_length =
     match max_length_opt with Some n -> n | None -> Int.max_value
@@ -43,24 +38,24 @@ let get_ledger_hashes_chain t
   let source =
     match source_opt with
     | `Genesis ->
-        Diff.empty_ledger_hash ~depth:constraint_constants.ledger_depth
+        Da_state.empty ~depth:constraint_constants.ledger_depth
     | `Specific source ->
         source
   in
-  [%log debug] "Getting ledger hashes chain from $source to $target"
+  [%log debug] "Getting DA states chain from $source to $target"
     ~metadata:
-      [ ("source", `String (Ledger_hash.to_decimal_string source))
-      ; ("target", `String (Ledger_hash.to_decimal_string target))
+      [ ("source", `String (Da_state.to_string source))
+      ; ("target", `String (Da_state.to_string target))
       ] ;
   let rec go n current =
-    if Ledger_hash.equal current source || n <= 0 then return []
+    if Da_state.equal current source || n <= 0 then return []
     else
       let%bind source =
-        Db.Async.get_diff ~ledger_hash:current t.db
-        >>| fun diff ->
+        Db.Async.get_diff ~state:current t.db
+        >>| fun stored_diff ->
         Option.value_exn ~here:[%here]
-          ~message:"Get_ledger_hashes_chain: diff not found" diff
-        |> Diff.Stable.V4.source_ledger_hash
+          ~message:"Get_states_chain: diff not found" stored_diff
+        |> fun (stored : Stored_diff.t) -> stored.source_state
       in
       let%map next = go (n - 1) source in
       current :: next
@@ -73,12 +68,12 @@ let implementations t =
       [ (* Healthcheck *)
         Rpc.Rpc.implement Rpc_def.Healthcheck.V1.t (fun () () -> return ())
       ; (* Post_diff *)
-        Rpc.Rpc.implement Rpc_def.Post_diff.V1.t
-          (fun () { ledger_openings; acc_set_openings; diff } ->
+        Rpc.Rpc.implement Rpc_def.Post_diff.V2.t
+          (fun () { source_state; ledger_openings; acc_set_openings; diff } ->
             match%bind
               Core.post_diff ~logger:t.logger ~proof_cache_db:t.proof_cache_db
                 ~kvdb:t.db ~network_id:t.chain ~signer:t.signer ~ledger_openings
-                ~acc_set_openings ~diff
+                ~source_state ~acc_set_openings ~diff
               |> function Error e -> Deferred.return (Error e) | Ok d -> d
             with
             | Ok signature ->
@@ -89,41 +84,40 @@ let implementations t =
                 [%log warn] "Error posting diff: %s" (Error.to_string_hum e) ;
                 failwith (Error.to_string_hum e) )
       ; (* Get_diff *)
-        Rpc.Rpc.implement Rpc_def.Get_diff.V4.t (fun () query ->
-            Db.Async.get_diff t.db ~ledger_hash:query )
+        Rpc.Rpc.implement Rpc_def.Get_diff.V5.t (fun () query ->
+            Db.Async.get_diff t.db ~state:query )
       ; (* Has_diff *)
-        Rpc.Rpc.implement Rpc_def.Has_diff.V1.t (fun () query ->
-            Db.Async.has_diff t.db ~ledger_hash:query )
+        Rpc.Rpc.implement Rpc_def.Has_diff.V2.t (fun () query ->
+            Db.Async.has_diff t.db ~state:query )
       ; (* Get_diff_source *)
-        Rpc.Rpc.implement Rpc_def.Get_diff_source.V1.t (fun () query ->
-            Db.Async.get_diff t.db ~ledger_hash:query
-            >>| fun diff ->
+        Rpc.Rpc.implement Rpc_def.Get_diff_source.V2.t (fun () query ->
+            Db.Async.get_diff t.db ~state:query
+            >>| fun stored_diff ->
             Option.value_exn
               ~error:
                 ( Error.of_string
                 @@ sprintf
-                     "Get_diff_source exception: Diff not found for ledger \
-                      hash %s"
-                     (Ledger_hash.to_decimal_string query) )
-              diff
-            |> Diff.Stable.Latest.source_ledger_hash )
+                     "Get_diff_source exception: Diff not found for DA state %s"
+                     (Da_state.to_string query) )
+              stored_diff
+            |> fun (stored : Stored_diff.t) -> stored.source_state )
       ; (* Get_signed_public_key *)
         Rpc.Rpc.implement Rpc_def.Get_signer_public_key.V1.t (fun () () ->
             return @@ Signer_service.Signer.public_key t.signer )
       ; (* Get_signature *)
-        Async.Rpc.Rpc.implement Rpc_def.Get_signature.V1.t (fun () query ->
+        Async.Rpc.Rpc.implement Rpc_def.Get_signature.V2.t (fun () query ->
             let pk = Signer_service.Signer.public_key t.signer in
-            let%map signature = get_signature t ~ledger_hash:query in
+            let%map signature = get_signature t ~state:query in
             Option.map signature ~f:(fun s -> (pk, s)) )
       ; (* Get_ledger_hashes_chain *)
-        Rpc.Rpc.implement Rpc_def.Get_ledger_hashes_chain.V1.t (fun () query ->
-            get_ledger_hashes_chain t query )
+        Rpc.Rpc.implement Rpc_def.Get_ledger_hashes_chain.V2.t (fun () query ->
+            get_states_chain t query )
       ; (* Get_diffs_chain *)
-        Rpc.Rpc.implement Rpc_def.Get_diffs_chain.V2.t
+        Rpc.Rpc.implement Rpc_def.Get_diffs_chain.V3.t
           (fun () { source; target; max_length } ->
             let logger = t.logger in
             let%bind chain =
-              get_ledger_hashes_chain t { source; target; max_length }
+              get_states_chain t { source; target; max_length }
             in
             [%log debug]
               "Got ledger hashes chain from $source to $target with length \
@@ -135,54 +129,43 @@ let implementations t =
                       | `Genesis ->
                           "genesis"
                       | `Specific source ->
-                          Ledger_hash.to_decimal_string source ) )
-                ; ("target", `String (Ledger_hash.to_decimal_string target))
+                          Da_state.to_string source ) )
+                ; ("target", `String (Da_state.to_string target))
                 ; ("length", `Int (List.length chain))
                 ] ;
-            Deferred.List.map ~how:`Parallel chain ~f:(fun ledger_hash ->
-                [%log debug] "Getting diff for ledger hash: $ledger_hash"
-                  ~metadata:
-                    [ ( "ledger_hash"
-                      , `String (Ledger_hash.to_decimal_string ledger_hash) )
-                    ] ;
-                Db.Async.get_diff ~ledger_hash t.db
-                >>| fun diff ->
-                Option.value_exn ~here:[%here] ~message:"Diff not found" diff ) )
+            Deferred.List.map ~how:`Parallel chain ~f:(fun state ->
+                [%log debug] "Getting diff for DA state: $state"
+                  ~metadata:[ ("state", `String (Da_state.to_string state)) ] ;
+                Db.Async.get_diff ~state t.db
+                >>| fun stored_diff ->
+                Option.value_exn ~here:[%here] ~message:"Diff not found"
+                  stored_diff ) )
       ; (* Diffs_stream *)
-        Rpc.Pipe_rpc.implement Rpc_def.Diffs_stream.V3.t
+        Rpc.Pipe_rpc.implement Rpc_def.Diffs_stream.V4.t
           (fun () { source; target } ->
             let logger = t.logger in
             let r, w = Pipe.create () in
             let%bind chain =
-              get_ledger_hashes_chain t { source; target; max_length = None }
+              get_states_chain t { source; target; max_length = None }
             in
             don't_wait_for
               ( Monitor.try_with (fun () ->
-                    Deferred.List.iter ~how:`Sequential chain
-                      ~f:(fun ledger_hash ->
-                        [%log debug]
-                          "Getting diff for ledger hash: $ledger_hash"
+                    Deferred.List.iter ~how:`Sequential chain ~f:(fun state ->
+                        [%log debug] "Getting diff for DA state: $state"
                           ~metadata:
-                            [ ( "ledger_hash"
-                              , `String
-                                  (Ledger_hash.to_decimal_string ledger_hash) )
-                            ] ;
-                        let%bind diff =
-                          Db.Async.get_diff ~ledger_hash t.db
+                            [ ("state", `String (Da_state.to_string state)) ] ;
+                        let%bind stored_diff =
+                          Db.Async.get_diff ~state t.db
                           >>| fun o ->
                           Option.value_exn o ~here:[%here]
                             ~message:
-                              (sprintf "Diff stream didn't find diff %s"
-                                 (Ledger_hash.to_decimal_string ledger_hash) )
+                              (sprintf "Diff stream didn't find DA state %s"
+                                 (Da_state.to_string state) )
                         in
-                        let%map () = Pipe.write w diff in
-                        [%log debug]
-                          "Wrote diff to pipe for ledger hash: $ledger_hash"
+                        let%map () = Pipe.write w stored_diff in
+                        [%log debug] "Wrote diff to pipe for DA state: $state"
                           ~metadata:
-                            [ ( "ledger_hash"
-                              , `String
-                                  (Ledger_hash.to_decimal_string ledger_hash) )
-                            ] ) )
+                            [ ("state", `String (Da_state.to_string state)) ] ) )
               >>| Result.iter_error ~f:(fun exn ->
                       [%log error] "Diff stream worker crashed: $error"
                         ~metadata:

--- a/src/app/zeko/da_layer/lib/node.ml
+++ b/src/app/zeko/da_layer/lib/node.ml
@@ -76,9 +76,13 @@ let implementations t =
                 ~source_state ~acc_set_openings ~diff
               |> function Error e -> Deferred.return (Error e) | Ok d -> d
             with
-            | Ok signature ->
-                let pk = Signer_service.Signer.public_key t.signer in
-                return (pk, signature)
+            | Ok (state, signature) ->
+                return
+                  Rpc_def.Post_diff.V2.Response.
+                    { state_id = state
+                    ; signer = Signer_service.Signer.public_key t.signer
+                    ; signature
+                    }
             | Error e ->
                 let logger = t.logger in
                 [%log warn] "Error posting diff: %s" (Error.to_string_hum e) ;

--- a/src/app/zeko/da_layer/lib/rpc.ml
+++ b/src/app/zeko/da_layer/lib/rpc.ml
@@ -48,7 +48,11 @@ module Post_diff = struct
     end
 
     module Response = struct
-      type t = Public_key.Compressed.Stable.V1.t * Signature.Stable.V1.t
+      type t =
+        { state_id : Da_state.Stable.V1.t
+        ; signer : Public_key.Compressed.Stable.V1.t
+        ; signature : Signature.Stable.V1.t
+        }
       [@@deriving bin_io_unversioned]
     end
 

--- a/src/app/zeko/da_layer/lib/rpc.ml
+++ b/src/app/zeko/da_layer/lib/rpc.ml
@@ -35,6 +35,27 @@ module Post_diff = struct
       Rpc.Rpc.create ~name:"Post_diff" ~version:1 ~bin_query:Query.bin_t
         ~bin_response:Response.bin_t
   end
+
+  module V2 = struct
+    module Query = struct
+      type t =
+        { source_state : Da_state.Stable.V1.t
+        ; ledger_openings : Sparse_ledger.Stable.V2.t
+        ; diff : Diff.Pending.Stable.V1.t
+        ; acc_set_openings : Indexed_merkle_tree.Sparse.Stable.V1.t
+        }
+      [@@deriving bin_io_unversioned]
+    end
+
+    module Response = struct
+      type t = Public_key.Compressed.Stable.V1.t * Signature.Stable.V1.t
+      [@@deriving bin_io_unversioned]
+    end
+
+    let t : (Query.t, Response.t) Rpc.Rpc.t =
+      Rpc.Rpc.create ~name:"Post_diff" ~version:2 ~bin_query:Query.bin_t
+        ~bin_response:Response.bin_t
+  end
 end
 
 (* val get_diff : Ledger_hash.t -> Diff.t option *)
@@ -78,6 +99,16 @@ module Get_diff = struct
       Rpc.Rpc.create ~name:"Get_diff" ~version:4
         ~bin_query:Ledger_hash.Stable.V1.bin_t ~bin_response:Response.bin_t
   end
+
+  module V5 = struct
+    module Response = struct
+      type t = Stored_diff.Stable.V1.t option [@@deriving bin_io_unversioned]
+    end
+
+    let t : (Da_state.Stable.V1.t, Response.t) Rpc.Rpc.t =
+      Rpc.Rpc.create ~name:"Get_diff" ~version:5
+        ~bin_query:Da_state.Stable.V1.bin_t ~bin_response:Response.bin_t
+  end
 end
 
 (* val has_diff : Ledger_hash.t -> bool *)
@@ -86,6 +117,12 @@ module Has_diff = struct
     let t : (Ledger_hash.t, bool) Rpc.Rpc.t =
       Rpc.Rpc.create ~name:"Has_diff" ~version:1
         ~bin_query:Ledger_hash.Stable.V1.bin_t ~bin_response:Bool.bin_t
+  end
+
+  module V2 = struct
+    let t : (Da_state.Stable.V1.t, bool) Rpc.Rpc.t =
+      Rpc.Rpc.create ~name:"Has_diff" ~version:2
+        ~bin_query:Da_state.Stable.V1.bin_t ~bin_response:Bool.bin_t
   end
 end
 
@@ -96,6 +133,13 @@ module Get_diff_source = struct
       Rpc.Rpc.create ~name:"Get_diff_source" ~version:1
         ~bin_query:Ledger_hash.Stable.V1.bin_t
         ~bin_response:Ledger_hash.Stable.V1.bin_t
+  end
+
+  module V2 = struct
+    let t : (Da_state.Stable.V1.t, Da_state.Stable.V1.t) Rpc.Rpc.t =
+      Rpc.Rpc.create ~name:"Get_diff_source" ~version:2
+        ~bin_query:Da_state.Stable.V1.bin_t
+        ~bin_response:Da_state.Stable.V1.bin_t
   end
 end
 
@@ -127,6 +171,21 @@ module Get_signature = struct
       Rpc.Rpc.create ~name:"Get_signature" ~version:1
         ~bin_query:Ledger_hash.Stable.V1.bin_t ~bin_response:Response.bin_t
   end
+
+  module V2 = struct
+    module Response = struct
+      type t =
+        (Public_key.Compressed.Stable.V1.t * Signature.Stable.V1.t) option
+      [@@deriving bin_io_unversioned]
+    end
+
+    let t :
+        ( Da_state.Stable.V1.t
+        , (Public_key.Compressed.t * Signature.t) option )
+        Rpc.Rpc.t =
+      Rpc.Rpc.create ~name:"Get_signature" ~version:2
+        ~bin_query:Da_state.Stable.V1.bin_t ~bin_response:Response.bin_t
+  end
 end
 
 (* val get_ledger_hashes_chain : source:Ledger_hash.t option -> target:Ledger_hash.t -> Ledger_hash.t list *)
@@ -147,6 +206,25 @@ module Get_ledger_hashes_chain = struct
 
     let t : (Query.t, Response.t) Rpc.Rpc.t =
       Rpc.Rpc.create ~name:"Get_ledger_hashes_chain" ~version:1
+        ~bin_query:Query.bin_t ~bin_response:Response.bin_t
+  end
+
+  module V2 = struct
+    module Query = struct
+      type t =
+        { source : [ `Genesis | `Specific of Da_state.Stable.V1.t ]
+        ; target : Da_state.Stable.V1.t
+        ; max_length : int option
+        }
+      [@@deriving bin_io_unversioned]
+    end
+
+    module Response = struct
+      type t = Da_state.Stable.V1.t list [@@deriving bin_io_unversioned]
+    end
+
+    let t : (Query.t, Response.t) Rpc.Rpc.t =
+      Rpc.Rpc.create ~name:"Get_ledger_hashes_chain" ~version:2
         ~bin_query:Query.bin_t ~bin_response:Response.bin_t
   end
 end
@@ -171,6 +249,25 @@ module Get_diffs_chain = struct
       Rpc.Rpc.create ~name:"Get_diffs_chain" ~version:2 ~bin_query:Query.bin_t
         ~bin_response:Response.bin_t
   end
+
+  module V3 = struct
+    module Query = struct
+      type t =
+        { source : [ `Genesis | `Specific of Da_state.Stable.V1.t ]
+        ; target : Da_state.Stable.V1.t
+        ; max_length : int option
+        }
+      [@@deriving bin_io_unversioned]
+    end
+
+    module Response = struct
+      type t = Stored_diff.Stable.V1.t list [@@deriving bin_io_unversioned]
+    end
+
+    let t : (Query.t, Response.t) Rpc.Rpc.t =
+      Rpc.Rpc.create ~name:"Get_diffs_chain" ~version:3 ~bin_query:Query.bin_t
+        ~bin_response:Response.bin_t
+  end
 end
 
 (* val diffs_stream : source:Ledger_hash.t option -> target:Ledger_hash.t -> Diff.t stream *)
@@ -190,6 +287,24 @@ module Diffs_stream = struct
 
     let t : (Query.t, Response.t, Error.t) Rpc.Pipe_rpc.t =
       Rpc.Pipe_rpc.create ~name:"Diffs_stream" ~version:3 ~bin_query:Query.bin_t
+        ~bin_response:Response.bin_t ~bin_error:Error.bin_t ()
+  end
+
+  module V4 = struct
+    module Query = struct
+      type t =
+        { source : [ `Genesis | `Specific of Da_state.Stable.V1.t ]
+        ; target : Da_state.Stable.V1.t
+        }
+      [@@deriving bin_io_unversioned]
+    end
+
+    module Response = struct
+      type t = Stored_diff.Stable.V1.t [@@deriving bin_io_unversioned]
+    end
+
+    let t : (Query.t, Response.t, Error.t) Rpc.Pipe_rpc.t =
+      Rpc.Pipe_rpc.create ~name:"Diffs_stream" ~version:4 ~bin_query:Query.bin_t
         ~bin_response:Response.bin_t ~bin_error:Error.bin_t ()
   end
 end

--- a/src/app/zeko/da_layer/lib/stored_diff.ml
+++ b/src/app/zeko/da_layer/lib/stored_diff.ml
@@ -1,0 +1,41 @@
+open Core_kernel
+
+[%%versioned
+module Stable = struct
+  [@@@with_top_version_tag]
+
+  [@@@no_toplevel_latest_type]
+
+  module V1 = struct
+    type t =
+      { source_state : Da_state.Stable.V1.t
+      ; target_state : Da_state.Stable.V1.t
+      ; diff : Diff.Stable.V4.t
+      }
+    [@@deriving compare, sexp_of]
+
+    let to_latest = Fn.id
+  end
+end]
+
+type t = Stable.V1.t =
+  { source_state : Da_state.t
+  ; target_state : Da_state.t
+  ; diff : Diff.Stable.V4.t
+  }
+[@@deriving compare, sexp_of]
+
+let equal left right = Int.equal (compare left right) 0
+
+let same_payload left right =
+  Da_state.equal left.source_state right.source_state
+  && Da_state.equal left.target_state right.target_state
+  &&
+  let right_diff =
+    { right.diff with Diff.Stable.V4.timestamp = left.diff.timestamp }
+  in
+  Int.equal (Diff.Stable.V4.compare left.diff right_diff) 0
+
+let to_bigstring = Binable.to_bigstring (module Stable.V1.With_top_version_tag)
+
+let of_bigstring = Binable.of_bigstring (module Stable.V1.With_top_version_tag)

--- a/src/app/zeko/sequencer/archive_relay/archive_relay.ml
+++ b/src/app/zeko/sequencer/archive_relay/archive_relay.ml
@@ -109,6 +109,38 @@ module Protocol_state = struct
         compile_time_genesis.data
 end
 
+module Da_state_store = struct
+  include Kvdb_base.Make_singleton (struct
+    type t = Da_layer.Da_state.t [@@deriving yojson]
+
+    let key = "archive_relay_da_state"
+  end)
+
+  let get_exn ledger =
+    let kvdb = Ledger.Db.zeko_kvdb ledger in
+    match get kvdb with
+    | Some state
+      when Ledger_hash.equal state.ledger_hash (Ledger.Db.merkle_root ledger) ->
+        state
+    | Some state ->
+        failwithf "Archive DA state ledger mismatch: %s != %s"
+          (Ledger_hash.to_decimal_string state.ledger_hash)
+          (Ledger.Db.merkle_root ledger |> Ledger_hash.to_decimal_string)
+          ()
+    | None ->
+        let empty =
+          Da_layer.Da_state.empty ~depth:constraint_constants.ledger_depth
+        in
+        if Ledger_hash.equal empty.ledger_hash (Ledger.Db.merkle_root ledger)
+        then empty
+        else
+          failwith
+            "Archive checkpoint predates composite DA states; rebuild it from \
+             genesis"
+
+  let set ledger state = set (Ledger.Db.zeko_kvdb ledger) ~data:state
+end
+
 type t =
   { logger : Logger.t
   ; db_dir : string
@@ -267,27 +299,25 @@ let prune_checkpoints t =
             (Filename.concat (checkpoints_dir db_dir)
                (Checkpoint_label.to_string checkpoint) ) )
 
-let sync_archive (t : t) ~hash =
+let sync_archive (t : t) ~state =
   let logger = t.logger in
+  let source_state = Da_state_store.get_exn t.ledger in
   Da_layer.Client.iter_diffs ~logger ~config:t.da_config
-    ~depth:constraint_constants.ledger_depth
-    ~source_ledger_hash:(`Specific (Ledger.Db.merkle_root t.ledger))
-    ~target_ledger_hash:hash ()
-    ~f:(fun ~current_chunk ~current_diff:_ ~chunks_length diff ->
+    ~source_state:(`Specific source_state) ~target_state:state ()
+    ~f:(fun ~current_chunk ~current_diff:_ ~chunks_length stored_diff ->
+      let diff = stored_diff.Da_layer.Stored_diff.diff in
       [%log debug]
-        !"Applying diff with source ledger hash: %{sexp: Ledger_hash.t}"
-        (Da_layer.Diff.Stable.Latest.source_ledger_hash diff) ;
+        !"Applying diff with source DA state: %{sexp: Da_layer.Da_state.t}"
+        stored_diff.source_state ;
       (* Sanity check *)
-      let source_ledger_hash_matches =
-        Ledger_hash.equal
-          (Da_layer.Diff.Stable.Latest.source_ledger_hash diff)
-          (Ledger.Db.merkle_root t.ledger)
+      let current_state = Da_state_store.get_exn t.ledger in
+      let source_state_matches =
+        Da_layer.Da_state.equal stored_diff.source_state current_state
       in
-      if not source_ledger_hash_matches then
-        failwithf "Source ledger hash mismatch: %s != %s"
-          (Ledger_hash.to_decimal_string
-             (Da_layer.Diff.Stable.Latest.source_ledger_hash diff) )
-          (Ledger_hash.to_decimal_string (Ledger.Db.merkle_root t.ledger))
+      if not source_state_matches then
+        failwithf "Source DA state mismatch: %s != %s"
+          (Da_layer.Da_state.to_string stored_diff.source_state)
+          (Da_layer.Da_state.to_string current_state)
           () ;
       let ledger = Ledger.of_database t.ledger in
       let changed_accounts =
@@ -303,10 +333,20 @@ let sync_archive (t : t) ~hash =
       in
       List.iter changed_accounts ~f:(fun (index, account) ->
           Ledger.set_at_index_exn ledger index account ) ;
+      if
+        not
+          (Ledger_hash.equal stored_diff.target_state.ledger_hash
+             (Ledger.merkle_root ledger) )
+      then
+        failwithf "Target ledger hash mismatch: %s != %s"
+          (Ledger_hash.to_decimal_string stored_diff.target_state.ledger_hash)
+          (Ledger.merkle_root ledger |> Ledger_hash.to_decimal_string)
+          () ;
       match diff.actions with
       | `Actions _ ->
           [%log info] "No command with action step flags, committing ledger" ;
           Ledger.commit ledger ;
+          Da_state_store.set t.ledger stored_diff.target_state ;
           return ()
       | `Command_with_action_step_flags (command, _) -> (
           let command =
@@ -338,17 +378,17 @@ let sync_archive (t : t) ~hash =
                 ( Float.of_int current_chunk /. Float.of_int chunks_length
                 *. 100.0 )
                 (Int.to_string_hum height) ;
-              let ledger_hash = Ledger.Db.merkle_root t.ledger in
-              let%map ledger_hash_exists =
+              let target_state = stored_diff.target_state in
+              let%map state_exists =
                 Da_layer.Client.diff_exists ~logger ~config:t.da_config
-                  ~ledger_hash ()
+                  ~state:target_state ()
                 >>| Or_error.ok_exn
               in
-              [%log info] "Ledger hash %s exists: %b"
-                (Ledger_hash.to_decimal_string ledger_hash)
-                ledger_hash_exists ;
+              [%log info] "DA state %s exists: %b"
+                (Da_layer.Da_state.to_string target_state)
+                state_exists ;
               (* Sanity check *)
-              assert ledger_hash_exists ;
+              assert state_exists ;
               make_checkpoint t
                 ~label:
                   ( Da_layer.Diff.Stable.Latest.timestamp diff
@@ -368,21 +408,25 @@ let sync_archive (t : t) ~hash =
               Ledger.commit ledger ;
               [%log debug] "Committed ledger" ;
               Protocol_state.set kvdb ~data:new_protocol_state ;
+              Da_state_store.set t.ledger stored_diff.target_state ;
               return ()
           | Error e ->
               raise (Error.to_exn e) ) )
 
-let fetch_current_ledger_hash ~logger ~zeko_uri () =
-  match Sys.getenv_opt "ZEKO_ARCHIVE_RELAY_OVERRIDE_TARGET_LEDGER_HASH" with
-  | Some hash ->
-      [%log info] "Using override target ledger hash: %s" hash ;
-      return (Ok (Ledger_hash.of_decimal_string hash))
+let fetch_current_da_state ~logger ~zeko_uri () =
+  match Sys.getenv_opt "ZEKO_ARCHIVE_RELAY_OVERRIDE_TARGET_DA_STATE" with
+  | Some state ->
+      [%log info] "Using override target DA state: %s" state ;
+      return
+        ( Da_layer.Da_state.of_string state
+        |> Result.map_error ~f:Error.to_string_hum )
   | None -> (
       let query =
         {|
       query {
         stateHashes {
           unprovedLedgerHash
+          unprovedAccountSetHash
         }
       }
     |}
@@ -428,29 +472,37 @@ let fetch_current_ledger_hash ~logger ~zeko_uri () =
             |> member "unprovedLedgerHash"
             |> to_string |> Ledger_hash.of_decimal_string
           in
-          return (Ok unproved_ledger_hash) )
+          let unproved_acc_set =
+            member "stateHashes" raw_json
+            |> member "unprovedAccountSetHash"
+            |> to_string |> Snark_params.Tick.Field.of_string
+          in
+          return
+            (Ok
+               (Da_layer.Da_state.create ~ledger_hash:unproved_ledger_hash
+                  ~acc_set:unproved_acc_set ) ) )
 
 let sync (t : t) () =
   let logger = t.logger in
   Thread_safe.block_on_async_exn (fun () ->
-      let%bind ledger_hash =
-        match%bind
-          fetch_current_ledger_hash ~logger ~zeko_uri:t.zeko_uri ()
-        with
-        | Ok hash ->
-            [%log info] "Fetched ledger hash: %s"
-              (Ledger_hash.to_decimal_string hash) ;
-            return hash
+      let%bind target_state =
+        match%bind fetch_current_da_state ~logger ~zeko_uri:t.zeko_uri () with
+        | Ok state ->
+            [%log info] "Fetched DA state: %s"
+              (Da_layer.Da_state.to_string state) ;
+            return state
         | Error e ->
             failwith e
       in
-      [%log info] "Syncing to ledger hash %s from %s"
-        (Ledger_hash.to_decimal_string ledger_hash)
-        (Ledger.Db.merkle_root t.ledger |> Ledger_hash.to_decimal_string) ;
+      let source_state = Da_state_store.get_exn t.ledger in
+      [%log info] "Syncing to DA state %s from %s"
+        (Da_layer.Da_state.to_string target_state)
+        (Da_layer.Da_state.to_string source_state) ;
       if%bind
-        Da_layer.Client.diff_exists ~logger ~config:t.da_config ~ledger_hash ()
+        Da_layer.Client.diff_exists ~logger ~config:t.da_config
+          ~state:target_state ()
         >>| Or_error.ok_exn
-      then time ~logger "Synced" (sync_archive t ~hash:ledger_hash)
+      then time ~logger "Synced" (sync_archive t ~state:target_state)
       else (
         [%log warn] "Diff does not exist yet, skipping sync" ;
         return (Ok ()) ) )

--- a/src/app/zeko/sequencer/archive_relay/archive_relay.ml
+++ b/src/app/zeko/sequencer/archive_relay/archive_relay.ml
@@ -306,6 +306,15 @@ let sync_archive (t : t) ~state =
     ~source_state:(`Specific source_state) ~target_state:state ()
     ~f:(fun ~current_chunk ~current_diff:_ ~chunks_length stored_diff ->
       let diff = stored_diff.Da_layer.Stored_diff.diff in
+      if
+        not
+          (Snark_params.Tick.Field.equal stored_diff.target_state.acc_set
+             diff.acc_set )
+      then
+        failwithf "Target account-set root mismatch: %s != %s"
+          (Snark_params.Tick.Field.to_string stored_diff.target_state.acc_set)
+          (Snark_params.Tick.Field.to_string diff.acc_set)
+          () ;
       [%log debug]
         !"Applying diff with source DA state: %{sexp: Da_layer.Da_state.t}"
         stored_diff.source_state ;

--- a/src/app/zeko/sequencer/cli.ml
+++ b/src/app/zeko/sequencer/cli.ml
@@ -600,23 +600,19 @@ let update_inner_verification_keys =
              Da_layer.Diff.create_pending ~source_ledger_hash
                ~changed_accounts:diff ~actions:(`Actions [])
            in
-           let new_accounts_keys =
-             List.filter diff.changed_accounts ~f:(fun (index, _) ->
-                 Account.equal
-                   (Sparse_ledger.get_exn ledger_openings index)
-                   Account.empty )
-             |> List.sort ~compare:(fun (a, _) (b, _) -> Int.compare a b)
-             |> List.map ~f:(fun (_, account) ->
-                    Account_id.derive_token_id
-                      ~owner:(Account.identifier account) )
+           let target_state =
+             Da_layer.Da_state.create ~ledger_hash:target_ledger_hash
+               ~acc_set:(Indexed_merkle_tree.Db.merkle_root imt)
            in
            printf "Distributing diff\n%!" ;
            let%bind () =
              Da_layer.Client.distribute_diff ~logger ~config:da_config
-               ~source_state ~ledger_openings
+               ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+               ~source_state ~target_state ~ledger_openings
                ~acc_set_openings:
-                 (Indexed_merkle_tree.Sparse.of_db_subset ~logger ~db:imt
-                    ~keys:new_accounts_keys )
+                 (Da_layer.Client.get_acc_set_openings ~logger
+                    ~changed_accounts:diff.changed_accounts ~ledger_openings
+                    ~imt )
                ~diff
            in
            let%bind body =

--- a/src/app/zeko/sequencer/cli.ml
+++ b/src/app/zeko/sequencer/cli.ml
@@ -5,10 +5,18 @@ open Signature_lib
 open Cli_lib
 open Mina_base
 open Mina_ledger
+open Zeko_types
 module Field = Snark_params.Tick.Field
 module Sequencer = Zeko_sequencer.Sequencer
 
 let take2 (a, b, _) = (a, b)
+
+let account_set_root account_set =
+  match Account_set.to_fields account_set |> Array.to_list with
+  | [ root ] ->
+      root
+  | fields ->
+      failwithf "Expected one account-set field, got %d" (List.length fields) ()
 
 let default_admin_permissions : Permissions.t =
   { edit_state = Either
@@ -390,14 +398,16 @@ let update_inner_verification_keys =
          Stdout_log.setup log_json log_level ;
 
          (* Fetch current state *)
-         let%bind commited_ledger_hash =
+         let%bind committed_state =
            Gql_client.infer_state ~logger l1_uri
              ~zkapp_pk:Zeko_circuits_config.Inputs.zeko_l1
              ~signer_pk:(Public_key.compress sender.public_key)
            >>| Or_error.ok_exn
            >>| Utils.value_of_zkapp_state
                  Zeko_circuits.Rollup_state.Outer_state.typ
-           >>| fun { ledger_hash; _ } -> ledger_hash
+           >>| fun { ledger_hash; acc_set; _ } ->
+           Da_layer.Da_state.create ~ledger_hash
+             ~acc_set:(account_set_root acc_set)
          and fetched_outer_vk_hash =
            Gql_client.fetch_vk ~logger l1_uri
              ( Account_id.of_public_key
@@ -433,16 +443,25 @@ let update_inner_verification_keys =
          in
 
          (* Sync ledger *)
+         let source_state =
+           Da_layer.Da_state.create
+             ~ledger_hash:(Ledger.merkle_root ledger)
+             ~acc_set:(Indexed_merkle_tree.Db.merkle_root imt)
+         in
          let%bind () =
            Da_layer.Client.map_diffs ~logger ~config:da_config
-             ~depth:Zeko_constants.constraint_constants.ledger_depth
-             ~source_ledger_hash:(`Specific (Ledger.merkle_root ledger))
-             ~target_ledger_hash:commited_ledger_hash ()
-             ~f:(fun ~current_chunk ~current_diff:_ ~chunks_length diff ->
+             ~source_state:(`Specific source_state)
+             ~target_state:committed_state ()
+             ~f:(fun ~current_chunk ~current_diff:_ ~chunks_length stored_diff
+                ->
+               let diff = stored_diff.Da_layer.Stored_diff.diff in
+               let current_state =
+                 Da_layer.Da_state.create
+                   ~ledger_hash:(Ledger.merkle_root ledger)
+                   ~acc_set:(Indexed_merkle_tree.Db.merkle_root imt)
+               in
                assert (
-                 Ledger_hash.equal
-                   (Da_layer.Diff.Stable.Latest.source_ledger_hash diff)
-                   (Ledger.merkle_root ledger) ) ;
+                 Da_layer.Da_state.equal stored_diff.source_state current_state ) ;
                let progress =
                  Float.of_int current_chunk /. Float.of_int chunks_length
                in
@@ -461,6 +480,13 @@ let update_inner_verification_keys =
                        (Account_id.derive_token_id ~owner:aid)
                    in
                    () ) ;
+               let target_state =
+                 Da_layer.Da_state.create
+                   ~ledger_hash:(Ledger.merkle_root ledger)
+                   ~acc_set:(Indexed_merkle_tree.Db.merkle_root imt)
+               in
+               assert (
+                 Da_layer.Da_state.equal stored_diff.target_state target_state ) ;
                return () )
            >>| Or_error.ok_exn >>| ignore
          in
@@ -557,6 +583,10 @@ let update_inner_verification_keys =
 
            (* Update the ledegr *)
            let source_ledger_hash = Ledger.merkle_root ledger in
+           let source_state =
+             Da_layer.Da_state.create ~ledger_hash:source_ledger_hash
+               ~acc_set:(Indexed_merkle_tree.Db.merkle_root imt)
+           in
            let ledger_openings =
              Sparse_ledger.of_ledger_subset_exn ledger
                (List.map diff ~f:(fun (_, acc) -> Account.identifier acc))
@@ -583,7 +613,7 @@ let update_inner_verification_keys =
            printf "Distributing diff\n%!" ;
            let%bind () =
              Da_layer.Client.distribute_diff ~logger ~config:da_config
-               ~ledger_openings
+               ~source_state ~ledger_openings
                ~acc_set_openings:
                  (Indexed_merkle_tree.Sparse.of_db_subset ~logger ~db:imt
                     ~keys:new_accounts_keys )
@@ -1278,6 +1308,9 @@ let sync_ledger =
        and target_ledger_hash =
          flag "--target-ledger-hash" (required string)
            ~doc:"string Target ledger hash"
+       and target_acc_set =
+         flag "--target-account-set-hash" (required string)
+           ~doc:"string Target account-set hash"
        and output_path =
          flag "--output-path" (required string) ~doc:"string Output path"
        in
@@ -1296,18 +1329,43 @@ let sync_ledger =
            Ledger.Db.create_checkpoint ledger
              ~directory_name:(output_path ^ "/ledger") ()
          in
+         let imt =
+           let db =
+             Indexed_merkle_tree.Db.create
+               ~depth:Zeko_constants.constraint_constants.ledger_depth ()
+           in
+           Ledger.Db.iteri ledger ~f:(fun _ account ->
+               let owner = Account.identifier account in
+               let _index, _witness =
+                 Indexed_merkle_tree.Db.get_or_create_entry_exn db
+                   (Account_id.derive_token_id ~owner)
+               in
+               () ) ;
+           db
+         in
+         let source_state =
+           Da_layer.Da_state.create
+             ~ledger_hash:(Ledger.Db.merkle_root ledger)
+             ~acc_set:(Indexed_merkle_tree.Db.merkle_root imt)
+         in
+         let target_state =
+           Da_layer.Da_state.create
+             ~ledger_hash:(Ledger_hash.of_decimal_string target_ledger_hash)
+             ~acc_set:(Field.of_string target_acc_set)
+         in
          let%bind () =
            Da_layer.Client.iter_diffs ~logger ~config:da_config
-             ~depth:Zeko_constants.constraint_constants.ledger_depth
-             ~source_ledger_hash:(`Specific (Ledger.Db.merkle_root ledger))
-             ~target_ledger_hash:
-               (Ledger_hash.of_decimal_string target_ledger_hash)
-             ()
-             ~f:(fun ~current_chunk ~current_diff:_ ~chunks_length diff ->
+             ~source_state:(`Specific source_state) ~target_state ()
+             ~f:(fun ~current_chunk ~current_diff:_ ~chunks_length stored_diff
+                ->
+               let diff = stored_diff.Da_layer.Stored_diff.diff in
+               let current_state =
+                 Da_layer.Da_state.create
+                   ~ledger_hash:(Ledger.Db.merkle_root ledger)
+                   ~acc_set:(Indexed_merkle_tree.Db.merkle_root imt)
+               in
                assert (
-                 Ledger_hash.equal
-                   (Da_layer.Diff.Stable.Latest.source_ledger_hash diff)
-                   (Ledger.Db.merkle_root ledger) ) ;
+                 Da_layer.Da_state.equal stored_diff.source_state current_state ) ;
                [%log info]
                  "Applying diff with source ledger hash %s, progress: %.0f%%"
                  (Ledger_hash.to_decimal_string
@@ -1323,6 +1381,21 @@ let sync_ledger =
                List.iter changed_accounts ~f:(fun (index, account) ->
                    Ledger.set_at_index_exn mask index account ) ;
                Ledger.Mask.Attached.commit mask ;
+
+               List.iter changed_accounts ~f:(fun (_, account) ->
+                   let owner = Account.identifier account in
+                   let _index, _witness =
+                     Indexed_merkle_tree.Db.get_or_create_entry_exn imt
+                       (Account_id.derive_token_id ~owner)
+                   in
+                   () ) ;
+               let applied_state =
+                 Da_layer.Da_state.create
+                   ~ledger_hash:(Ledger.Db.merkle_root ledger)
+                   ~acc_set:(Indexed_merkle_tree.Db.merkle_root imt)
+               in
+               assert (
+                 Da_layer.Da_state.equal stored_diff.target_state applied_state ) ;
 
                let () =
                  match diff.actions with
@@ -1345,26 +1418,7 @@ let sync_ledger =
            >>| Or_error.ok_exn
          in
          [%log info] "Synced ledger" ;
-
-         [%log info] "Creating IMT" ;
-         let imt =
-           Indexed_merkle_tree.Db.create
-             ~depth:Zeko_constants.constraint_constants.ledger_depth ()
-         in
-         let l = Ledger.Db.num_accounts ledger in
-         let () =
-           Ledger.Db.iteri ledger ~f:(fun index account ->
-               let progress = Float.of_int index /. Float.of_int l *. 100.0 in
-               if index mod 200 = 0 then
-                 [%log info] "Progress: %.2f%%\t%d/%d" progress index l ;
-               let aid = Account.identifier account in
-               let tid = Account_id.derive_token_id ~owner:aid in
-               let _witness =
-                 Indexed_merkle_tree.Db.get_or_create_entry_exn imt tid
-               in
-               () )
-         in
-         [%log info] "Created IMT" ;
+         [%log info] "Synced account set" ;
          return () ) )
 
 let () =

--- a/src/app/zeko/sequencer/deploy.ml
+++ b/src/app/zeko/sequencer/deploy.ml
@@ -258,16 +258,6 @@ let generate ~l1_uri ~sender_pk ~ledger_input ~faucet_aid ~pause_key
                 (Sparse_ledger.merkle_root old_ledger_openings)
               ~changed_accounts ~actions:(`Actions [])
           in
-          let new_accounts_keys =
-            List.filter changed_accounts ~f:(fun (index, _) ->
-                Account.equal
-                  (Sparse_ledger.get_exn old_ledger_openings index)
-                  Account.empty )
-            |> List.sort ~compare:(fun (a, _) (b, _) -> Int.compare a b)
-            |> List.map ~f:(fun (_, account) ->
-                   Account_id.derive_token_id
-                     ~owner:(Account.identifier account) )
-          in
           let source_state =
             match old_ledger_witness with
             | Some (ledger_hash, acc_set, _, _) ->
@@ -275,11 +265,17 @@ let generate ~l1_uri ~sender_pk ~ledger_input ~faucet_aid ~pause_key
             | None ->
                 failwith "Unreachable"
           in
+          let target_state =
+            Da_layer.Da_state.create ~ledger_hash:(L.merkle_root new_ledger)
+              ~acc_set:(Indexed_merkle_tree.Db.merkle_root imt)
+          in
           Da_layer.Client.distribute_diff ~logger ~config:da_config
-            ~source_state ~ledger_openings:old_ledger_openings
+            ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 ~source_state
+            ~target_state ~ledger_openings:old_ledger_openings
             ~acc_set_openings:
-              (Indexed_merkle_tree.Sparse.of_db_subset ~logger ~db:imt
-                 ~keys:new_accounts_keys )
+              (Da_layer.Client.get_acc_set_openings ~logger
+                 ~changed_accounts:diff.changed_accounts
+                 ~ledger_openings:old_ledger_openings ~imt )
             ~diff
         else
           let () =
@@ -287,6 +283,7 @@ let generate ~l1_uri ~sender_pk ~ledger_input ~faucet_aid ~pause_key
               "(* Post the whole genesis diff with all the accounts *)"
           in
           Da_layer.Client.distribute_genesis_diff ~logger ~config:da_config
+            ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
             ~ledger:new_ledger ~get_actions_for_aid:(fun _aid -> [])
       in
       return command )

--- a/src/app/zeko/sequencer/deploy.ml
+++ b/src/app/zeko/sequencer/deploy.ml
@@ -122,6 +122,17 @@ let generate ~l1_uri ~sender_pk ~ledger_input ~faucet_aid ~pause_key
                    L.set_at_index_exn ledger index account ) ;
 
             let old_ledger_hash = L.merkle_root ledger in
+            let old_acc_set =
+              let tree =
+                Indexed_merkle_tree.In_memory.create
+                  ~depth:constraint_constants.ledger_depth ()
+              in
+              L.to_list_sequential ledger
+              |> List.map ~f:Account.identifier
+              |> List.map ~f:(fun aid -> Account_id.derive_token_id ~owner:aid)
+              |> Indexed_merkle_tree.In_memory.insert_batch_exn tree ;
+              Indexed_merkle_tree.In_memory.merkle_root tree
+            in
             printf "Old ledger hash: %s\n%!"
               (Ledger_hash.to_decimal_string old_ledger_hash) ;
 
@@ -176,7 +187,11 @@ let generate ~l1_uri ~sender_pk ~ledger_input ~faucet_aid ~pause_key
               printf "IMT hash: %s\n%!" (Ledger_hash.to_decimal_string imt_hash) ;
               Account_set.of_fields [| imt_hash |]
             in
-            ( Some (old_ledger_hash, old_ledger_openings, accounts_diff)
+            ( Some
+                ( old_ledger_hash
+                , old_acc_set
+                , old_ledger_openings
+                , accounts_diff )
             , ledger
             , imt_hash
             , imt )
@@ -204,11 +219,15 @@ let generate ~l1_uri ~sender_pk ~ledger_input ~faucet_aid ~pause_key
       let da_config = Da_layer.Client.Config.{ nodes = da_nodes } in
 
       (* If the old ledger exists, we need to just post the diff with updated inner account *)
-      let old_ledger_hash = Option.map old_ledger_witness ~f:fst3 in
+      let old_ledger_hash =
+        Option.map old_ledger_witness ~f:(fun (ledger_hash, _, _, _) ->
+            ledger_hash )
+      in
       let%bind old_ledger_exists =
         match old_ledger_witness with
-        | Some (ledger_hash, _, _) ->
-            Da_layer.Client.get_diff ~logger ~config:da_config ~ledger_hash
+        | Some (ledger_hash, acc_set, _, _) ->
+            let state = Da_layer.Da_state.create ~ledger_hash ~acc_set in
+            Da_layer.Client.get_diff ~logger ~config:da_config ~state
             >>| Result.is_ok
         | None ->
             return false
@@ -228,7 +247,7 @@ let generate ~l1_uri ~sender_pk ~ledger_input ~faucet_aid ~pause_key
           in
           let old_ledger_openings, changed_accounts =
             match old_ledger_witness with
-            | Some (_, old_ledger_openings, diff) ->
+            | Some (_, _, old_ledger_openings, diff) ->
                 (old_ledger_openings, diff)
             | None ->
                 failwith "Unreachable"
@@ -249,8 +268,15 @@ let generate ~l1_uri ~sender_pk ~ledger_input ~faucet_aid ~pause_key
                    Account_id.derive_token_id
                      ~owner:(Account.identifier account) )
           in
+          let source_state =
+            match old_ledger_witness with
+            | Some (ledger_hash, acc_set, _, _) ->
+                Da_layer.Da_state.create ~ledger_hash ~acc_set
+            | None ->
+                failwith "Unreachable"
+          in
           Da_layer.Client.distribute_diff ~logger ~config:da_config
-            ~ledger_openings:old_ledger_openings
+            ~source_state ~ledger_openings:old_ledger_openings
             ~acc_set_openings:
               (Indexed_merkle_tree.Sparse.of_db_subset ~logger ~db:imt
                  ~keys:new_accounts_keys )

--- a/src/app/zeko/sequencer/lib/db.ml
+++ b/src/app/zeko/sequencer/lib/db.ml
@@ -1,5 +1,7 @@
 open Async
+open Core_kernel
 open Relational_db
+module Field = Snark_params.Tick.Field
 
 let migrations : Db.Migration.t list =
   let open Deferred.Result.Let_syntax in
@@ -151,6 +153,158 @@ let migrations : Db.Migration.t list =
           (Caqti_request.exec Caqti_type.unit
              {sql| ALTER TABLE da_diff ADD COLUMN acc_set_openings BYTEA NOT NULL |sql} )
           () )
+  ; Db.Migration.make 6 "key_da_by_ledger_and_account_set"
+      (fun (module Conn : CONNECTION) ->
+        let exec sql = Conn.exec (Caqti_request.exec Caqti_type.unit sql) () in
+        let%bind () =
+          exec
+            {sql| ALTER TABLE da_diff
+                    ADD COLUMN target_acc_set TEXT,
+                    ADD COLUMN source_acc_set TEXT |sql}
+        in
+        let%bind rows =
+          Conn.collect_list
+            (Caqti_request.collect Caqti_type.unit
+               Caqti_type.(tup4 int (option string) octets octets)
+               {sql| SELECT id, source_ledger_hash, diff, acc_set_openings FROM da_diff |sql} )
+            ()
+        in
+        let parse_acc_set_root openings =
+          let ok_exn = function
+            | Ppx_deriving_yojson_runtime.Result.Ok value ->
+                value
+            | Ppx_deriving_yojson_runtime.Result.Error error ->
+                failwithf "Error parsing account-set openings: %s" error ()
+          in
+          Indexed_merkle_tree.Sparse.of_yojson
+            (Yojson.Safe.from_string openings)
+          |> ok_exn |> Indexed_merkle_tree.Sparse.merkle_root |> Field.to_string
+        in
+        let empty_state =
+          Da_layer.Da_state.empty
+            ~depth:Zeko_constants.constraint_constants.ledger_depth
+        in
+        let migration_error message =
+          Caqti_error.request_failed
+            ~uri:(Uri.of_string "zeko://migration")
+            ~query:"key_da_by_ledger_and_account_set" (Caqti_error.Msg message)
+        in
+        let%bind () =
+          Deferred.List.fold rows ~init:(Ok ())
+            ~f:(fun result (id, source_ledger_hash, diff, openings) ->
+              match result with
+              | Error _ ->
+                  Deferred.return result
+              | Ok () -> (
+                  let pending_diff =
+                    Binable.of_bigstring
+                      ( module Da_layer.Diff.Pending.Stable.V1
+                               .With_top_version_tag )
+                      (Bigstring.of_string diff)
+                  in
+                  match source_ledger_hash with
+                  | None
+                    when not
+                           (Mina_base.Ledger_hash.equal
+                              pending_diff.source_ledger_hash
+                              empty_state.ledger_hash ) ->
+                      Deferred.return
+                        (Error
+                           (migration_error
+                              (sprintf
+                                 "Cannot recover the source account-set root \
+                                  for legacy DA queue row %d starting at \
+                                  non-genesis ledger %s; rebuild the local DA \
+                                  queue from a checkpoint with an explicit \
+                                  account-set root"
+                                 id
+                                 (Mina_base.Ledger_hash.to_decimal_string
+                                    pending_diff.source_ledger_hash ) ) ) )
+                  | None | Some _ ->
+                      Conn.exec
+                        (Caqti_request.exec
+                           Caqti_type.(tup2 string int)
+                           {sql| UPDATE da_diff SET target_acc_set = ? WHERE id = ? |sql} )
+                        (parse_acc_set_root openings, id) ) )
+        in
+        let%bind () =
+          exec
+            {sql| UPDATE da_diff AS child
+                    SET source_acc_set = parent.target_acc_set
+                   FROM da_diff AS parent
+                  WHERE child.source_ledger_hash = parent.target_ledger_hash |sql}
+        in
+        let empty_acc_set = Field.to_string empty_state.acc_set in
+        let%bind () =
+          Conn.exec
+            (Caqti_request.exec Caqti_type.string
+               {sql| UPDATE da_diff
+                       SET source_acc_set = ?
+                     WHERE source_acc_set IS NULL |sql} )
+            empty_acc_set
+        in
+        let%bind () =
+          exec
+            {sql| ALTER TABLE da_signature ADD COLUMN target_acc_set TEXT |sql}
+        in
+        let%bind () =
+          exec
+            {sql| UPDATE da_signature AS signature
+                    SET target_acc_set = diff.target_acc_set
+                   FROM da_diff AS diff
+                  WHERE signature.target_ledger_hash = diff.target_ledger_hash |sql}
+        in
+        let%bind () =
+          exec
+            {sql| ALTER TABLE da_signature DROP CONSTRAINT da_signature_target_ledger_hash_fkey |sql}
+        in
+        let%bind () =
+          exec
+            {sql| ALTER TABLE da_diff DROP CONSTRAINT da_diff_source_ledger_hash_fkey |sql}
+        in
+        let%bind () =
+          exec
+            {sql| ALTER TABLE da_signature DROP CONSTRAINT da_signature_target_ledger_hash_public_key_key |sql}
+        in
+        let%bind () =
+          exec
+            {sql| ALTER TABLE da_diff DROP CONSTRAINT da_diff_target_ledger_hash_key |sql}
+        in
+        let%bind () =
+          exec
+            {sql| ALTER TABLE da_diff
+                    ALTER COLUMN target_acc_set SET NOT NULL,
+                    ALTER COLUMN source_acc_set SET NOT NULL |sql}
+        in
+        let%bind () =
+          exec
+            {sql| ALTER TABLE da_signature ALTER COLUMN target_acc_set SET NOT NULL |sql}
+        in
+        let%bind () =
+          exec
+            {sql| ALTER TABLE da_diff
+                    ADD CONSTRAINT da_diff_target_state_key
+                      UNIQUE (target_ledger_hash, target_acc_set),
+                    ADD CONSTRAINT da_diff_source_state_fkey
+                      FOREIGN KEY (source_ledger_hash, source_acc_set)
+                      REFERENCES da_diff (target_ledger_hash, target_acc_set)
+                      ON UPDATE CASCADE
+                      ON DELETE RESTRICT |sql}
+        in
+        let%bind () =
+          exec
+            {sql| CREATE INDEX idx_da_diff_source_state
+                    ON da_diff (source_ledger_hash, source_acc_set) |sql}
+        in
+        exec
+          {sql| ALTER TABLE da_signature
+                  ADD CONSTRAINT da_signature_target_state_public_key_key
+                    UNIQUE (target_ledger_hash, target_acc_set, public_key),
+                  ADD CONSTRAINT da_signature_target_state_fkey
+                    FOREIGN KEY (target_ledger_hash, target_acc_set)
+                    REFERENCES da_diff (target_ledger_hash, target_acc_set)
+                    ON UPDATE CASCADE
+                    ON DELETE CASCADE |sql} )
   ]
 
 let create_and_migrate ~postgres_uri ~logger =

--- a/src/app/zeko/sequencer/lib/gql.ml
+++ b/src/app/zeko/sequencer/lib/gql.ml
@@ -1026,6 +1026,12 @@ module Types = struct
               ~resolve:(fun _ t ->
                 Field.to_string
                   Zeko_sequencer.State_hashes.(t.unproved_ledger_hash) )
+          ; field "unprovedAccountSetHash" ~typ:(non_null string)
+              ~doc:"Account-set hash of latest unproved state"
+              ~args:Arg.[]
+              ~resolve:(fun _ t ->
+                Field.to_string Zeko_sequencer.State_hashes.(t.unproved_acc_set)
+                )
           ; field "committedLedgerHash" ~typ:(non_null string)
               ~doc:"Ledger hash of latest committed state"
               ~args:Arg.[]

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -12,6 +12,14 @@ module Field = Snark_params.Tick.Field
 module Sequencer = struct
   let constraint_constants = Zeko_constants.constraint_constants
 
+  let account_set_root account_set =
+    match Account_set.to_fields account_set |> Array.to_list with
+    | [ root ] ->
+        root
+    | fields ->
+        failwithf "Expected one account-set field, got %d" (List.length fields)
+          ()
+
   module Config = struct
     type t =
       { max_pool_size : int
@@ -152,8 +160,13 @@ module Sequencer = struct
             ~f:(fun () ->
               let open Deferred.Result.Let_syntax in
               let%bind da_multisig =
-                Da_layer.Client.get_multisig da_client
-                  ~ledger_hash:(Sparse_ledger.merkle_root new_inner_ledger)
+                let (txn_statement : Zeko_stmt.t), _ = txn_snark in
+                let state =
+                  Da_layer.Da_state.create
+                    ~ledger_hash:(Sparse_ledger.merkle_root new_inner_ledger)
+                    ~acc_set:(account_set_root txn_statement.target_acc_set)
+                in
+                Da_layer.Client.get_multisig da_client ~state
                 |> Deferred.map ~f:(fun (quorum, multisig) ->
                        Multisig.Witness.make ~signatures:multisig ~quorum )
                 |> Deferred.map ~f:Result.return
@@ -220,6 +233,7 @@ module Sequencer = struct
     type t =
       { proved_ledger_hash : Ledger_hash.t
       ; unproved_ledger_hash : Ledger_hash.t
+      ; unproved_acc_set : Field.t
       ; committed_ledger_hash : Ledger_hash.t
       }
   end
@@ -276,6 +290,7 @@ module Sequencer = struct
     State_hashes.
       { proved_ledger_hash = Field.zero
       ; unproved_ledger_hash = get_root t
+      ; unproved_acc_set = Indexed_merkle_tree.Db.merkle_root t.imt
       ; committed_ledger_hash = Field.zero
       }
 
@@ -450,6 +465,7 @@ module Sequencer = struct
                   return (Error e)
           in
 
+          let source_acc_set = Indexed_merkle_tree.Db.merkle_root t.imt in
           let%bind.Deferred.Result source_ledger, witnesses =
             let sequencer_pk =
               Even_PC.create_exn
@@ -513,13 +529,22 @@ module Sequencer = struct
                      ~owner:(Account.identifier account) )
           in
           let%bind () =
+            let source_state =
+              Da_layer.Da_state.create
+                ~ledger_hash:(Sparse_ledger.merkle_root source_ledger)
+                ~acc_set:source_acc_set
+            in
+            let target_state =
+              Da_layer.Da_state.create
+                ~ledger_hash:(L.Db.merkle_root t.ledger)
+                ~acc_set:(Indexed_merkle_tree.Db.merkle_root t.imt)
+            in
             Da_layer.Client.enqueue_diff t.da_client ~genesis:false
-              ~ledger_openings:source_ledger
+              ~source_state ~target_state ~ledger_openings:source_ledger
               ~acc_set_openings:
                 (Indexed_merkle_tree.Sparse.of_db_subset ~logger:t.logger
                    ~db:t.imt ~keys:new_accounts_keys )
               ~diff
-              ~target_ledger_hash:(L.Db.merkle_root t.ledger)
           in
 
           (* Add witnesses to the merger *)
@@ -555,6 +580,7 @@ module Sequencer = struct
         && Currency.Fee.(fee < constraint_constants.account_creation_fee)
       then return `Skip
       else
+        let source_acc_set = Indexed_merkle_tree.Db.merkle_root t.imt in
         match
           Zeko_transaction_logic.apply_fee_transfer_unchecked ~receiver_pk ~fee
             ~constraint_constants ~global_slot:l1_global_slot ledger t.imt
@@ -593,13 +619,22 @@ module Sequencer = struct
                        ~owner:(Account.identifier account) )
             in
             let%bind () =
+              let source_state =
+                Da_layer.Da_state.create
+                  ~ledger_hash:(Sparse_ledger.merkle_root source_ledger)
+                  ~acc_set:source_acc_set
+              in
+              let target_state =
+                Da_layer.Da_state.create
+                  ~ledger_hash:(L.Db.merkle_root t.ledger)
+                  ~acc_set:(Indexed_merkle_tree.Db.merkle_root t.imt)
+              in
               Da_layer.Client.enqueue_diff t.da_client ~genesis:false
-                ~ledger_openings:source_ledger
+                ~source_state ~target_state ~ledger_openings:source_ledger
                 ~acc_set_openings:
                   (Indexed_merkle_tree.Sparse.of_db_subset ~logger:t.logger
                      ~db:t.imt ~keys:new_accounts_keys )
                 ~diff
-                ~target_ledger_hash:(L.Db.merkle_root t.ledger)
             in
             match%map
               Merger.P.add_job t.db_pool t.merger t.merger_ctx ~data:witness
@@ -788,16 +823,17 @@ module Sequencer = struct
 
   let sync ~logger ({ config; _ } as t) da_config source =
     [%log info] "Syncing" ;
-    let%bind commited_ledger_hash =
+    let%bind committed_state =
       Gql_client.infer_state ~logger config.l1_uri
         ~zkapp_pk:Zeko_circuits_config.Inputs.zeko_l1
         ~signer_pk:(Signer_service.Signer.public_key config.signer)
       >>| Or_error.ok_exn
       >>| Utils.value_of_zkapp_state Zeko_circuits.Rollup_state.Outer_state.typ
-      >>| fun { ledger_hash; _ } -> ledger_hash
+      >>| fun { ledger_hash; acc_set; _ } ->
+      Da_layer.Da_state.create ~ledger_hash ~acc_set:(account_set_root acc_set)
     in
     [%log info] "Fetched commited root: %s"
-      Ledger_hash.(to_decimal_string commited_ledger_hash) ;
+      (Da_layer.Da_state.to_string committed_state) ;
 
     [%log info] "Init root: %s" Ledger_hash.(to_decimal_string (get_root t)) ;
 
@@ -810,48 +846,119 @@ module Sequencer = struct
           [%log info] "Syncing from specific ledger hash: %s"
             (Ledger_hash.to_decimal_string ledger_hash) ;
 
-          [%log info] "Creating genesis diff" ;
-          let ledger = L.of_database t.ledger in
-          let%bind diffs =
-            Da_layer.Client.create_genesis_diffs ~logger ledger
-              ~get_actions_for_aid:(fun aid ->
-                Archive.query_actions t.archive aid
-                |> List.map ~f:(fun x -> List.map x.actions ~f:Array.to_list) )
+          (* Rebuild the local posting queue from the original DA history.
+             A synthetic snapshot from the empty ledger cannot safely import
+             historical receipt-chain hashes without the commands that
+             authorized them. *)
+          [%log info] "Reconstructing DA history up to checkpoint" ;
+          let replay_ledger =
+            L.create_ephemeral ~depth:constraint_constants.ledger_depth ()
           in
-          let%bind inserted_genesis =
-            Deferred.List.foldi ~init:false diffs
-              ~f:(fun
-                   i
-                   acc
-                   ( diff
-                   , ledger_openings
-                   , acc_set_openings
-                   , `Target target_ledger_hash )
-                 ->
-                let genesis = i = 0 in
-                let%map () =
-                  Da_layer.Client.enqueue_diff t.da_client ~diff
-                    ~ledger_openings ~acc_set_openings ~target_ledger_hash
-                    ~genesis
-                in
-                genesis || acc )
+          let replay_imt =
+            Indexed_merkle_tree.In_memory.create
+              ~depth:constraint_constants.ledger_depth ()
           in
-          [%log info] "Enqueued genesis diff" ;
-          return inserted_genesis
+          let checkpoint_state =
+            Da_layer.Da_state.create ~ledger_hash
+              ~acc_set:(Indexed_merkle_tree.Db.merkle_root t.imt)
+          in
+          Monitor.protect
+            ~finally:(fun () ->
+              let (_ : L.unattached_mask) =
+                L.Maskable.unregister_mask_exn ~loc:__LOC__
+                  ~grandchildren:`Recursive replay_ledger
+              in
+              return () )
+            (fun () ->
+              let%map replayed =
+                Da_layer.Client.map_diffs ~logger ~config:da_config
+                  ~source_state:`Genesis ~target_state:checkpoint_state ()
+                  ~f:(fun
+                       ~current_chunk
+                       ~current_diff
+                       ~chunks_length:_
+                       stored_diff
+                     ->
+                    let diff = stored_diff.Da_layer.Stored_diff.diff in
+                    let current_state =
+                      Da_layer.Da_state.create
+                        ~ledger_hash:(L.merkle_root replay_ledger)
+                        ~acc_set:
+                          (Indexed_merkle_tree.In_memory.merkle_root replay_imt)
+                    in
+                    assert (
+                      Da_layer.Da_state.equal stored_diff.source_state
+                        current_state ) ;
+                    let ledger_openings =
+                      Da_layer.Client.get_ledger_openings ~diff
+                        ~ledger:replay_ledger
+                    in
+                    let changed_accounts =
+                      Da_layer.Diff.Stable.Latest.changed_accounts diff
+                      |> List.sort ~compare:(fun (a, _) (b, _) ->
+                             Int.compare a b )
+                    in
+                    let new_accounts_keys =
+                      List.filter changed_accounts ~f:(fun (index, _) ->
+                          Account.equal
+                            (Sparse_ledger.get_exn ledger_openings index)
+                            Account.empty )
+                      |> List.map ~f:(fun (_, account) ->
+                             Account_id.derive_token_id
+                               ~owner:(Account.identifier account) )
+                    in
+                    List.iter changed_accounts ~f:(fun (index, account) ->
+                        L.set_at_index_exn replay_ledger index account ) ;
+                    Indexed_merkle_tree.In_memory.insert_batch_exn replay_imt
+                      new_accounts_keys ;
+                    let acc_set_openings =
+                      Indexed_merkle_tree.Sparse.of_in_memory_subset ~logger
+                        ~db:replay_imt ~keys:new_accounts_keys
+                    in
+                    let replayed_state =
+                      Da_layer.Da_state.create
+                        ~ledger_hash:(L.merkle_root replay_ledger)
+                        ~acc_set:
+                          (Indexed_merkle_tree.In_memory.merkle_root replay_imt)
+                    in
+                    assert (
+                      Da_layer.Da_state.equal stored_diff.target_state
+                        replayed_state ) ;
+                    Da_layer.Client.enqueue_diff t.da_client
+                      ~diff:(Da_layer.Diff.drop_time diff)
+                      ~source_state:stored_diff.source_state
+                      ~target_state:stored_diff.target_state ~ledger_openings
+                      ~acc_set_openings
+                      ~genesis:(current_chunk = 0 && current_diff = 0) )
+                >>| Or_error.ok_exn
+              in
+              [%log info] "Reconstructed %d DA diffs up to checkpoint"
+                (List.length replayed) ;
+              not (List.is_empty replayed) )
     in
 
     (* apply diffs from DA layer *)
+    let source_state =
+      match source with
+      | `Genesis ->
+          `Genesis
+      | `Specific ledger_hash ->
+          `Specific
+            (Da_layer.Da_state.create ~ledger_hash
+               ~acc_set:(Indexed_merkle_tree.Db.merkle_root t.imt) )
+    in
     let%bind () =
       Da_layer.Client.map_diffs
         ?interval_size:
           (Sys.getenv_opt "ZEKO_INTERVAL_SIZE" |> Option.map ~f:Int.of_string)
-        ~logger ~config:da_config ~depth:constraint_constants.ledger_depth
-        ~source_ledger_hash:source ~target_ledger_hash:commited_ledger_hash ()
-        ~f:(fun ~current_chunk ~current_diff ~chunks_length diff ->
-          assert (
-            Ledger_hash.equal
-              (Da_layer.Diff.Stable.Latest.source_ledger_hash diff)
-              (get_root t) ) ;
+        ~logger ~config:da_config ~source_state ~target_state:committed_state ()
+        ~f:(fun ~current_chunk ~current_diff ~chunks_length stored_diff ->
+          let diff = stored_diff.Da_layer.Stored_diff.diff in
+          let current_state =
+            Da_layer.Da_state.create ~ledger_hash:(get_root t)
+              ~acc_set:(Indexed_merkle_tree.Db.merkle_root t.imt)
+          in
+          assert (Da_layer.Da_state.equal stored_diff.source_state current_state) ;
           [%log info]
             "Applying diff with source ledger hash %s, progress: %.0f%%"
             (Ledger_hash.to_decimal_string
@@ -880,6 +987,13 @@ module Sequencer = struct
               in
               () ) ;
 
+          let applied_state =
+            Da_layer.Da_state.create
+              ~ledger_hash:(L.Db.merkle_root t.ledger)
+              ~acc_set:(Indexed_merkle_tree.Db.merkle_root t.imt)
+          in
+          assert (Da_layer.Da_state.equal stored_diff.target_state applied_state) ;
+
           let acc_set_openings =
             Da_layer.Client.get_acc_set_openings ~logger ~diff ~ledger_openings
               ~imt:t.imt
@@ -889,8 +1003,9 @@ module Sequencer = struct
           let%bind () =
             Da_layer.Client.enqueue_diff t.da_client
               ~diff:(Da_layer.Diff.drop_time diff)
-              ~ledger_openings ~acc_set_openings
-              ~target_ledger_hash:(L.Db.merkle_root t.ledger)
+              ~source_state:stored_diff.source_state
+              ~target_state:stored_diff.target_state ~ledger_openings
+              ~acc_set_openings
               ~genesis:
                 ((not inserted_genesis) && current_chunk = 0 && current_diff = 0)
           in
@@ -923,7 +1038,7 @@ module Sequencer = struct
     [%log info] "IMT root: %s"
       (Ledger_hash.to_decimal_string @@ Indexed_merkle_tree.Db.merkle_root t.imt) ;
 
-    if not @@ Ledger_hash.equal current_root commited_ledger_hash then
+    if not @@ Ledger_hash.equal current_root committed_state.ledger_hash then
       [%log error] "Ledger mismatch" ;
 
     let sparse_ledger =
@@ -1249,7 +1364,10 @@ module Sequencer = struct
       >>| Or_error.ok_exn
     in
     let () =
-      Da_layer.Client.start_client da_client ~target_ledger_hash:(get_root t)
+      Da_layer.Client.start_client da_client
+        ~target_state:
+          (Da_layer.Da_state.create ~ledger_hash:(get_root t)
+             ~acc_set:(Indexed_merkle_tree.Db.merkle_root t.imt) )
     in
     return t
 end

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -518,16 +518,6 @@ module Sequencer = struct
                         Zkapp_command.all_account_updates_list command
                         |> List.map ~f:(fun _ -> true) ) )
           in
-          let new_accounts_keys =
-            List.filter changed_accounts ~f:(fun (index, _) ->
-                Account.equal
-                  (Sparse_ledger.get_exn source_ledger index)
-                  Account.empty )
-            |> List.sort ~compare:(fun (a, _) (b, _) -> Int.compare a b)
-            |> List.map ~f:(fun (_, account) ->
-                   Account_id.derive_token_id
-                     ~owner:(Account.identifier account) )
-          in
           let%bind () =
             let source_state =
               Da_layer.Da_state.create
@@ -542,8 +532,9 @@ module Sequencer = struct
             Da_layer.Client.enqueue_diff t.da_client ~genesis:false
               ~source_state ~target_state ~ledger_openings:source_ledger
               ~acc_set_openings:
-                (Indexed_merkle_tree.Sparse.of_db_subset ~logger:t.logger
-                   ~db:t.imt ~keys:new_accounts_keys )
+                (Da_layer.Client.get_acc_set_openings ~logger:t.logger
+                   ~changed_accounts:diff.changed_accounts
+                   ~ledger_openings:source_ledger ~imt:t.imt )
               ~diff
           in
 
@@ -608,16 +599,6 @@ module Sequencer = struct
                 ~source_ledger_hash:(Sparse_ledger.merkle_root source_ledger)
                 ~changed_accounts ~actions:(`Actions [])
             in
-            let new_accounts_keys =
-              List.filter changed_accounts ~f:(fun (index, _) ->
-                  Account.equal
-                    (Sparse_ledger.get_exn source_ledger index)
-                    Account.empty )
-              |> List.sort ~compare:(fun (a, _) (b, _) -> Int.compare a b)
-              |> List.map ~f:(fun (_, account) ->
-                     Account_id.derive_token_id
-                       ~owner:(Account.identifier account) )
-            in
             let%bind () =
               let source_state =
                 Da_layer.Da_state.create
@@ -632,8 +613,9 @@ module Sequencer = struct
               Da_layer.Client.enqueue_diff t.da_client ~genesis:false
                 ~source_state ~target_state ~ledger_openings:source_ledger
                 ~acc_set_openings:
-                  (Indexed_merkle_tree.Sparse.of_db_subset ~logger:t.logger
-                     ~db:t.imt ~keys:new_accounts_keys )
+                  (Da_layer.Client.get_acc_set_openings ~logger:t.logger
+                     ~changed_accounts:diff.changed_accounts
+                     ~ledger_openings:source_ledger ~imt:t.imt )
                 ~diff
             in
             match%map
@@ -912,8 +894,9 @@ module Sequencer = struct
                     Indexed_merkle_tree.In_memory.insert_batch_exn replay_imt
                       new_accounts_keys ;
                     let acc_set_openings =
-                      Indexed_merkle_tree.Sparse.of_in_memory_subset ~logger
-                        ~db:replay_imt ~keys:new_accounts_keys
+                      Da_layer.Client.get_in_memory_acc_set_openings ~logger
+                        ~changed_accounts:diff.changed_accounts ~ledger_openings
+                        ~imt:replay_imt
                     in
                     let replayed_state =
                       Da_layer.Da_state.create
@@ -995,7 +978,8 @@ module Sequencer = struct
           assert (Da_layer.Da_state.equal stored_diff.target_state applied_state) ;
 
           let acc_set_openings =
-            Da_layer.Client.get_acc_set_openings ~logger ~diff ~ledger_openings
+            Da_layer.Client.get_acc_set_openings ~logger
+              ~changed_accounts:diff.changed_accounts ~ledger_openings
               ~imt:t.imt
           in
 
@@ -1186,7 +1170,8 @@ module Sequencer = struct
     in
     let%bind db_pool = Db.create_and_migrate ~postgres_uri ~logger in
     let%bind da_client =
-      Da_layer.Client.create ~logger ~config:da_config ~quorum:da_quorum
+      Da_layer.Client.create ~logger ~config:da_config
+        ~signature_kind:Zeko_circuits_config.Inputs.chain_l2 ~quorum:da_quorum
         ~da_keys ~db_pool
     in
     let kvdb = L.Db.zeko_kvdb ledger in

--- a/src/app/zeko/sequencer/tests/relational_db_test.ml
+++ b/src/app/zeko/sequencer/tests/relational_db_test.ml
@@ -115,3 +115,129 @@ let () =
       [%log info] "Finished"
   | Error e ->
       [%log error] "Error: %s" (Caqti_error.show e)
+
+let () =
+  let postgres_uri =
+    Thread_safe.block_on_async_exn (fun () ->
+        Relational_db.For_tests.create_database ~port:5433
+          "zeko_da_state_migration" )
+  in
+  let logger = Logger.create () in
+  let acc_set_openings =
+    let tree =
+      Indexed_merkle_tree.In_memory.create
+        ~depth:Zeko_constants.constraint_constants.ledger_depth ()
+    in
+    Indexed_merkle_tree.Sparse.of_in_memory_subset ~logger ~db:tree ~keys:[]
+  in
+  let expected_acc_set =
+    Indexed_merkle_tree.Sparse.merkle_root acc_set_openings
+    |> Snark_params.Tick.Field.to_string
+  in
+  let openings_json =
+    Indexed_merkle_tree.Sparse.to_yojson acc_set_openings
+    |> Yojson.Safe.to_string
+  in
+  let legacy_diff =
+    let empty_state =
+      Da_layer.Da_state.empty
+        ~depth:Zeko_constants.constraint_constants.ledger_depth
+    in
+    Da_layer.Diff.create_pending ~source_ledger_hash:empty_state.ledger_hash
+      ~changed_accounts:[] ~actions:(`Actions [])
+    |> Binable.to_bigstring
+         (module Da_layer.Diff.Pending.Stable.V1.With_top_version_tag)
+    |> Bigstring.to_string
+  in
+  let target_ledger_hash =
+    Mina_base.Ledger_hash.empty_hash |> Snark_params.Tick.Field.to_string
+  in
+  let open Deferred.Result.Let_syntax in
+  match
+    Thread_safe.block_on_async_exn (fun () ->
+        let%bind pool = Deferred.return (Db.create_pool ~postgres_uri ()) in
+        let%bind () =
+          Db.Migration.run ~logger ~target_version:(`Version 5) pool
+            Sequencer_lib.Db.migrations
+        in
+        let%bind () =
+          Pool.use
+            (fun (module Conn : CONNECTION) ->
+              let%bind.Deferred.Result () =
+                Conn.exec
+                  (Caqti_request.exec
+                     Caqti_type.(
+                       tup2 string (tup4 (option string) octets octets octets))
+                     {sql| INSERT INTO da_diff
+                              (target_ledger_hash, source_ledger_hash, diff,
+                               ledger_openings, acc_set_openings)
+                            VALUES (?, ?, ?, ?, ?) |sql} )
+                  ( target_ledger_hash
+                  , (None, legacy_diff, "legacy-ledger", openings_json) )
+              in
+              Conn.exec
+                (Caqti_request.exec
+                   Caqti_type.(tup3 string string octets)
+                   {sql| INSERT INTO da_signature
+                            (target_ledger_hash, public_key, signature)
+                          VALUES (?, ?, ?) |sql} )
+                (target_ledger_hash, "legacy-key", "legacy-signature") )
+            pool
+        in
+        let%bind () =
+          Db.Migration.run ~logger ~target_version:`Latest pool
+            Sequencer_lib.Db.migrations
+        in
+        let%bind () =
+          Pool.use
+            (fun (module Conn : CONNECTION) ->
+              let%bind.Deferred.Result ( migrated_diff_acc_set
+                                       , migrated_source_acc_set ) =
+                Conn.find
+                  (Caqti_request.find Caqti_type.unit
+                     Caqti_type.(tup2 string string)
+                     {sql| SELECT target_acc_set, source_acc_set FROM da_diff |sql} )
+                  ()
+              in
+              let%bind.Deferred.Result migrated_signature_acc_set =
+                Conn.find
+                  (Caqti_request.find Caqti_type.unit Caqti_type.string
+                     {sql| SELECT target_acc_set FROM da_signature |sql} )
+                  ()
+              in
+              assert (String.equal migrated_diff_acc_set expected_acc_set) ;
+              assert (String.equal migrated_source_acc_set expected_acc_set) ;
+              assert (String.equal migrated_signature_acc_set expected_acc_set) ;
+              let%bind.Deferred.Result () =
+                Conn.exec
+                  (Caqti_request.exec
+                     Caqti_type.(
+                       tup3 string string (tup4 string octets octets octets))
+                     {sql| INSERT INTO da_diff
+                              (target_ledger_hash, target_acc_set,
+                               source_ledger_hash, source_acc_set, diff,
+                               ledger_openings, acc_set_openings)
+                            VALUES (?, ?, NULL, ?, ?, ?, ?) |sql} )
+                  ( target_ledger_hash
+                  , "1"
+                  , ( expected_acc_set
+                    , "second-diff"
+                    , "second-ledger"
+                    , openings_json ) )
+              in
+              let%map.Deferred.Result count =
+                Conn.find
+                  (Caqti_request.find Caqti_type.unit Caqti_type.int
+                     {sql| SELECT COUNT(*) FROM da_diff |sql} )
+                  ()
+              in
+              assert (Int.equal count 2) )
+            pool
+        in
+        return () )
+  with
+  | Ok () ->
+      [%log info] "Composite DA state migration test finished"
+  | Error e ->
+      failwithf "Composite DA state migration test failed: %s"
+        (Caqti_error.show e) ()

--- a/src/app/zeko/sequencer/tests/sequencer_test.ml
+++ b/src/app/zeko/sequencer/tests/sequencer_test.ml
@@ -347,14 +347,14 @@ let () =
       in
 
       print_endline "(* Requeue witnesses and commit with quorum 3 *)" ;
-      let ledger_hash =
+      let da_state =
         run (fun () ->
             let%bind commit_result = commit new_sequencer >>| Or_error.ok_exn in
             let%bind _txn_snark = commit_result >>| Or_error.ok_exn in
             let%bind () =
               Executor.wait_to_finish new_sequencer.merger_ctx.executor
             in
-            let%map { ledger_hash = committed_ledger_hash; _ } =
+            let%map { ledger_hash = committed_ledger_hash; acc_set; _ } =
               Gql_client.infer_state ~logger gql_uri ~signer_pk
                 ~zkapp_pk:(Public_key.compress outer_kp.public_key)
               >>| Or_error.ok_exn
@@ -363,7 +363,8 @@ let () =
             in
             let target_ledger_hash = get_root new_sequencer in
             [%test_eq: Ledger_hash.t] committed_ledger_hash target_ledger_hash ;
-            committed_ledger_hash )
+            Da_layer.Da_state.create ~ledger_hash:committed_ledger_hash
+              ~acc_set:(account_set_root acc_set) )
       in
 
       print_endline "(* Check that all da nodes are synced *)" ;
@@ -371,12 +372,12 @@ let () =
           let%bind _multisig =
             Da_layer.Client.get_multisig
               { new_sequencer.da_client with quorum = 3 }
-              ~ledger_hash
+              ~state:da_state
           in
           let%map da_nodes_synced =
             Deferred.List.map da_config_with3.nodes ~f:(fun node ->
                 Da_layer.Client.Rpc.has_diff ~logger ~node_location:node
-                  ~ledger_hash )
+                  ~state:da_state )
             >>| Result.all >>| Or_error.ok_exn >>| List.for_all ~f:Fn.id
           in
           [%test_eq: bool] da_nodes_synced true ) ;
@@ -441,14 +442,14 @@ let () =
               apply_user_command !sequencer command >>| Or_error.ok_exn ) ) ;
 
       print_endline "(* Commit *)" ;
-      let ledger_hash =
+      let da_state =
         run (fun () ->
             let%bind commit_result = commit !sequencer >>| Or_error.ok_exn in
             let%bind _txn_snark = commit_result >>| Or_error.ok_exn in
             let%bind () =
               Executor.wait_to_finish !sequencer.merger_ctx.executor
             in
-            let%map { ledger_hash = committed_ledger_hash; _ } =
+            let%map { ledger_hash = committed_ledger_hash; acc_set; _ } =
               Gql_client.infer_state ~logger gql_uri ~signer_pk
                 ~zkapp_pk:(Public_key.compress outer_kp.public_key)
               >>| Or_error.ok_exn
@@ -457,7 +458,8 @@ let () =
             in
             let target_ledger_hash = get_root !sequencer in
             [%test_eq: Ledger_hash.t] committed_ledger_hash target_ledger_hash ;
-            committed_ledger_hash )
+            Da_layer.Da_state.create ~ledger_hash:committed_ledger_hash
+              ~acc_set:(account_set_root acc_set) )
       in
 
       let[@warning "-26"] sequencer = free_sequencer sequencer in
@@ -483,12 +485,12 @@ let () =
           let%bind _multisig =
             Da_layer.Client.get_multisig
               { new_sequencer.da_client with quorum = 3 }
-              ~ledger_hash
+              ~state:da_state
           in
           let%map da_nodes_synced =
             Deferred.List.map da_config_with3.nodes ~f:(fun node ->
                 Da_layer.Client.Rpc.has_diff ~logger ~node_location:node
-                  ~ledger_hash )
+                  ~state:da_state )
             >>| Result.all >>| Or_error.ok_exn >>| List.for_all ~f:Fn.id
           in
           [%test_eq: bool] da_nodes_synced true ) ;

--- a/src/app/zeko/sequencer/tests/test_spec.ml
+++ b/src/app/zeko/sequencer/tests/test_spec.ml
@@ -492,6 +492,7 @@ module Sequencer_spec = struct
     print_endline "(* Post genesis batch *)" ;
     run (fun () ->
         Da_layer.Client.distribute_genesis_diff ~logger ~config:da_config
+          ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
           ~ledger:ephemeral_ledger ~get_actions_for_aid:(fun _aid -> []) ) ;
 
     print_endline "(* Deploy zkapp *)" ;


### PR DESCRIPTION
## Summary

Fix the two medium-severity findings from the second zkSecurity audit that remained unaddressed in Zeko v1.0.5:

- [Users can censor storage of commands in archive nodes](https://reports.zksecurity.xyz/reports/zeko-2/#users-can-censor-storage-of-commands-in-archive-nodes)
- [DA nodes do not store diffs that lead to the same target ledger](https://reports.zksecurity.xyz/reports/zeko-2/#da-nodes-do-not-store-diffs-that-lead-to-the-same-target-ledger)

## Changes

- Reject actions-only diffs that change receipt-chain hashes, so a command cannot be omitted while reproducing its target ledger state.
- Reject conflicting payloads for an already stored exact target state and store validated diffs before signing.
- Introduce a composite DA state containing both the ledger root and account-set root.
- Key RocksDB, PostgreSQL diffs/signatures, RPC queries, chain traversal, quorum collection, archive replay, and CLI synchronization by the composite state.
- Store exact source and target states with every DA diff.
- Add RocksDB and PostgreSQL migrations with fail-closed handling for unrecoverable legacy checkpoint roots.
- Persist the exact archive DA state and fail closed for ambiguous legacy non-genesis archive checkpoints.
- Reconstruct the original command-bearing DA history when bootstrapping from a sequencer checkpoint instead of synthesizing an actions-only ledger snapshot.

## Compatibility and rollout

The secure DA RPC versions intentionally do not fall back to the ledger-only RPCs. DA nodes, sequencers, and archive relays therefore need a coordinated maintenance-window upgrade.

A legacy PostgreSQL queue rooted at a non-genesis checkpoint may require rebuilding the local DA queue if its source account-set root cannot be recovered. Legacy nonempty archive checkpoints without exact DA-state metadata must be rebuilt from genesis.

## Validation

- `dune runtest src/app/zeko/da_layer/lib --force`
- Focused PostgreSQL migration v6 regression test
- `dune build ./src/app/zeko/sequencer ./src/app/zeko/da_layer ./src/app/zeko/signer`
- `src/app/zeko/sequencer/tests/run-sequencer-test.sh real 1 false true`
  - Passed the complete 42-minute real proving and bridge gate, including checkpoint history reconstruction, three-node catch-up, deposits, cancellation, withdrawals, and restart/recommit coverage.
  - The test-only L1 endpoint was temporarily moved locally because another process occupied port 8080; the committed test remains on port 8080.
- `git diff --check`

## Base

This PR targets `v105`, created at the exact peeled `v1.0.5` tag commit: `872031b1d5fadd7b94732cf0d077ce16b7cc18f2`.
