### PR TITLE
Add dedicated Ethereum deployment artifact exporter

### DIFF
--- a/src/app/zeko/sequencer/README.md
+++ b/src/app/zeko/sequencer/README.md
@@ -22,6 +22,31 @@ dune build
 ./src/app/zeko/sequencer/tests/run-sequencer-test.sh {fake | real} <num_provers>
 ```
 
+## Export Ethereum deployment artifacts
+
+Ethereum deployment uses a dedicated exporter instead of deriving release
+artifacts from a sequencer test scenario. The exporter starts isolated local
+L1, database, queue, signer, DA, and prover services, creates the production
+genesis ledger, and makes one real sequencer commit. It writes exactly one
+settlement artifact together with `genesis-ledger.json` and a
+`deployment-manifest.json` that binds the sequencer identity and DA topology.
+
+Set `ZEKO_CIRCUITS_CONFIG`, `ZEKO_DEPLOY_CONFIG`,
+`ZEKO_DEPLOYMENT_SEQUENCER_PRIVATE_KEY`, and one
+`ZEKO_DEPLOYMENT_DA<N>_PRIVATE_KEY` per selected DA node, then run:
+
+```bash
+mkdir -p build/deployment-artifacts
+src/app/zeko/sequencer/run-deployment-export.sh \
+  build/deployment-artifacts 3 2
+```
+
+The final two arguments are the DA node count and signature quorum. The runner
+supports one through three local DA nodes. This performs real local Pickles
+proving but does not request or generate an SP1 proof. It selects an available
+local port range automatically; set `ZEKO_DEPLOYMENT_EXPORT_PORT_OFFSET` only
+when a specific range is required.
+
 ## Run
 
 Running the sequencer exposes the Graphql API on the port `-p`. The Graphql schema is a subset of the L1 Graphql API joined with the L1 Graphql API for fetching of actions/events.

--- a/src/app/zeko/sequencer/deployment_export.ml
+++ b/src/app/zeko/sequencer/deployment_export.ml
@@ -1,0 +1,316 @@
+open Core
+open Async
+open Mina_base
+open Signature_lib
+open Sequencer_lib
+open Zeko_sequencer
+open Zeko_types
+open Sequencer
+module Field = Snark_params.Tick.Field
+module L = Mina_ledger.Ledger
+
+let constraint_constants = Zeko_constants.constraint_constants
+
+let run = Thread_safe.block_on_async_exn
+
+let write_json path json =
+  Out_channel.write_all path ~data:(Yojson.Safe.pretty_to_string json ^ "\n")
+
+let payment ~(sender : Keypair.t) ~receiver ~nonce =
+  Signed_command.sign ~signature_kind:Zeko_circuits_config.Inputs.chain_l2
+    sender
+    { common =
+        { fee = Zeko_constants.transaction_fee
+        ; fee_payer_pk = Public_key.compress sender.public_key
+        ; nonce
+        ; valid_until = Mina_numbers.Global_slot_since_genesis.max_value
+        ; memo = Signed_command_memo.empty
+        }
+    ; body =
+        Payment
+          { receiver_pk = receiver
+          ; amount = Currency.Amount.of_mina_string_exn "1"
+          }
+    }
+  |> Signed_command.forget_check
+
+let export ~logger ~output_directory ~db_directory ~l1_uri ~postgres_uri
+    ~da_nodes ~da_quorum ~mq_host ~signer_location ~commit_validity_period =
+  if
+    not
+      ( Caml.Sys.file_exists output_directory
+      && Caml.Sys.is_directory output_directory )
+  then failwithf "Output directory does not exist: %s" output_directory () ;
+  if List.is_empty da_nodes then failwith "At least one --da-node is required" ;
+  if da_quorum < 1 || da_quorum > List.length da_nodes then
+    failwithf "DA quorum %d is invalid for %d nodes" da_quorum
+      (List.length da_nodes) () ;
+  Unix.putenv ~key:"ZEKO_ETHEREUM_SETTLEMENT_FIXTURE_DIR" ~data:output_directory ;
+  Unix.putenv ~key:"ZEKO_ETHEREUM_SETTLEMENT_FIXTURE_ONLY" ~data:"true" ;
+  let da_config = Da_layer.Client.Config.of_string_list da_nodes in
+  let da_keys =
+    run (fun () -> Da_layer.Client.Config.fetch_public_keys ~logger da_config)
+  in
+  if List.length da_keys <> List.length da_nodes then
+    failwithf "Fetched %d DA keys for %d nodes" (List.length da_keys)
+      (List.length da_nodes) () ;
+  let da_commitment =
+    Multisig.commit { public_keys = da_keys; quorum = Field.of_int da_quorum }
+  in
+  let deploy_config =
+    Option.value_exn ~message:"ZEKO_DEPLOY_CONFIG is not set"
+      Zeko_circuits_config.deploy_config
+  in
+  let outer_keypair = Keypair.of_private_key_exn deploy_config.zeko_l1 in
+  let holder_keypair =
+    Keypair.of_private_key_exn @@ List.hd_exn deploy_config.holder_accounts_l1
+  in
+  let token_holder_keypair =
+    Keypair.of_private_key_exn deploy_config.helper_token_owner_l1
+  in
+  let signer =
+    run (fun () ->
+        Signer_service.Client.create ~logger ~location:signer_location
+        >>| Signer_service.Signer.of_client )
+  in
+  let signer_public_key = Signer_service.Signer.public_key signer in
+  let signer_keypair =
+    Sys.getenv_exn "ZEKO_DEPLOYMENT_SEQUENCER_PRIVATE_KEY"
+    |> Private_key.of_base58_check_exn |> Keypair.of_private_key_exn
+  in
+  if
+    not
+      (Public_key.Compressed.equal signer_public_key
+         (Public_key.compress signer_keypair.public_key) )
+  then
+    failwith
+      "ZEKO_DEPLOYMENT_SEQUENCER_PRIVATE_KEY does not match the signer endpoint" ;
+  run (fun () ->
+      Gql_client.Local_l1.create_account ~logger l1_uri signer_public_key
+      >>| ignore ) ;
+  let ( `Inner inner_account
+      , `Holder holder_account
+      , `Ethereum_asset_registry registry_account ) =
+    run Sequencer_lib.Deploy.Z.Inner.initial_accounts
+  in
+  let funded_balance = Currency.Balance.of_mina_string_exn "100" in
+  let signer_account_id =
+    Account_id.create signer_public_key Token_id.default
+  in
+  let signer_account =
+    (signer_account_id, Account.create signer_account_id funded_balance)
+  in
+  let fee_recipient_account_id =
+    Account_id.create Zeko_circuits_config.Inputs.bridge_fee_recipient_l2
+      Token_id.default
+  in
+  let fee_recipient_account =
+    ( fee_recipient_account_id
+    , Account.create fee_recipient_account_id Currency.Balance.zero )
+  in
+  let genesis_accounts =
+    [ (Account.identifier inner_account, inner_account)
+    ; (Account.identifier holder_account, holder_account)
+    ]
+    @ ( Option.to_list registry_account
+      |> List.map ~f:(fun account -> (Account.identifier account, account)) )
+    @ [ signer_account; fee_recipient_account ]
+  in
+  let genesis_ledger =
+    L.create_ephemeral ~depth:constraint_constants.ledger_depth ()
+  in
+  List.iter genesis_accounts ~f:(fun (account_id, account) ->
+      L.create_new_account_exn genesis_ledger account_id account ) ;
+  let account_set_hash =
+    let db =
+      Indexed_merkle_tree.Db.create ~depth:constraint_constants.ledger_depth ()
+    in
+    List.iter genesis_accounts ~f:(fun (account_id, _) ->
+        let token_id = Account_id.derive_token_id ~owner:account_id in
+        let _, _ = Indexed_merkle_tree.Db.get_or_create_entry_exn db token_id in
+        () ) ;
+    Account_set.of_fields [| Indexed_merkle_tree.Db.merkle_root db |]
+  in
+  run (fun () ->
+      Da_layer.Client.distribute_genesis_diff ~logger ~config:da_config
+        ~ledger:genesis_ledger ~get_actions_for_aid:(fun _ -> []) ) ;
+  run (fun () ->
+      let%bind nonce =
+        Gql_client.infer_nonce ~logger l1_uri signer_public_key
+        >>| Or_error.ok_exn
+      in
+      let%bind command =
+        Sequencer_lib.Deploy.deploy_command_exn
+          ~signature_kind:Zeko_circuits_config.Inputs.chain_l1
+          ~signer_pk:signer_public_key
+          ~outer_pk:(Public_key.compress outer_keypair.public_key)
+          ~holder_pk:(Public_key.compress holder_keypair.public_key)
+          ~token_holder_pk:(Public_key.compress token_holder_keypair.public_key)
+          ~fee:Zeko_constants.outer_account_creation_fee ~nonce
+          ~initial_ledger:genesis_ledger
+          ~account_creation_fee:Zeko_constants.account_creation_fee
+          ~account_set_hash
+          ~pause_key:(Even_PC.create_exn signer_public_key)
+          ~sequencer:(Even_PC.create_exn signer_public_key)
+          ~da_key:da_commitment ~prefund_amount:Currency.Amount.zero ()
+      in
+      let command =
+        Utils.sign_zkapp_command
+          ~signature_kind:Zeko_circuits_config.Inputs.chain_l1 command
+          [ outer_keypair
+          ; holder_keypair
+          ; token_holder_keypair
+          ; signer_keypair
+          ]
+      in
+      let%bind _ =
+        Gql_client.send_zkapp l1_uri
+          (Zkapp_command.read_all_proofs_from_disk command)
+        >>| function
+        | Ok response ->
+            response
+        | Error (`Failed_request error | `Graphql_error error) ->
+            failwith error
+      in
+      let%map _ = Gql_client.Local_l1.create_new_block ~logger l1_uri in
+      () ) ;
+  let genesis_timestamp =
+    run (fun () ->
+        Gql_client.fetch_genesis_timestamp ~logger l1_uri >>| Or_error.ok_exn )
+  in
+  let l1_config : Utils.Slot.l1_config =
+    { fork_timestamp = genesis_timestamp
+    ; fork_slot = Mina_numbers.Global_slot_since_genesis.zero
+    ; slot_duration_sec = 180
+    }
+  in
+  let sequencer =
+    run (fun () ->
+        Sequencer.create ~logger ~max_pool_size:10 ~commitment_period_sec:0.
+          ~da_config ~da_keys ~da_quorum ~db_dir:(Some db_directory)
+          ~checkpoints_dir:None ~postgres_uri ~l1_uri ~archive_uri:l1_uri
+          ~signer ~deposit_delay_blocks:0 ~mq_host ~fee_modifier:1.0
+          ~minimum_fee:Zeko_constants.minimum_fee
+          ~slot_acceptance:(Time.Span.of_min 10.)
+          ~proof_cache_db:(Proof_cache_tag.create_identity_db ())
+          ~l1_config
+          ~commit_validity_period:
+            (Mina_numbers.Global_slot_span.of_int commit_validity_period)
+          ~commit_fee:Zeko_constants.transaction_fee
+          ~bridge_txn_fee:Zeko_constants.transaction_fee )
+  in
+  let outer_public_key = Public_key.compress outer_keypair.public_key in
+  let outer_action_state =
+    run (fun () ->
+        Gql_client.fetch_action_state l1_uri outer_public_key ~logger
+        >>| Or_error.ok_exn )
+  in
+  let genesis_ledger_json =
+    L.to_list_sequential genesis_ledger
+    |> List.mapi ~f:(fun index account -> (index, account))
+    |> [%to_yojson: (int * Account.t) list]
+  in
+  let genesis_ledger_hash = L.merkle_root genesis_ledger in
+  write_json
+    (Filename.concat output_directory "genesis-ledger.json")
+    genesis_ledger_json ;
+  write_json
+    (Filename.concat output_directory "deployment-manifest.json")
+    (`Assoc
+      [ ("schemaVersion", `Int 1)
+      ; ("commitValidityPeriod", `Int commit_validity_period)
+      ; ( "outerPublicKey"
+        , `String (Public_key.Compressed.to_base58_check outer_public_key) )
+      ; ( "outerActionState"
+        , `String (Ethereum_settlement_export.field_to_hex outer_action_state)
+        )
+      ; ( "genesisLedgerHash"
+        , `String (Ledger_hash.to_base58_check genesis_ledger_hash) )
+      ; ( "genesisLedgerField"
+        , `String
+            (Ethereum_settlement_export.field_to_hex
+               (genesis_ledger_hash :> Field.t) ) )
+      ; ( "sequencerPublicKey"
+        , `String (Public_key.Compressed.to_base58_check signer_public_key) )
+      ; ( "daPublicKeys"
+        , `List
+            (List.map da_keys ~f:(fun public_key ->
+                 `String (Public_key.Compressed.to_base58_check public_key) ) )
+        )
+      ; ("daNodeCount", `Int (List.length da_keys))
+      ; ("daQuorum", `Int da_quorum)
+      ; ( "daCommitment"
+        , `String (Ethereum_settlement_export.field_to_hex da_commitment) )
+      ] ) ;
+  let submit_payment () =
+    let nonce =
+      Sequencer.infer_nonce sequencer
+        (Public_key.compress signer_keypair.public_key)
+    in
+    run (fun () ->
+        Sequencer.apply_user_command sequencer
+          (Signed_command
+             (payment ~sender:signer_keypair
+                ~receiver:Zeko_circuits_config.Inputs.bridge_fee_recipient_l2
+                ~nonce ) )
+        >>| Or_error.ok_exn )
+  in
+  submit_payment () ;
+  submit_payment () ;
+  run (fun () ->
+      let%bind commit_result = Sequencer.commit sequencer >>| Or_error.ok_exn in
+      let%bind settlement = commit_result >>| Or_error.ok_exn in
+      if Option.is_none settlement then failwith "Deployment commit was empty" ;
+      let%bind () = Executor.wait_to_finish sequencer.merger_ctx.executor in
+      let%bind _ = Gql_client.Local_l1.create_new_block ~logger l1_uri in
+      let%map { ledger_hash = committed_ledger_hash; _ } =
+        Gql_client.infer_state ~logger l1_uri ~signer_pk:signer_public_key
+          ~zkapp_pk:outer_public_key
+        >>| Or_error.ok_exn
+        >>| Utils.value_of_zkapp_state
+              Zeko_circuits.Rollup_state.Outer_state.typ
+      in
+      let target_ledger_hash = Sequencer.get_root sequencer in
+      if not (Ledger_hash.equal committed_ledger_hash target_ledger_hash) then
+        failwith "Exported settlement did not commit the sequencer ledger" ) ;
+  run (fun () -> Sequencer.shutdown sequencer)
+
+let command =
+  Command.basic ~summary:"Export proof-bound Ethereum deployment artifacts"
+    (let%map_open.Command output_directory =
+       flag "--output-directory" (required string)
+         ~doc:"path Existing artifact output directory"
+     and l1_uri =
+       flag "--l1-uri" (required string) ~doc:"URI Local Mina GraphQL endpoint"
+     and db_directory =
+       flag "--db-dir" (required string)
+         ~doc:"path Dedicated sequencer database directory"
+     and postgres_uri =
+       flag "--postgres-uri" (required string)
+         ~doc:"URI Dedicated sequencer PostgreSQL database"
+     and da_nodes = flag "--da-node" (listed string) ~doc:"host:port DA node"
+     and da_quorum =
+       flag "--da-quorum" (required int) ~doc:"int DA signature quorum"
+     and mq_host =
+       flag "--mq-host" (required string) ~doc:"host:port Prover message queue"
+     and signer_location =
+       flag "--signer" (required string)
+         ~doc:"host:port Sequencer signer endpoint"
+     and commit_validity_period =
+       flag "--commit-validity-period"
+         (optional_with_default 20 int)
+         ~doc:"slots Settlement validity period"
+     and log_json = Cli_lib.Flag.Log.json
+     and log_level = Cli_lib.Flag.Log.level in
+     fun () ->
+       Cli_lib.Stdout_log.setup log_json log_level ;
+       let logger = Logger.create () in
+       export ~logger ~output_directory ~db_directory
+         ~l1_uri:(Uri.of_string l1_uri)
+         ~postgres_uri:(Uri.of_string postgres_uri)
+         ~da_nodes ~da_quorum
+         ~mq_host:(Host_and_port.of_string mq_host)
+         ~signer_location:(Host_and_port.of_string signer_location)
+         ~commit_validity_period )
+
+let () = Command_unix.run command

--- a/src/app/zeko/sequencer/dune
+++ b/src/app/zeko/sequencer/dune
@@ -171,3 +171,21 @@
  (preprocess
   (pps ppx_jane ppx_mina))
  (modules cli_fake))
+
+(executable
+ (name deployment_export)
+ (libraries
+  sequencer_lib
+  signer_service
+  is_compile_simple_real_real
+  init
+  signature_lib
+  cli_lib
+  core
+  core_kernel
+  async
+  async_unix
+  core_unix.command_unix)
+ (preprocess
+  (pps ppx_let ppx_jane ppx_mina))
+ (modules deployment_export))

--- a/src/app/zeko/sequencer/gql_client/gql_client.ml
+++ b/src/app/zeko/sequencer/gql_client/gql_client.ml
@@ -890,7 +890,7 @@ let fetch_fork_slot uri =
         |> to_int)
       |> Mina_numbers.Global_slot_since_genesis.of_int )
 
-module For_tests = struct
+module Local_l1 = struct
   let create_account ~logger uri pk =
     let q =
       object
@@ -1036,3 +1036,5 @@ module For_tests = struct
              |> List.map ~f:to_list
              |> List.map ~f:(List.map ~f:to_string) ))
 end
+
+module For_tests = Local_l1

--- a/src/app/zeko/sequencer/run-deployment-export.sh
+++ b/src/app/zeko/sequencer/run-deployment-export.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <output-directory> <da-node-count> <da-quorum>" >&2
+  exit 2
+}
+
+[[ $# -eq 3 ]] || usage
+OUTPUT_DIRECTORY=$1
+DA_NODE_COUNT=$2
+DA_QUORUM=$3
+[[ $DA_NODE_COUNT =~ ^[1-3]$ ]] || {
+  echo "DA node count must be between 1 and 3" >&2
+  exit 1
+}
+[[ $DA_QUORUM =~ ^[1-3]$ && $DA_QUORUM -le $DA_NODE_COUNT ]] || {
+  echo "DA quorum must be between 1 and the DA node count" >&2
+  exit 1
+}
+[[ -d $OUTPUT_DIRECTORY ]] || {
+  echo "Output directory does not exist: $OUTPUT_DIRECTORY" >&2
+  exit 1
+}
+OUTPUT_DIRECTORY=$(realpath "$OUTPUT_DIRECTORY")
+
+for command in awk docker dune nc openssl pgrep realpath; do
+  command -v "$command" >/dev/null || {
+    echo "Missing command: $command" >&2
+    exit 1
+  }
+done
+
+for variable in ZEKO_CIRCUITS_CONFIG ZEKO_DEPLOY_CONFIG \
+  ZEKO_DEPLOYMENT_SEQUENCER_PRIVATE_KEY; do
+  [[ -n ${!variable:-} ]] || {
+    echo "$variable is required" >&2
+    exit 1
+  }
+done
+for ((index = 1; index <= DA_NODE_COUNT; index++)); do
+  variable="ZEKO_DEPLOYMENT_DA${index}_PRIVATE_KEY"
+  [[ -n ${!variable:-} ]] || {
+    echo "$variable is required" >&2
+    exit 1
+  }
+done
+
+ROOT=$(git rev-parse --show-toplevel)
+BUILD_ROOT=$ROOT/_build/default/src/app/zeko
+TMP_DIRECTORY=$(mktemp -d)
+POSTGRES_CONTAINER="zeko-deployment-export-postgres-$$"
+RABBITMQ_CONTAINER="zeko-deployment-export-rabbitmq-$$"
+SERVICE_PIDS=()
+SIGNING_NETWORK_ID=${MINA_SIGNING_NETWORK_ID:-testnet}
+export ZEKO_SIGNATURE_KIND=$SIGNING_NETWORK_ID
+export ZEKO_TEST_L1_NETWORK_ID=$SIGNING_NETWORK_ID
+export ZEKO_SIGNER_AUTH_TOKEN=deployment-export-signer-token
+export ZEKO_SIGNER_TLS_HOSTNAME=localhost
+
+terminate_tree() {
+  local pid=$1 child
+  while read -r child; do
+    [[ -n $child ]] && terminate_tree "$child"
+  done < <(pgrep -P "$pid" 2>/dev/null || true)
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+}
+
+cleanup() {
+  local status=$?
+  trap - EXIT INT TERM
+  for pid in "${SERVICE_PIDS[@]}"; do
+    terminate_tree "$pid"
+  done
+  docker rm -f "$POSTGRES_CONTAINER" "$RABBITMQ_CONTAINER" \
+    >/dev/null 2>&1 || true
+  rm -rf "$TMP_DIRECTORY"
+  exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+wait_for_port() {
+  local port=$1 pid=$2
+  for _ in $(seq 1 600); do
+    nc -z 127.0.0.1 "$port" 2>/dev/null && return 0
+    kill -0 "$pid" 2>/dev/null || {
+      echo "Process for port $port exited" >&2
+      return 1
+    }
+    sleep 1
+  done
+  echo "Timed out waiting for port $port" >&2
+  return 1
+}
+
+port_is_listening() {
+  local port_hex
+  printf -v port_hex '%04X' "$1"
+  awk -v port=":$port_hex" \
+    '$2 ~ (port "$") && $4 == "0A" { found = 1 } END { exit !found }' \
+    /proc/net/tcp /proc/net/tcp6 2>/dev/null
+}
+
+wait_for_listen() {
+  local port=$1 pid=$2
+  for _ in $(seq 1 600); do
+    port_is_listening "$port" && return 0
+    kill -0 "$pid" 2>/dev/null || {
+      echo "Process for port $port exited" >&2
+      return 1
+    }
+    sleep 1
+  done
+  echo "Timed out waiting for port $port" >&2
+  return 1
+}
+
+wait_for_container_port() {
+  local port=$1 container=$2
+  for _ in $(seq 1 600); do
+    nc -z 127.0.0.1 "$port" 2>/dev/null && return 0
+    [[ $(docker inspect -f '{{.State.Running}}' "$container" 2>/dev/null) == true ]] || {
+      echo "Container for port $port exited" >&2
+      return 1
+    }
+    sleep 1
+  done
+  echo "Timed out waiting for port $port" >&2
+  return 1
+}
+
+wait_for_prover() {
+  local pid=$1 consumers
+  for _ in $(seq 1 1800); do
+    consumers=$(
+      { docker exec "$RABBITMQ_CONTAINER" rabbitmqctl -q list_queues \
+        name consumers 2>/dev/null || true; } \
+        | awk '$2 ~ /^[0-9]+$/ { total += $2 } END { print total + 0 }'
+    )
+    [[ $consumers -ge 1 ]] && return 0
+    kill -0 "$pid" 2>/dev/null || {
+      echo "Prover exited before accepting jobs" >&2
+      return 1
+    }
+    sleep 1
+  done
+  echo "Timed out waiting for prover circuit compilation" >&2
+  return 1
+}
+
+requested_offset=${ZEKO_DEPLOYMENT_EXPORT_PORT_OFFSET:-}
+if [[ -n $requested_offset && ! $requested_offset =~ ^[0-9]+$ ]]; then
+  echo "ZEKO_DEPLOYMENT_EXPORT_PORT_OFFSET must be a non-negative integer" >&2
+  exit 1
+fi
+if [[ -n $requested_offset ]]; then
+  port_offsets=("$requested_offset")
+else
+  port_offsets=(0 10000 20000 30000 40000)
+fi
+PORT_OFFSET=
+for candidate in "${port_offsets[@]}"; do
+  ((candidate <= 50000)) || continue
+  candidate_ports=("$((5433 + candidate))" "$((5672 + candidate))" \
+    "$((8080 + candidate))" "$((8600 + candidate))")
+  for ((index = 1; index <= DA_NODE_COUNT; index++)); do
+    candidate_ports+=("$((8554 + candidate + index))" \
+      "$((8557 + candidate + index))" "$((8600 + candidate + index))")
+  done
+  ports_available=true
+  for port in "${candidate_ports[@]}"; do
+    port_is_listening "$port" && ports_available=false
+  done
+  if [[ $ports_available == true ]]; then
+    PORT_OFFSET=$candidate
+    break
+  fi
+done
+[[ -n $PORT_OFFSET ]] || {
+  echo "Could not find an available local port range" >&2
+  exit 1
+}
+POSTGRES_PORT=$((5433 + PORT_OFFSET))
+RABBITMQ_PORT=$((5672 + PORT_OFFSET))
+L1_PORT=$((8080 + PORT_OFFSET))
+SEQUENCER_SIGNER_PORT=$((8600 + PORT_OFFSET))
+if ((PORT_OFFSET > 0)); then
+  echo "Using local service port offset $PORT_OFFSET" >&2
+fi
+
+dune build \
+  ./src/app/zeko/sequencer/deployment_export.exe \
+  ./src/app/zeko/sequencer/prover/cli.exe \
+  ./src/app/zeko/sequencer/tests/testing_ledger/run.exe \
+  ./src/app/zeko/da_layer/cli.exe \
+  ./src/app/zeko/signer/cli.exe
+
+docker run --rm --name "$POSTGRES_CONTAINER" \
+  -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres \
+  --tmpfs /var/lib/postgresql/data:rw,noexec,nosuid \
+  -p "127.0.0.1:$POSTGRES_PORT:5432" \
+  -d "${POSTGRES_IMAGE:-postgres:16-alpine}" \
+  >/dev/null
+docker run --rm --name "$RABBITMQ_CONTAINER" \
+  -p "127.0.0.1:$RABBITMQ_PORT:5672" \
+  -d "${RABBITMQ_IMAGE:-rabbitmq:4-alpine}" \
+  >/dev/null
+wait_for_container_port "$POSTGRES_PORT" "$POSTGRES_CONTAINER"
+wait_for_container_port "$RABBITMQ_PORT" "$RABBITMQ_CONTAINER"
+
+openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+  -keyout "$TMP_DIRECTORY/signer.key" -out "$TMP_DIRECTORY/signer.crt" \
+  -subj /CN=localhost -addext subjectAltName=DNS:localhost \
+  >/dev/null 2>&1
+export ZEKO_SIGNER_TLS_CA_FILE=$TMP_DIRECTORY/signer.crt
+
+env MINA_PRIVATE_KEY="$ZEKO_DEPLOYMENT_SEQUENCER_PRIVATE_KEY" \
+  "$BUILD_ROOT/signer/cli.exe" run --port "$SEQUENCER_SIGNER_PORT" \
+    --allow-zkapp-signing \
+    --max-fee 10 --max-balance-change 1000000 \
+    --tls-cert-file "$TMP_DIRECTORY/signer.crt" \
+    --tls-key-file "$TMP_DIRECTORY/signer.key" &
+service_pid=$!
+SERVICE_PIDS+=("$service_pid")
+wait_for_listen "$SEQUENCER_SIGNER_PORT" "$service_pid"
+
+DA_NODES=()
+for ((index = 1; index <= DA_NODE_COUNT; index++)); do
+  signer_port=$((8600 + PORT_OFFSET + index))
+  da_port=$((8554 + PORT_OFFSET + index))
+  health_port=$((8557 + PORT_OFFSET + index))
+  variable="ZEKO_DEPLOYMENT_DA${index}_PRIVATE_KEY"
+  env MINA_PRIVATE_KEY="${!variable}" \
+    "$BUILD_ROOT/signer/cli.exe" run --port "$signer_port" \
+      --allow-field-signing --tls-cert-file "$TMP_DIRECTORY/signer.crt" \
+      --tls-key-file "$TMP_DIRECTORY/signer.key" &
+  service_pid=$!
+  SERVICE_PIDS+=("$service_pid")
+  wait_for_listen "$signer_port" "$service_pid"
+  "$BUILD_ROOT/da_layer/cli.exe" run-node --bind-localhost --port "$da_port" \
+    --healthcheck-port "$health_port" --network-id "$SIGNING_NETWORK_ID" \
+    --db-dir "$TMP_DIRECTORY/da${index}" \
+    --signer "localhost:$signer_port" &
+  service_pid=$!
+  SERVICE_PIDS+=("$service_pid")
+  wait_for_port "$da_port" "$service_pid"
+  DA_NODES+=("127.0.0.1:$da_port")
+done
+
+"$BUILD_ROOT/sequencer/tests/testing_ledger/run.exe" -p "$L1_PORT" \
+  --db-dir "$TMP_DIRECTORY/l1" --network-id "$SIGNING_NETWORK_ID" \
+  --block-period 9999999 &
+service_pid=$!
+SERVICE_PIDS+=("$service_pid")
+wait_for_port "$L1_PORT" "$service_pid"
+
+"$BUILD_ROOT/sequencer/prover/cli.exe" run-server \
+  --mq-host "127.0.0.1:$RABBITMQ_PORT" &
+service_pid=$!
+SERVICE_PIDS+=("$service_pid")
+wait_for_prover "$service_pid"
+
+DA_NODE_ARGUMENTS=()
+for node in "${DA_NODES[@]}"; do
+  DA_NODE_ARGUMENTS+=(--da-node "$node")
+done
+"$BUILD_ROOT/sequencer/deployment_export.exe" \
+  --output-directory "$OUTPUT_DIRECTORY" \
+  --db-dir "$TMP_DIRECTORY/sequencer" \
+  --l1-uri "http://127.0.0.1:$L1_PORT/graphql" \
+  --postgres-uri \
+    "postgres://postgres:postgres@127.0.0.1:$POSTGRES_PORT/postgres" \
+  "${DA_NODE_ARGUMENTS[@]}" --da-quorum "$DA_QUORUM" \
+  --mq-host "127.0.0.1:$RABBITMQ_PORT" \
+  --signer "127.0.0.1:$SEQUENCER_SIGNER_PORT" \
+  --commit-validity-period "${ZEKO_ETHEREUM_COMMIT_VALIDITY_PERIOD:-20}"


### PR DESCRIPTION
## Summary

- add a dedicated `deployment_export.exe` for Ethereum deployment artifacts
- build the minimal deterministic deployment genesis and one genuine nonempty Pickles settlement without invoking `sequencer_test.exe`
- run PostgreSQL, RabbitMQ, local Mina L1, signer, prover, and configurable 1-3-node DA topology in an isolated, self-cleaning harness
- select an unused local port range without probing TLS signers as clients

The exported manifest binds the genesis ledger, initial outer action state, sequencer identity, selected DA keys/quorum/commitment, and commit validity period. Bridge deposit/withdrawal scenario generation remains test-only.

Companion integration: zeko-labs/ethereum-settlement#12.

## Validation

- `dune build ./src/app/zeko/sequencer ./src/app/zeko/da_layer ./src/app/zeko/signer`
- `deployment_export.exe --help`
- `bash -n src/app/zeko/sequencer/run-deployment-export.sh`
- real isolated 1-of-1 DA export through the companion packaging command; one settlement produced and validated, with no SP1 proof/request
