### PR TITLE
fix(sequencer): wait for Ethereum settlement finality

### DIFF
--- a/src/app/zeko/sequencer/lib/committer.ml
+++ b/src/app/zeko/sequencer/lib/committer.ml
@@ -431,11 +431,25 @@ let recommit_all ~logger ~proof_cache_db ~db_pool ~provers
     ~(executor : Executor.t) ~l1_uri ~archive ~zkapp_pk ~archive_uri ~l1_config
     ~commit_validity_period ~commit_fee =
   let open Deferred.Result.Let_syntax in
-  let%bind { ledger_hash; _ } =
-    Gql_client.infer_state ~logger l1_uri ~zkapp_pk
-      ~signer_pk:(Signer_service.Signer.public_key executor.signer)
-    >>| Utils.value_of_zkapp_state Rollup_state.Outer_state.typ
+  let signer_pk = Signer_service.Signer.public_key executor.signer in
+  let fetch_outer_state () =
+    let%bind () =
+      Settlement_finality.wait_for_previous_settlement ~logger ~l1_uri
+        ~signer_pk
+        ~message:
+          "Waiting for the previous Ethereum settlement to finalize before \
+           recommitting"
+    in
+    let%map state =
+      if Settlement_finality.ethereum_gateway_enabled () then
+        Gql_client.fetch_state ~logger l1_uri
+          ( Account_id.of_public_key
+          @@ Signature_lib.Public_key.decompress_exn zkapp_pk )
+      else Gql_client.infer_state ~logger l1_uri ~zkapp_pk ~signer_pk
+    in
+    Utils.value_of_zkapp_state Rollup_state.Outer_state.typ state
   in
+  let%bind { ledger_hash; _ } = fetch_outer_state () in
   let rec recommit_next current_state =
     match%bind
       Pool.use
@@ -468,6 +482,12 @@ let recommit_all ~logger ~proof_cache_db ~db_pool ~provers
           Executor.send_zkapp_command ~logger ?settlement_export executor
             command
         in
-        recommit_next target_ledger_hash
+        let%bind next_state =
+          if Settlement_finality.ethereum_gateway_enabled () then
+            let%map { ledger_hash; _ } = fetch_outer_state () in
+            ledger_hash
+          else return target_ledger_hash
+        in
+        recommit_next next_state
   in
   recommit_next ledger_hash

--- a/src/app/zeko/sequencer/lib/settlement_finality.ml
+++ b/src/app/zeko/sequencer/lib/settlement_finality.ml
@@ -1,0 +1,34 @@
+open Async_kernel
+open Core_kernel
+
+let ethereum_gateway_enabled () =
+  Option.is_some (Sys.getenv_opt "ZEKO_ETHEREUM_GATEWAY_TOKEN")
+
+let wait_until_idle ?(retry_delay = Time_ns.Span.of_sec 15.)
+    ?(sleep = Clock_ns.after) ~has_pending ~on_wait () =
+  let rec loop () =
+    match%bind has_pending () with
+    | Error error ->
+        Deferred.return (Error error)
+    | Ok false ->
+        Deferred.Or_error.return ()
+    | Ok true ->
+        on_wait () ;
+        let%bind () = sleep retry_delay in
+        loop ()
+  in
+  loop ()
+
+(* The Ethereum gateway keeps accepted commands in its Mina-compatible pool
+   until their Ethereum transactions are finalized or fail. An empty pool is
+   therefore the boundary at which it is safe to build a new state-bound
+   settlement proof. *)
+let wait_for_previous_settlement ~logger ~l1_uri ~signer_pk ~message =
+  if not (ethereum_gateway_enabled ()) then Deferred.Or_error.return ()
+  else
+    wait_until_idle
+      ~has_pending:(fun () ->
+        Gql_client.fetch_pooled_zkapp_commands ~logger l1_uri signer_pk
+        >>| Result.map ~f:(Fn.non List.is_empty) )
+      ~on_wait:(fun () -> [%log info] "%s" message)
+      ()

--- a/src/app/zeko/sequencer/lib/zeko_sequencer.ml
+++ b/src/app/zeko/sequencer/lib/zeko_sequencer.ml
@@ -166,17 +166,54 @@ module Sequencer = struct
           Utils.retry
             ~f:(fun () ->
               let open Deferred.Result.Let_syntax in
+              let old_inner_ledger =
+                State.Last_committed_ledger.get sequencer_state
+                |> Option.value_exn ~message:"No previous committed ledger"
+              in
+              let expected_ledger_hash =
+                Sparse_ledger.merkle_root old_inner_ledger
+              in
+              let%bind () =
+                if not (Settlement_finality.ethereum_gateway_enabled ()) then
+                  Deferred.Or_error.return ()
+                else
+                  let%bind () =
+                    Settlement_finality.wait_for_previous_settlement ~logger
+                      ~l1_uri:config.l1_uri
+                      ~signer_pk:
+                        (Signer_service.Signer.public_key executor.signer)
+                      ~message:
+                        "Waiting for the previous Ethereum settlement to \
+                         finalize before proving the next commit"
+                  in
+                  let%bind state =
+                    Gql_client.fetch_state ~logger config.l1_uri
+                      ( Account_id.of_public_key
+                      @@ Public_key.decompress_exn
+                           Zeko_circuits_config.Inputs.zeko_l1 )
+                  in
+                  let ({ ledger_hash = finalized_ledger_hash; _ }
+                        : C.Rollup_state.Outer_state.t ) =
+                    Utils.value_of_zkapp_state C.Rollup_state.Outer_state.typ
+                      state
+                  in
+                  if
+                    Ledger_hash.equal finalized_ledger_hash expected_ledger_hash
+                  then Deferred.Or_error.return ()
+                  else
+                    Deferred.return
+                      (Or_error.errorf
+                         "Finalized Ethereum settlement ledger %s does not \
+                          match the sequencer's last committed ledger %s"
+                         (Ledger_hash.to_decimal_string finalized_ledger_hash)
+                         (Ledger_hash.to_decimal_string expected_ledger_hash) )
+              in
               let%bind da_multisig =
                 Da_layer.Client.get_multisig da_client
                   ~ledger_hash:(Sparse_ledger.merkle_root new_inner_ledger)
                 |> Deferred.map ~f:(fun (quorum, multisig) ->
                        Multisig.Witness.make ~signatures:multisig ~quorum )
                 |> Deferred.map ~f:Result.return
-              in
-
-              let old_inner_ledger =
-                State.Last_committed_ledger.get sequencer_state
-                |> Option.value_exn ~message:"No previous committed ledger"
               in
               let commit_witness : Committer.Commit_witness.t =
                 { old_inner_ledger

--- a/src/app/zeko/sequencer/tests/dune
+++ b/src/app/zeko/sequencer/tests/dune
@@ -53,6 +53,13 @@
  (modules commit_schedule_test))
 
 (executable
+ (name settlement_finality_test)
+ (libraries sequencer_lib is_compile_simple_real_fake)
+ (preprocess
+  (pps ppx_let ppx_jane ppx_mina))
+ (modules settlement_finality_test))
+
+(executable
  (name slot_duration_test)
  (libraries utils core_kernel mina_numbers is_compile_simple_real_fake)
  (modules slot_duration_test))

--- a/src/app/zeko/sequencer/tests/settlement_finality_test.ml
+++ b/src/app/zeko/sequencer/tests/settlement_finality_test.ml
@@ -1,0 +1,19 @@
+open Async
+open Core_kernel
+module Finality = Sequencer_lib.Settlement_finality
+
+let () =
+  let observations = Queue.of_list [ true; false ] in
+  let fetch_count = ref 0 in
+  let wait_count = ref 0 in
+  Thread_safe.block_on_async_exn (fun () ->
+      Finality.wait_until_idle
+        ~sleep:(fun _ -> Deferred.unit)
+        ~has_pending:(fun () ->
+          Int.incr fetch_count ;
+          Deferred.Or_error.return (Queue.dequeue_exn observations) )
+        ~on_wait:(fun () -> Int.incr wait_count)
+        ()
+      >>| Or_error.ok_exn ) ;
+  assert (!fetch_count = 2) ;
+  assert (!wait_count = 1)


### PR DESCRIPTION
## Summary

- wait for the Ethereum gateway pending-command pool to clear before proving the next settlement
- verify the finalized Ethereum ledger matches the sequencer checkpoint
- apply the same finality gate between restart replay attempts
- add a deterministic pending-to-finalized regression test

## Root cause

The gateway acknowledges `sendZkapp` when a settlement is queued. The sequencer could therefore advance its local committed checkpoint and prove the next settlement before the preceding Ethereum transaction finalized, binding the new proof to a stale action state.

## Validation

- `dune exec ./src/app/zeko/sequencer/tests/settlement_finality_test.exe`
- `dune exec ./src/app/zeko/sequencer/tests/commit_schedule_test.exe`
- `dune build ./src/app/zeko/sequencer ./src/app/zeko/da_layer ./src/app/zeko/signer`

## Rollout

Sequencer binary/service only. This does not change circuits, proof formats, verification keys, or Solidity contracts.